### PR TITLE
Make sure the SWANK port file is an absolute path

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2014-02-27  Luís Oliveira  <loliveira@common-lisp.net>
+
+	Make sure the SWANK port file is an absolute path and free of
+	shell-isms like ~ that not all Lisps know how to parse. Bug
+	reported by Mirko Vukovic.
+
+	* slime.el (slime-swank-port-file): Use expand-file-name.
+
 2014-02-25  João Távora  <joaotavora@gmail.com>
 
 	* README.md: Add link to manual in github pages (hosted under

--- a/slime.el
+++ b/slime.el
@@ -1376,8 +1376,7 @@ See `slime-start'."
 
 (defun slime-swank-port-file ()
   "Filename where the SWANK server writes its TCP port number."
-  (concat (file-name-as-directory (slime-temp-directory))
-          (format "slime.%S" (emacs-pid))))
+  (expand-file-name (format "slime.%S" (emacs-pid)) (slime-temp-directory)))
 
 (defun slime-temp-directory ()
   (cond ((fboundp 'temp-directory) (temp-directory))


### PR DESCRIPTION
... and free of shell-isms like ~ that not all Lisps know how
to parse.
- slime.el (slime-swank-port-file): Use expand-file-name.
