### PR TITLE
Update default URLs for SBCL manual in contrib/slime-references.el

### DIFF
--- a/contrib/slime-references.el
+++ b/contrib/slime-references.el
@@ -19,18 +19,18 @@
    (setq slime-tree-printer 'slime-tree-default-printer)
    (remove-hook 'sldb-extras-hooks 'sldb-maybe-insert-references)))
 
-(defcustom slime-sbcl-manual-root "http://www.sbcl.org/manual/"
+(defcustom slime-sbcl-manual-root "http://www.sbcl.org/manual"
   "*The base URL of the SBCL manual, for documentation lookup."
   :type 'string
   :group 'slime-mode)
 
-(defface sldb-reference-face 
+(defface sldb-reference-face
   (list (list t '(:underline t)))
   "Face for references."
   :group 'slime-debugger)
 
 
-;;;;; SBCL-style references 
+;;;;; SBCL-style references
 
 (defvar slime-references-local-keymap
   (let ((map (make-sparse-keymap "local keymap for slime references")))
@@ -99,7 +99,7 @@ See SWANK-BACKEND:CONDITION-REFERENCES for the datatype."
              (t
               (hyperspec-lookup what))))
           (t
-           (let ((url (format "%s%s.html" slime-sbcl-manual-root
+           (let ((url (format "%s#%s" slime-sbcl-manual-root
                               (subst-char-in-string ?\  ?\- what))))
              (browse-url url))))))))
 
@@ -119,10 +119,10 @@ See SWANK-BACKEND:CONDITION-REFERENCES for the datatype."
 ;;; FIXME: `compilation-mode' will swallow the `mouse-face'
 ;;; etc. properties.
 (defadvice slime-note.message (after slime-note.message+references)
-  (setq ad-return-value 
+  (setq ad-return-value
         (concat ad-return-value
                 (with-temp-buffer
-                  (slime-insert-references 
+                  (slime-insert-references
                    (slime-note.references (ad-get-arg 0)))
                   (buffer-string)))))
 


### PR DESCRIPTION
It seems like node URLs in SBCL's manual have changed from

  http://www.sbcl.org/manual/NODE.html

to

  http://www.sbcl.org/manual#NODE

I could not yet get confirmation in #sbcl, so treating this pull request with slight suspicion would be best.
