### PR TITLE
abcl:  DESCRIBE-DEFINTION now works for macros.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2014-02-17  Mark Evenson  <evenson@panix.com>
+
+	* swank-abcl.lisp (describe-definition): Describe macros.
+
 2014-02-11  João Távora  <joaotavora@gmail.com>
 
 	* slime-tests.el (slime-test-recipe-test-for): Simplify and make

--- a/swank-abcl.lisp
+++ b/swank-abcl.lisp
@@ -299,7 +299,7 @@
 
 (defimplementation describe-definition (symbol namespace)
   (ecase namespace
-    (:variable 
+    ((:variable :macro)
      (describe symbol))
     ((:function :generic-function)
      (describe (symbol-function symbol)))


### PR DESCRIPTION
Trivial extension of ABCL implementation of SWANK-BACKEND:DESCRIBE-DEFINITION to macro symbols.
