### PR TITLE
Some slime asdf cleanups:

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2014-01-05  Francois-Rene Rideau <tunes@google.com>
+
+	* swank.asd : Drop the calling of init after loading swank.
+	It was using unsupported (and to-be-removed) operation-forced interface.
+	* contrib/slime-asdf.el : Tweak some docstrings.
+	* contrib/swank-asdf.el : Tweak some comments and docstrings,
+	remove an obsolete #+asdf2, since we don't support ASDF 1 anymore.
+
 2014-01-05  Syohei YOSHIDA <syohex@gmail.com>
 
 	* slime.el : Add package headers

--- a/contrib/slime-asdf.el
+++ b/contrib/slime-asdf.el
@@ -272,7 +272,7 @@ depending on it."
   (:handler (lambda ()
               (interactive)
               (slime-oos (slime-read-system-name) 'test-op :force t)))
-  (:one-liner "Compile (as needed) and force test an ASDF system."))
+  (:one-liner "Recompile and test an ASDF system."))
 
 (defslime-repl-shortcut slime-repl-test-system ("test-system")
   (:handler (lambda ()
@@ -291,7 +291,7 @@ depending on it."
   (:handler (lambda ()
               (interactive)
               (slime-oos (slime-read-system-name) 'compile-op :force t)))
-  (:one-liner "Recompile (but not load) an ASDF system."))
+  (:one-liner "Recompile (but not completely load) an ASDF system."))
 
 (defslime-repl-shortcut slime-repl-open-system ("open-system")
   (:handler 'slime-open-system)

--- a/contrib/swank-asdf.lisp
+++ b/contrib/swank-asdf.lisp
@@ -36,13 +36,17 @@
   (unless (member :asdf *features*)
     (error "Could not load ASDF.
 Please update your implementation or
-install ASDF2 and in your ~~/.swank.lisp specify:
+install a recent release of ASDF and in your ~~/.swank.lisp specify:
  (defparameter swank::*asdf-path* #p\"/path/containing/asdf/asdf.lisp\")")))
 
 ;;; If ASDF is too old, punt.
-;; Quicklisp has 2.014.6 for the longest time, now 2.26.
-;; CLISP ships with 2.11? Too bad, have them upgrade or
-;; install an upgrade yourself and configure *asdf-path*
+;; As of January 2014, Quicklisp has been providing 2.26 for a year
+;; (and previously had 2.014.6 for over a year), whereas
+;; all SLIME-supported implementations provide ASDF3 (i.e. 2.27 or later)
+;; except LispWorks (stuck with 2.019) and SCL (which hasn't been released
+;; in years and doesn't provide ASDF at all, but is fully supported by ASDF).
+;; If your implementation doesn't provide ASDF, or provides an old one,
+;; install an upgrade yourself and configure *asdf-path*.
 ;; It's just not worth the hassle supporting something
 ;; that doesn't even have COERCE-PATHNAME.
 ;;
@@ -71,8 +75,7 @@ install ASDF2 and in your ~~/.swank.lisp specify:
 ;;; If you want ASDF utilities in user software, please use ASDF-UTILS.
 
 (defun asdf-at-least (version)
-  (or #+asdf2 (asdf:version-satisfies
-               (asdf:asdf-version) version)))
+  (asdf:version-satisfies (asdf:asdf-version) version))
 
 (defmacro asdefs (version &rest defs)
   (flet ((defun* (version name aname rest)
@@ -367,7 +370,7 @@ Record compiler notes signalled as `compiler-condition's."
   "Perform OPERATION-NAME on SYSTEM-NAME using ASDF.
 The KEYWORD-ARGS are passed on to the operation.
 Example:
-\(operate-on-system \"swank\" 'compile-op :force t)"
+\(operate-on-system \"cl-ppcre\" 'compile-op :force t)"
   (handler-case
       (with-compilation-hooks ()
         (apply #'asdf:operate (asdf-operation operation-name)

--- a/swank.asd
+++ b/swank.asd
@@ -19,21 +19,11 @@
 ;; This code has been placed in the Public Domain.  All warranties
 ;; are disclaimed.
 
-(defpackage :swank-loader
-  (:use :cl))
-
-(in-package :swank-loader)
-
-(defclass swank-loader-file (asdf:cl-source-file) ())
-
-;;;; after loading run init
-
-(defmethod asdf:perform ((o asdf:load-op) (f swank-loader-file))
-  (load (asdf::component-pathname f))
-  (funcall (read-from-string "swank-loader::init")
-           :reload (asdf::operation-forced o)
-           :delete (asdf::operation-forced o)))
+;; NB: This does NOT run init after loading.
+;; ASDF is not for system construction, not for initialization.
+;; Whoever calls (asdf:load-system :swank) is well-advised to afterwards call
+;; (funcall (read-from-string "swank-loader::init") ...)
+;; with proper flag (:delete :reload :load-contribs :setup :quiet)
 
 (asdf:defsystem :swank
-  :default-component-class swank-loader-file
   :components ((:file "swank-loader")))


### PR DESCRIPTION
- Drop the unsupported :force hack from swank.asd
- Update some comments and docstrings
- Remove an obsolete #+asdf2

This addresses https://github.com/slime/slime/issues/63
