### PR TITLE
typo fix

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2014-04-12  Christophe Rhodes  <csr21@cantab.net>
+
+	* slime.el (slime-eval-with-transcript): Fix typo in docstring.
+
 2014-04-10  Phil Hargett <phil@haphazardhouse.net>
 
 	Using nicknames, especially short terse ones, are more likely to create package

--- a/slime.el
+++ b/slime.el
@@ -4069,7 +4069,7 @@ inserted in the current buffer."
   (slime-message "%s" value))
 
 (defun slime-eval-with-transcript (form)
-  "Eval FROM in Lisp.  Display output, if any."
+  "Eval FORM in Lisp.  Display output, if any."
   (run-hooks 'slime-transcript-start-hook)
   (slime-rex () (form)
     ((:ok value)


### PR DESCRIPTION
- slime.el (slime-eval-with-transcript): fix typo in docstring.
