### PR TITLE
Add flag to indicate the minimum Emacs version.

### DIFF
--- a/contrib/slime-fancy.el
+++ b/contrib/slime-fancy.el
@@ -16,21 +16,12 @@
                        slime-scratch
                        slime-references
                        slime-package-fu
-                       slime-fontifying-fu
-                       slime-trace-dialog)
-  (:on-load
-   (slime-trace-dialog-init)
-   (slime-repl-init)
-   (slime-autodoc-init)
-   (slime-c-p-c-init)
-   (slime-editing-commands-init)
-   (slime-fancy-inspector-init)
-   (slime-fancy-trace-init)
-   (slime-fuzzy-init)
-   (slime-presentations-init)
-   (slime-scratch-init)
-   (slime-references-init)
-   (slime-package-fu-init)
-   (slime-fontifying-fu-init)))
+                       slime-fontifying-fu))
+
+(unless (version< emacs-version "24")
+  (require 'slime-trace-dialog)
+  (push 'slime-trace-dialog
+        (slime-contrib-slime-dependencies
+         (slime-find-contrib 'slime-fancy))))
 
 (provide 'slime-fancy)

--- a/contrib/slime-trace-dialog.el
+++ b/contrib/slime-trace-dialog.el
@@ -15,6 +15,7 @@
 inspecting details of traced functions. Invoke this dialog with C-c T."
   (:authors "João Távora <joaotavora@gmail.com>")
   (:license "GPL")
+  (:minimum-emacs-version "24")
   (:swank-dependencies swank-trace-dialog)
   (:on-load (add-hook 'slime-mode-hook 'slime-trace-dialog-enable)
             (add-hook 'slime-repl-mode-hook 'slime-trace-dialog-enable))

--- a/slime.el
+++ b/slime.el
@@ -7108,7 +7108,8 @@ is setup, unless the user already set one explicitly."
                                on-unload
                                gnu-emacs-only
                                authors
-                               license)
+                               license
+                               minimum-emacs-version)
       (cl-loop for (key . value) in clauses append `(,key ,value))
     (cl-labels
         ((enable-fn (c) (intern (concat (symbol-name c) "-init")))
@@ -7119,6 +7120,13 @@ is setup, unless the user already set one explicitly."
                (cl-assert (not (featurep 'xemacs)) ()
                           ,(concat (symbol-name name)
                                    " does not work with XEmacs."))))
+         ,(when minimum-emacs-version
+            `(eval-and-compile
+               (cl-assert (not (version< emacs-version ,(car minimum-emacs-version)))
+                          ,(concat (symbol-name name)
+                                   " requires at least Emacs "
+                                   (car minimum-emacs-version)
+                                   "."))))
          ,@(mapcar (lambda (d) `(require ',d)) slime-dependencies)
          (defun ,(enable-fn name) ()
            (let ((contrib (slime-find-contrib ',name)))


### PR DESCRIPTION
So to fix my issue with https://github.com/slime/slime/issues/127 here is an additional flag for `define-slime-contrib` to define the minimum version of Emacs for which a contrib can be loaded.
