### PR TITLE
Add package headers

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2014-01-05  Syohei YOSHIDA <syohex@gmail.com>
+
+	* slime.el : Add package headers
+
 2013-12-31  João Távora  <joaotavora@gmail.com>
 
 	* slime-tests.el (slime-test-buffer-name): remove it

--- a/slime.el
+++ b/slime.el
@@ -1,5 +1,9 @@
 ;;; slime.el --- Superior Lisp Interaction Mode for Emacs -*- lexical-binding: t -*-
-;;
+
+;; URL: https://github.com/slime/slime
+;; Package-Requires: ((cl-lib "0.3"))
+;; Keywords: languages, lisp, slime
+
 ;;;; License
 ;;     Copyright (C) 2003  Eric Marsden, Luke Gorrie, Helmut Eller
 ;;     Copyright (C) 2004,2005,2006  Luke Gorrie, Helmut Eller


### PR DESCRIPTION
Especially `Package-Requires` is necessary when slime is installed with package.el.

See Also
- http://www.gnu.org/software/emacs/manual/html_node/elisp/Simple-Packages.html
- http://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html

Please add `Version` header if slime has version.
