### PR TITLE
Fix for slime/slime#144.  It turns out that there are 2 nicknames in use

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,25 @@
+2014-04-10  Phil Hargett <phil@haphazardhouse.net>
+
+	Using nicknames, especially short terse ones, are more likely to create package
+	name conflicts with othe packages.  Since swank is widely used, its better
+	to avoid using nicknames (or at least short ones).  All package nicknames removed.
+
+	Further, the "MONITOR" package has been renamed "SWANK-MONITOR" for the same reason:
+	without the extra qualification, the name could conflict with other packages.
+
+	* contrib/swank-trace-dialog.el (defpackage swank-trace-dialog): removed :std nickname
+
+	* metering.lisp (defpackage "MONITOR"): removed :mon nickname, touched up
+	references in comments
+
+	* swank-ccl.lisp (profile, profiled-functions, unprofile, unprofile-all, profile-report,
+	profile-reset, profile-package): replaced use of nickname mon: with new package
+	name swank-monitor:
+
+	* swank-clisp.lisp (profile, profiled-functions, unprofile, unprofile-all, profile-report,
+	profile-reset, profile-package): replaced use of nickname mon: with new package
+	name swank-monitor:
+
 2014-04-10  Stas Boukarev  <stassats@gmail.com>
 
 	* slime.el (slime-trim-whitespace): Handle multiline strings.
@@ -56,7 +78,7 @@
 	temp files are separate steps.
 
 2014-03-27  Paulo Madeira  <acelent@gmail.com>
-
+ 
 	Improve source file recording for ACL backend.
 
 	Finding definitions compiled with SWANK:SWANK-COMPILE-STRING

--- a/contrib/swank-trace-dialog.lisp
+++ b/contrib/swank-trace-dialog.lisp
@@ -1,6 +1,5 @@
 (defpackage :swank-trace-dialog
   (:use :cl)
-  (:nicknames :std)
   (:import-from :swank :defslimefun :from-string :to-string)
   (:export #:clear-trace-tree
            #:dialog-toggle-trace

--- a/metering.lisp
+++ b/metering.lisp
@@ -144,10 +144,10 @@
 ;;; in order to average out to a higher resolution.
 ;;;
 ;;; The easiest way to use this package is to load it and execute either
-;;;     (mon:with-monitoring (names*) ()
+;;;     (swank-monitor:with-monitoring (names*) ()
 ;;;         your-forms*)
 ;;; or
-;;;     (mon:monitor-form your-form)
+;;;     (swank-monitor:monitor-form your-form)
 ;;; The former allows you to specify which functions will be monitored; the
 ;;; latter monitors all functions in the current package. Both automatically
 ;;; produce a table of statistics. Other variants can be constructed from
@@ -246,7 +246,7 @@
 ;;; The named functions will be set up for monitoring by augmenting
 ;;; their function definitions with code that gathers statistical information
 ;;; about code performance. As with the TRACE macro, the function names are
-;;; not evaluated. Calls the function MON::MONITORING-ENCAPSULATE on each
+;;; not evaluated. Calls the function SWANK-MONITOR::MONITORING-ENCAPSULATE on each
 ;;; function name. If no names are specified, returns a list of all
 ;;; monitored functions.
 ;;;
@@ -360,7 +360,7 @@ Estimated total monitoring overhead: 0.88 seconds
 
 ;;; For CLtL2 compatible lisps
 
-(defpackage "MONITOR" (:nicknames "MON") (:use "COMMON-LISP")
+(defpackage "SWANK-MONITOR" (:use "COMMON-LISP")
   (:export "*MONITORED-FUNCTIONS*"
 	   "MONITOR" "MONITOR-ALL" "UNMONITOR" "MONITOR-FORM"
 	   "WITH-MONITORING"
@@ -1184,7 +1184,7 @@ Time      Cons~
         (if (> num-no-calls 20)
             (format *trace-output*
                     "~%~@(~r~) monitored functions were not called. ~
-                      ~%See the variable mon::*no-calls* for a list."
+                      ~%See the variable swank-monitor::*no-calls* for a list."
                     num-no-calls)
             (format *trace-output*
                     "~%The following monitored functions were not called:~

--- a/swank-ccl.lisp
+++ b/swank-ccl.lisp
@@ -295,26 +295,26 @@
 ;;; Profiling (alanr: lifted from swank-clisp)
 
 (defimplementation profile (fname)
-  (eval `(mon:monitor ,fname)))		;monitor is a macro
+  (eval `(swank-monitor:monitor ,fname)))		;monitor is a macro
 
 (defimplementation profiled-functions ()
-  mon:*monitored-functions*)
+  swank-monitor:*monitored-functions*)
 
 (defimplementation unprofile (fname)
-  (eval `(mon:unmonitor ,fname)))	;unmonitor is a macro
+  (eval `(swank-monitor:unmonitor ,fname)))	;unmonitor is a macro
 
 (defimplementation unprofile-all ()
-  (mon:unmonitor))
+  (swank-monitor:unmonitor))
 
 (defimplementation profile-report ()
-  (mon:report-monitoring))
+  (swank-monitor:report-monitoring))
 
 (defimplementation profile-reset ()
-  (mon:reset-all-monitoring))
+  (swank-monitor:reset-all-monitoring))
 
 (defimplementation profile-package (package callers-p methods)
   (declare (ignore callers-p methods))
-  (mon:monitor-all package))
+  (swank-monitor:monitor-all package))
 
 ;;; Debugging
 

--- a/swank-clisp.lisp
+++ b/swank-clisp.lisp
@@ -568,26 +568,26 @@ Return two values: NAME and VALUE"
 ;;;; Profiling
 
 (defimplementation profile (fname)
-  (eval `(mon:monitor ,fname)))         ;monitor is a macro
+  (eval `(swank-monitor:monitor ,fname)))         ;monitor is a macro
 
 (defimplementation profiled-functions ()
-  mon:*monitored-functions*)
+  swank-monitor:*monitored-functions*)
 
 (defimplementation unprofile (fname)
-  (eval `(mon:unmonitor ,fname)))       ;unmonitor is a macro
+  (eval `(swank-monitor:unmonitor ,fname)))       ;unmonitor is a macro
 
 (defimplementation unprofile-all ()
-  (mon:unmonitor))
+  (swank-monitor:unmonitor))
 
 (defimplementation profile-report ()
-  (mon:report-monitoring))
+  (swank-monitor:report-monitoring))
 
 (defimplementation profile-reset ()
-  (mon:reset-all-monitoring))
+  (swank-monitor:reset-all-monitoring))
 
 (defimplementation profile-package (package callers-p methods)
   (declare (ignore callers-p methods))
-  (mon:monitor-all package))
+  (swank-monitor:monitor-all package))
 
 ;;;; Handle compiler conditions (find out location of error etc.)
 


### PR DESCRIPTION
And both are relatively common.  The `swank-trace-dialog` package had the nickname `std` (although never used the nickname, AFAICT), and in metering.lisp there was a `monitor` package that had the nickname `mon`. The nickname was referenced in a  few places, which I've now changed. The last nickname has been around for a while, and is only used in CCL and CLISP.

For better or for worse, I've removed _both_ nicknames and renamed the `monitor` package to `swank-monitor`.

I probably should have stuck to just fixing the `std` nickname, but I agree with @attila-lendvai , we should be conservative with shared namespaces.
