### PR TITLE
Fix for #151: Adding CCL to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,20 +3,24 @@ language: emacs
 env:
   # we test emacs23 with sbcl only
   - "CHECK_TARGET=check       LISP=sbcl EMACS=emacs23"
+  - "CHECK_TARGET=check       LISP=ccl  EMACS=emacs23"
   - "CHECK_TARGET=check-fancy LISP=sbcl EMACS=emacs23"
+  - "CHECK_TARGET=check-fancy LISP=ccl  EMACS=emacs23"
 
   # for emacs24, use more combinations
   - "CHECK_TARGET=check       LISP=sbcl  EMACS=emacs24"
   - "CHECK_TARGET=check       LISP=cmucl EMACS=emacs24"
+  - "CHECK_TARGET=check       LISP=ccl   EMACS=emacs24"
   - "CHECK_TARGET=check-fancy LISP=sbcl  EMACS=emacs24"
   - "CHECK_TARGET=check-fancy LISP=cmucl EMACS=emacs24"
+  - "CHECK_TARGET=check-fancy LISP=ccl   EMACS=emacs24"
 
   # also, for emacs24/sbcl test some more contribs in isolation
   - "CHECK_TARGET=check-repl LISP=sbcl EMACS=emacs24"
   - "CHECK_TARGET=check-indentation LISP=sbcl EMACS=emacs24"
 
 install:
-  - curl https://raw2.github.com/luismbo/cl-travis/master/install.sh | bash
+  - curl https://raw2.github.com/luismbo/cl-travis/master/install.sh | bash ;
   - if [ "$EMACS" = "emacs23" ]; then
         sudo apt-get -qq update &&
         sudo apt-get -qq -f install &&

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2014-04-13  Phil Hargett  <phil@haphazardhouse.net>
+
+	* .travis.yml: added targets to include CCL 1.9 for Travis builds
+	* slime-tests.el (compile-defun,compile-defun-with-reader-characters):
+	Split test into two parts, as CCL does not pass 1 existing test
+	* contrib/test/slime-test-autodoc.el: Mark several tests as
+	failing for CCL 1.9
+
 2014-04-12  João Távora  <joaotavora@gmail.com>
 
 	Unbreak CCL and CLISP and cleanup ChangeLog.

--- a/contrib/test/slime-autodoc-tests.el
+++ b/contrib/test/slime-autodoc-tests.el
@@ -102,7 +102,7 @@
   ;; Test &optional
   ("(swank::symbol-status foo *HERE*"
    "(symbol-status symbol &optional\
- ===> (package (symbol-package symbol)) <===)" :fails-for ("allegro"))
+ ===> (package (symbol-package symbol)) <===)" :fails-for ("allegro" "ccl"))
 
   ;; Test context-sensitive autodoc (DEFMETHOD)
   ("(defmethod swank::arglist-dispatch (*HERE*"
@@ -116,40 +116,40 @@
   ("(apply 'swank::eval-for-emacs*HERE*"
    "(apply 'eval-for-emacs &optional form buffer-package id &rest args)")
   ("(apply #'swank::eval-for-emacs*HERE*"
-   "(apply #'eval-for-emacs &optional form buffer-package id &rest args)")
+   "(apply #'eval-for-emacs &optional form buffer-package id &rest args)" :fails-for ("ccl"))
   ("(apply 'swank::eval-for-emacs foo *HERE*"
    "(apply 'eval-for-emacs &optional form\
  ===> buffer-package <=== id &rest args)")
   ("(apply #'swank::eval-for-emacs foo *HERE*"
    "(apply #'eval-for-emacs &optional form\
- ===> buffer-package <=== id &rest args)")
+ ===> buffer-package <=== id &rest args)" :fails-for ("ccl"))
 
   ;; Test context-sensitive autodoc (ERROR, CERROR)
   ("(error 'simple-condition*HERE*"
    "(error 'simple-condition &rest arguments\
- &key format-arguments format-control)")
+ &key format-arguments format-control)" :fails-for ("ccl"))
   ("(cerror \"Foo\" 'simple-condition*HERE*"
    "(cerror \"Foo\" 'simple-condition\
  &rest arguments &key format-arguments format-control)"
-   :fails-for ("allegro"))
+   :fails-for ("allegro" "ccl"))
 
   ;; Test &KEY and nested arglists
   ("(swank::with-retry-restart (:msg *HERE*"
    "(with-retry-restart (&key ===> (msg \"Retry.\") <===) &body body)"
-   :fails-for ("allegro"))
+   :fails-for ("allegro" "ccl"))
   ("(swank::with-retry-restart (:msg *HERE*(foo"
    "(with-retry-restart (&key ===> (msg \"Retry.\") <===) &body body)"
    :skip-trailing-test-p t
-   :fails-for ("allegro"))
+   :fails-for ("allegro" "ccl"))
   ("(swank::start-server \"/tmp/foo\" :dont-close *HERE*"
    "(start-server port-file &key (style swank:*communication-style*)\
  ===> (dont-close swank:*dont-close*) <===)"
-   :fails-for ("allegro"))
+   :fails-for ("allegro" "ccl"))
 
   ;; Test declarations and type specifiers
   ("(declare (string *HERE*"
    "(declare (string &rest ===> variables <===))"
-   :fails-for ("allegro"))
+   :fails-for ("allegro") :fails-for ("ccl"))
   ("(declare ((string *HERE*"
    "(declare ((string &optional ===> size <===) &rest variables))")
   ("(declare (type (string *HERE*"
@@ -161,6 +161,6 @@
   ("(labels ((foo (x y) (+ x y))) (foo *HERE*" "(foo ===> x <=== y)")
   ("(labels ((foo (x y) (+ x y))
                  (bar (y) (foo *HERE*"
-   "(foo ===> x <=== y)" :fails-for ("cmucl" "sbcl" "allegro")))
+   "(foo ===> x <=== y)" :fails-for ("cmucl" "sbcl" "allegro" "ccl")))
 
 (provide 'slime-autodoc-tests)


### PR DESCRIPTION
2014-04-13  Phil Hargett  phil@haphazardhouse.net

```
* .travis.yml: added targets to include CCL 1.9 for Travis builds
* slime-tests.el (compile-defun,compile-defun2): Split test
into two parts, as CCL does not pass 1 existing test
* contrib/test/slime-test-autodoc.el: Mark several tests as
failing for CCL 1.9
```
