### PR TITLE
Fix encoding problems in ChangeLog.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4904,7 +4904,7 @@
 	* swank-sbcl.lisp (swank-compile-file): Return T for the FAILURE-P
 	return value in case of a FATAL-COMPILER-ERROR.
 
-	Reported by Philipp M. SchÃ¤fer
+	Reported by Philipp M. Schäfer
 
 2009-04-03  Tobias C. Rittweiler  <tcr@freebits.de>
 
@@ -5825,7 +5825,7 @@
 	* slime.el (slime-compute-modeline-connection-state): Fix
 	computation of debugged requests.
 
-2008-11-30  GÃ¡bor Melis  <mega@retes.hu>
+2008-11-30  Gábor Melis  <mega@retes.hu>
 
 	* slime.el (slime-compute-modeline-connection-state): Print the
 	number of debugged requests if non-zero.
@@ -5862,7 +5862,7 @@
 	(slime-restart-or-init-modeline-update-timer): Inrease the timer
 	interval to 0.5 seconds.
 
-2008-11-22  GÃ¡bor Melis  <mega@retes.hu>
+2008-11-22  Gábor Melis  <mega@retes.hu>
 
 	Reincarnate "eval..." (almost)
 
@@ -5912,7 +5912,7 @@
 2008-10-31  Helmut Eller  <heller@common-lisp.net>
 
 	* slime.el (slime-repl-history-pattern): Simplify as suggested by
-	Knut Olav BÃ¸hmer and Michael Weber.
+	Knut Olav Bøhmer and Michael Weber.
 
 2008-10-31  Helmut Eller  <heller@common-lisp.net>
 
@@ -6150,7 +6150,7 @@
 	* slime.el (slime-cycle-connections): Do not make the new
 	connection buffer-local if we're currently in a REPL buffer.
 
-2008-09-24  Knut Olav BÃ¸hmer <knut-olav.bohmer@telenor.com>
+2008-09-24  Knut Olav Bøhmer <knut-olav.bohmer@telenor.com>
 
 	* slime.el (slime-cycle-connections): New command.
 
@@ -7547,7 +7547,7 @@
 	* slime.el (slime-list-threads, slime-thread-insert): Adapted to
 	new return value of LIST-THREADS.
 
-2008-07-04  GÃ¡bor Melis  <mega@retes.hu>
+2008-07-04  Gábor Melis  <mega@retes.hu>
 
 	* swank.lisp (call-with-redirected-io): Rebind only standard
 	streams if *GLOBALLY-REDIRECT-IO*. Fixes lost output after
