### PR TITLE
Silence makeinfo error during `make slime.info'

### DIFF
--- a/doc/slime.texi
+++ b/doc/slime.texi
@@ -533,7 +533,7 @@ port number to the file.  At startup, @SLIME{} starts the Lisp process
 and sends the result of this function to Lisp's standard input.  As
 default, @code{slime-init-command} is used.  An example is shown in
 @ref{init-example,,Loading Swank faster}.
-@itemx INIT-FUNCTION
+@item INIT-FUNCTION
 should be a function which takes no arguments.  It is called after 
 the connection is established. (See also @ref{slime-connected-hook}.)
 @item ENV


### PR DESCRIPTION
The error reported was:

  slime.texi:536: @itemx must follow @item
