### PR TITLE
Fix Allegro CL backend problem with temporary files.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2014-03-19  Paulo Madeira  <acelent@gmail.com>
+
+	Fix Allegro CL backend problem with temporary files.
+
+	* swank-allegro.lisp (swank-compile-string): Don't bind
+	*default-pathname-defaults*.
+
 2014-03-09  João Távora  <joaotavora@gmail.com>
 
 	Save and restore windows that popped debugger windows.

--- a/swank-allegro.lisp
+++ b/swank-allegro.lisp
@@ -498,11 +498,7 @@
       (with-compilation-hooks ()
         (let ((*buffer-name* buffer)
               (*buffer-start-position* position)
-              (*buffer-string* string)
-              (*default-pathname-defaults*
-               (if filename 
-                   (merge-pathnames (pathname filename))
-                   *default-pathname-defaults*)))
+              (*buffer-string* string))
           (compile-from-temp-file string buffer position filename)))
     (reader-error () nil)))
 


### PR DESCRIPTION
- swank-allegro.lisp (swank-compile-string): Don't bind
  `*default-pathname-defaults*`.

---

This fixes a problem that is easy to replicate with Allegro CL in Windows:
1. Launch Allegro CL with SLIME
2. In a Lisp-mode buffer, C-c C-c over a definition, e.g. `(defun foo ())`

The following error, or a similar one, is signaled:

```
creating #P"c:\\tempa9548131523b" (which translates to
"c:\tempa9548131523b.lisp") resulted in
error: Permission denied [errno=13].
   [Condition of type FILE-ERROR]

Restarts:
 0: [ABORT] Abort compilation.
 1: [*ABORT] Return to SLIME's top level.
 2: [ABORT] Abort entirely from this (lisp) process.

Backtrace:
  0: (ERROR FILE-ERROR :PATHNAME #P"c:\\tempa9548131523b" :ERRNO 13 ...)
  1: ((METHOD EXCL:DEVICE-OPEN (EXCL:FILE-SIMPLE-STREAM T T)) #<EXCL:FILE-SIMPLE-STREAM "[not completely built]" closed @ #x237f279a> T ..)
  2: ((METHOD SHARED-INITIALIZE :AFTER (EXCL:SIMPLE-STREAM T)) #<EXCL:FILE-SIMPLE-STREAM "[not completely built]" closed @ #x237f279a> T :FILENAME #P"c:\\tempa9548131523b" :DIRECTION ...)
  3: ((:INTERNAL (:EFFECTIVE-METHOD 2 T NIL NIL NIL) 0) #<EXCL:FILE-SIMPLE-STREAM "[not completely built]" closed @ #x237f279a> T :FILENAME #P"c:\\tempa9548131523b" :DIRECTION ...)
  4: ((METHOD INITIALIZE-INSTANCE (STANDARD-OBJECT)) #<EXCL:FILE-SIMPLE-STREAM "[not completely built]" closed @ #x237f279a> :FILENAME #P"c:\\tempa9548131523b" :DIRECTION :OUTPUT ...)
  5: ((METHOD MAKE-INSTANCE (CLASS)) #<STANDARD-CLASS EXCL:FILE-SIMPLE-STREAM> :FILENAME #P"c:\\tempa9548131523b" :DIRECTION :OUTPUT ...)
  6: ((METHOD MAKE-INSTANCE (SYMBOL)) EXCL:FILE-SIMPLE-STREAM :FILENAME #P"c:\\tempa9548131523b" :DIRECTION :OUTPUT ...)
  7: (OPEN "c:\\tempa9548131523b" :DIRECTION :OUTPUT :IF-EXISTS :ERROR)
  8: (CALL-WITH-TEMP-FILE #<Closure (:INTERNAL COMPILE-FROM-TEMP-FILE 0) @ #x237f0d2a>)
  9: (COMPILE-FROM-TEMP-FILE ..)
  --more--
```

After aborting, another error is signaled:

```
There is no file named c:\tempa9548131523b:
No such file or directory
[errno=2].: No such file or directory [errno=2].
   [Condition of type FILE-ERROR]

Restarts:
 0: [ABORT] Abort compilation.
 1: [*ABORT] Return to SLIME's top level.
 2: [ABORT] Abort entirely from this (lisp) process.

Backtrace:
  0: (ERROR FILE-ERROR :ERRNO 2 :PATHNAME #P"c:\\tempa9548131523b" ...)
  1: (TRUENAME #P"c:\\tempa9548131523b" :FOLLOW-SYMLINKS NIL)
  2: (DELETE-FILE "c:\\tempa9548131523b")
  3: (CALL-WITH-TEMP-FILE #<Closure (:INTERNAL COMPILE-FROM-TEMP-FILE 0) @ #x237f0d2a>)
  4: (COMPILE-FROM-TEMP-FILE ..)
  --more--
```
