### PR TITLE
Closes #116: Deal with file-names with spaces for inferior-lisp-program

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2014-02-26  João Távora  <joaotavora@gmail.com>
+
+	* slime.el (slime-read-interactive-args): Use
+	`split-string-and-unquote' (closes #116). Spotted by Mirko
+	Vukovic.
+
 2014-02-25  João Távora  <joaotavora@gmail.com>
 
 	* README.md: Add link to manual in github pages (hosted under

--- a/slime.el
+++ b/slime.el
@@ -1137,9 +1137,9 @@ The rules for selecting the arguments are rather complicated:
              (slime-lookup-lisp-implementation table (intern key))))
           (t
            (cl-destructuring-bind (program &rest program-args)
-               (split-string (read-shell-command
-                              "Run lisp: " inferior-lisp-program
-                              'slime-inferior-lisp-program-history))
+               (split-string-and-unquote
+                (read-shell-command "Run lisp: " inferior-lisp-program
+                                    'slime-inferior-lisp-program-history))
              (let ((coding-system
                     (if (eq 16 (prefix-numeric-value current-prefix-arg))
                         (read-coding-system "set slime-coding-system: "


### PR DESCRIPTION
- slime.el (slime-read-interactive-args): Use
  `split-string-and-unquote' (closes #116).