@@ -8246,7 +8246,7 @@
 	Typical use is something like:
 	  (defun cmucl () (interactive) (slime 'cmucl))
 
-2008-01-22  LuÃ­s Oliveira  <loliveira@common-lisp.net>
+2008-01-22  Luís Oliveira  <loliveira@common-lisp.net>
 
 	* swank-source-path-parser.lisp (make-source-recording-readtable):
 	don't suppress the #. reader macro.
@@ -8324,7 +8324,7 @@
 	physical namestring, Emacs won't like a pathname or a logical
 	namestring.
 
-2008-01-02  LuÃ­s Oliveira  <loliveira@common-lisp.net>
+2008-01-02  Luís Oliveira  <loliveira@common-lisp.net>
 
 	Use sane default values for slime-repl-set-package.
 
@@ -8370,7 +8370,7 @@
 	* slime.el (slime-insert-xref-location): New function. Tries to
 	either insert the file name a function is defined in, or inserts
 	information about the buffer a function was interactively
-	`C-c C-c'd from. Idea from Knut Olav BÃ¸hmer.
+	`C-c C-c'd from. Idea from Knut Olav Bøhmer.
 	(slime-insert-xrefs): Use it.
 
 2007-12-14  Geo Carncross  <geocar@gmail.com>
@@ -8908,7 +8908,7 @@
 2007-08-31  Andreas Fuchs <asf@boinkor.net>
 
 	* slime.el (slime-reindent-defun): Fixed when used in lisp file
-	buffers. (Similiar patch also provided by GÃ¡bor Melis; problem
+	buffers. (Similiar patch also provided by Gábor Melis; problem
 	also reported by Jeff Cunningham.)
 
 2007-08-31  Jon Allen Boone <ipmonger@delamancha.org>
@@ -9556,7 +9556,7 @@
 
 2007-06-27  Tobias C. Rittweiler <tcr@freebits.de>
 
-	Fixing `C-c M-q' at the REPL. Thanks to AndrÃ© Thieme for pointing
+	Fixing `C-c M-q' at the REPL. Thanks to André Thieme for pointing
 	out that it has been broken since several months.
 
 	* slime.el (slime-reindent-defun): Use functions
@@ -9722,7 +9722,7 @@
 	* swank.lisp (fuzzy-find-matching-symbols): Modified to take
 	package nicknames into account. Previously, fuzzy completing on
 	nicknames did (except for some incidental cases) not work. Thanks
-	to LuÃ­s Oliveira and Attila Lendvai for pointing that out.
+	to Luís Oliveira and Attila Lendvai for pointing that out.
 
 2007-05-11  Tobias C. Rittweiler <tcr@freebits.de>
 
@@ -9995,7 +9995,7 @@
 	combined with their classification flags as determined by
 	CLASSIFY-SYMBOL.
 
-2007-04-08  LuÃ­s Oliveira <loliveira@common-lisp.net>
+2007-04-08  Luís Oliveira <loliveira@common-lisp.net>
 
 	* swank-backend.lisp (compute-sane-restarts): New interface.
 	* swank-clisp.lisp: Fix tabs and trailing whitespace.
@@ -10923,7 +10923,7 @@
 	(slime-repl-clear-buffer): Added optional prefix argument
 	specifying how many lines to leave.
 
-2006-12-06  Johan BockgÃ¥rd  <bojohan+sf@dd.chalmers.se>
+2006-12-06  Johan Bockgård  <bojohan+sf@dd.chalmers.se>
 
 	* swank.lisp (fuzzy-completion-set): Don't mix for clauses and
 	body clauses in loop.
@@ -11274,7 +11274,7 @@
 
 	* swank-allegro.lisp (initialize-multiprocessing): Update for new api.
 
-2006-10-20  Levente MÃ©szÃ¡ros <levente.meszaros@gmail.com>
+2006-10-20  Levente Mészáros <levente.meszaros@gmail.com>
 
 	Added "in-place" fuzzy completion GUI. See
 	slime-fuzzy-completions-map and
@@ -11809,7 +11809,7 @@
 
 	* swank.asd: Set *source-directory* to the asdf component dir.
 
-2006-07-01  LuÃ­s Oliveira  <loliveira@common-lisp.net>
+2006-07-01  Luís Oliveira  <loliveira@common-lisp.net>
 
 	* swank-sbcl.lisp (locate-compiler-note): Change first branch to
 	handle the changes introduced by the previous patch to
@@ -11820,7 +11820,7 @@
 	* swank-sbcl.lisp (find-definitions): Remove backward
 	compatibility code.
 
-2006-06-26  LuÃ­s Oliveira <loliveira@common-lisp.net>
+2006-06-26  Luís Oliveira <loliveira@common-lisp.net>
 
 	* swank-sbcl.lisp (tmpnam, temp-file-name): New functions.
 	(swank-compile-string): Create temporary file with the string and
@@ -12002,7 +12002,7 @@
 	* doc/Makefile (contributors.texi): use texinfo macros for
 	accented characters.
 
-	* ChangeLog: canonize Gabor Melis' spelling, otherwise he appears
+	* ChangeLog: canonize Gábor Melis' spelling, otherwise he appears
 	twice in the "Hackers of the good Hack table"
 
 	* doc/slime.texi (nyorsko): delete
@@ -12321,7 +12321,7 @@
 	* slime.el (slime-autodoc): Use it here to make use of the whole
 	width of the echo area for arglist display.
 
-2006-03-16  GÃ¡bor Melis <mega@hotpop.com>
+2006-03-16  Gábor Melis <mega@hotpop.com>
 
 	* swank-allegro.lisp (inspect-for-emacs): Fix typo.
 
@@ -12555,7 +12555,7 @@
 	* swank-backend.lisp: Add slot-value-using-class and
 	slot-boundp-using-class to the swank-mop package.
 
-2006-01-26  LuÃ­s Oliveira <loliveira@common-lisp.net>
+2006-01-26  Luís Oliveira <loliveira@common-lisp.net>
 
 	* slime.el (slime-enclosing-operator-names): detect make-instance
 	forms and collect the class-name argument if it exists and is a
@@ -12567,12 +12567,12 @@
 	(class-initargs-and-iniforms): New function.
 	(format-initargs-and-initforms-for-echo-area): New function.
 
-2006-01-20  MÃ©szÃ¡ros Levente <melevy@freemail.hu>
+2006-01-20 Mészáros Levente <melevy@freemail.hu>
 
 	* swank-sbcl.lisp (restart-frame): Provide an implementation even
 	if it doesn't quite do what it's supposed to do.
 
-2006-01-19  Helmut Eller  <heller@common-lisp.net>
+2006-01-19  Helmut Eller <heller@common-lisp.net>
 
 	Return to the previous loading strategy: load everything when
 	swank-loader is loaded.  It's just to convenient to give that up.
@@ -12847,7 +12847,7 @@
 	* slime.el (slime-repl-history-size, slime-repl-history-file): Use
 	defcustom to declare the variables.
 
-2005-10-23  GÃ¡bor Melis  <mega@hotpop.com>
+2005-10-23  Gábor Melis  <mega@hotpop.com>
 
 	* swank-backend.lisp (install-debugger-globally): new interface
 	function
@@ -13842,12 +13842,12 @@
 	(slime-repl-compile-and-load): Use save-some-lisp-buffers.
 	(slime-oos): Use save-some-lisp-buffers.
 
-2005-07-01  GÃ¡bor Melis  <mega@hotpop.com>
+2005-07-01  Gábor Melis  <mega@hotpop.com>
 
 	* swank-sbcl.lisp (threaded stuff): make SBCL 0.9.2.9+ work while
 	retaining support for 0.9.2
 
-2005-06-28  GÃ¡bor Melis <mega@hotpop.com>
+2005-06-28  Gábor Melis <mega@hotpop.com>
 
 	* swank-sbcl.lisp (threaded stuff): horrible hack to make threaded
 	SBCL 0.9.2 work.  (also, Happy Birthday Christophe!)
@@ -14327,7 +14327,7 @@
 	(slime-with-output-end-mark, slime-repl-return)
 	(slime-repl-send-input, slime-display-output-buffer): Use it
 	(slime-lisp-implementation-version, slime-machine-instance): New
-	connection variables.  Suggested by Eduardo MuÃ±oz.
+	connection variables.  Suggested by Eduardo Muñoz.
 	(slime-set-connection-info): Initialize them.
 
 	* swank.lisp (connection-info): Include version and hostname in
@@ -15009,7 +15009,7 @@
 
 	* swank-sbcl.lisp (profile-package): Add implementation for SBCL.
 
-2005-01-10  Eduardo MuÃ±oz <emufer@terra.es>
+2005-01-10  Eduardo Muñoz <emufer@terra.es>
 
 	* swank.lisp (inspect-for-emacs-list): LispWorks has a low args
 	limit for apply: use reduce instead of apply.
@@ -15896,7 +15896,7 @@
 	* swank-sbcl.lisp, swank-cmucl.lisp (inspect-for-emacs): Insert
 	function object's documentation when it's available.
 
-2004-09-15  Eduardo MuÃ±oz  <emufer@terra.es>
+2004-09-15  Eduardo Muñoz  <emufer@terra.es>
 
 	* .cvsignore: Added *.elc
 
@@ -16755,7 +16755,7 @@
 
 	* hyperspec.el (common-lisp-hyperspec-format): This command now
 	works at the end of the buffer, fixed `char-after' usage as
-	suggested by Johan BockgÃ¥rd.
+	suggested by Johan Bockgård.
 
 2004-06-28  Christophe Rhodes  <csr21@cam.ac.uk>
 
@@ -17191,11 +17191,11 @@
 	whitespace.
 
 	* (slime-init-output-buffer): Initialize the package stack.
-	Reported by Rui PatrocÃ­nio.
+	Reported by Rui Patrocínio.
 
 	* (slime-completions): Make it consistent with
 	slime-simple-completions. The second argument was never supplied.
-	Reported by Rui PatrocÃ­nio.
+	Reported by Rui Patrocínio.
 
 2004-06-09  Eric Blood <eblood@winkywooster.org>
 
@@ -18097,7 +18097,7 @@
 	`slime-mode'. This seems to give priority of keymap to the
 	inspector, so that it can override SPC.
 
-2004-03-26  BjÃ¸rn NordbÃ¸ <bn@telenor.net>
+2004-03-26  Bjørn Nordbø <bn@telenor.net>
 
 	* swank.lisp (print-arglist): Updated to handle arglists with
 	string elements, causing arglists for macros to display properly
@@ -18121,7 +18121,7 @@
 	Wrap byte-compilation in `save-window-excursion' to avoid showing
 	an unwanted warnings buffer (in XEmacs).
 
-2004-03-25  BjÃ¸rn NordbÃ¸ <bn@telenor.net>
+2004-03-25  Bjørn Nordbø <bn@telenor.net>
 
 	* swank-lispworks.lisp: (create-socket, set-sigint-handler)
 	(who-references, who-binds, who-sets): Add backward compatibility
@@ -18151,7 +18151,7 @@
 	(break): Be friendly to case-inverting readtables.
 
 	* swank-lispworks.lisp (emacs-connected): Add default method to
-	environment-display-notifier.  Reported by BjÃ¸rn NordbÃ¸.
+	environment-display-notifier.  Reported by Bjørn Nordbø.
 	(set-default-directory, who-specializes): Implemented for
 	Lispworks.
 	(gfp): New function.
@@ -18434,7 +18434,7 @@
 2004-03-09  Helmut Eller  <e9626484@stud3.tuwien.ac.at>
 
 	* swank-cmucl.lisp (read-into-simple-string): Use the correct fix.
-	Reported by HÃ¥kon Alstadheim.
+	Reported by Håkon Alstadheim.
 
 2004-03-08  Helmut Eller  <e9626484@stud3.tuwien.ac.at>
 
@@ -20085,7 +20085,7 @@
 2003-12-11  Helmut Eller  <e9626484@stud3.tuwien.ac.at>
 
 	* slime.el (slime-repl-previous-prompt, slime-repl-next-prompt):
-	New commands.  Suggested by HÃ¥kon Alstadheim.
+	New commands.  Suggested by Håkon Alstadheim.
 	(slime-repl-beginning-of-defun, slime-repl-end-of-defun): New
 	commands.  Suggested by Andreas Fuchs.
 	(slime-repl-insert-prompt): Mark the prompt with a


### PR DESCRIPTION
Fixes some characters that evidently were messed up when the encoding of the ChangeLog was switched to utf-8.
