### PR TITLE
fix #139

### DIFF
--- a/contrib/ChangeLog
+++ b/contrib/ChangeLog
@@ -1,3 +1,14 @@
+2014-04-12  Christophe Rhodes  <csr21@cantab.net>
+
+	* swank-presentations.lisp (lookup-and-save-presented-object-or-lose):
+	new slimefun, to take temporary presentations (e.g. from sldb or
+	slime-inspector) and turn them into permanent presentations in the
+	global presentation-id-object tables.
+
+	* slime-presentations.el (slime-copy-presentation-to-repl): rewrite,
+	including use of lookup-and-save-presented-object-or-lose, but also
+	restoring insertion of the presentation into the repl editing stream.
+
 2014-04-02  Stas Boukarev  <stassats@gmail.com>
 
 	* slime-repl.el (slime-repl-add-to-input-history): Fix whitespace

--- a/contrib/swank-presentations.lisp
+++ b/contrib/swank-presentations.lisp
@@ -84,6 +84,11 @@ The secondary value indicates the absence of an entry."
     (cond (foundp object)
           (t (error "Attempt to access unrecorded object (id ~D)." id)))))
 
+(defslimefun lookup-and-save-presented-object-or-lose (id)
+  "Get the object associated with ID and save it in the presentation tables."
+  (let ((obj (lookup-presented-object-or-lose id)))
+    (save-presented-object obj)))
+
 (defslimefun clear-repl-results ()
   "Forget the results of all previous REPL evaluations."
   (clear-presentation-tables)


### PR DESCRIPTION
- swank-presentations.lisp (lookup-and-save-presented-object-or-lose):
  new slimefun, to take temporary presentations (e.g. from sldb or
  slime-inspector) and turn them into permanent presentations in the
  global presentation-id-object tables.
- slime-presentations.el (slime-copy-presentation-to-repl): rewrite,
  including use of lookup-and-save-presented-object-or-lose, but also
  restoring insertion of the presentation into the repl editing stream.
