### PR TITLE
Fix warnings for contrib/slime-clipboard.el.

### DIFF
--- a/contrib/ChangeLog
+++ b/contrib/ChangeLog
@@ -1,3 +1,10 @@
+2014-04-17  Olof-Joachim Frahm <olof@macrolet.net>
+
+	* slime-clipboard.el: Require `cl-lib`/`cl` for `lexical-let` and
+	`cl-` prefix.
+	(slime-clipboard-insert-entries, slime-clipboard-insert-ref)
+	(slime-clipboard-ref-modified): Use `cl-` prefix.
+
 2014-04-15  Phil Hargett  <phil@haphazardhouse.net>
 
 	* test/slime-autodoc-tests.el: Mark several tests as failing for

--- a/contrib/slime-clipboard.el
+++ b/contrib/slime-clipboard.el
@@ -1,5 +1,8 @@
 (require 'slime)
 (require 'slime-repl)
+(require 'cl-lib)
+(eval-when-compile
+  (require 'cl)) ; lexical-let
 
 (define-slime-contrib slime-clipboard
   "This add a few commands to put objects into a clipboard and to
@@ -72,10 +75,10 @@ debugger to add the object at point to the clipboard."
     (insert (format fstring "Nr" "Id" "Value")
             (format fstring "--" "--" "-----" ))
     (save-excursion
-      (loop for i from 0 for (ref . value) in entries do
-	    (slime-insert-propertized `(slime-clipboard-entry ,i
-					slime-clipboard-ref ,ref)
-				      (format fstring i ref value))))))
+      (cl-loop for i from 0 for (ref . value) in entries do
+               (slime-insert-propertized `(slime-clipboard-entry ,i
+                                           slime-clipboard-ref ,ref)
+                                         (format fstring i ref value))))))
 
 (defun slime-clipboard-redisplay ()
   "Update the clipboard buffer."
@@ -121,7 +124,7 @@ debugger to add the object at point to the clipboard."
 ;; remove this property in a modification when a user tries to modify
 ;; he real text.
 (defun slime-clipboard-insert-ref (entry)
-  (destructuring-bind (ref . string) 
+  (cl-destructuring-bind (ref . string) 
       (slime-eval `(swank-clipboard:entry-to-ref ,entry))
     (slime-insert-propertized
      `(display ,(format "#@%d%s" ref string)
@@ -134,7 +137,7 @@ debugger to add the object at point to the clipboard."
     (let ((inhibit-modification-hooks t))
       (save-excursion
 	(goto-char start)
-	(destructuring-bind (dstart dend) (slime-property-bounds 'display)
+	(cl-destructuring-bind (dstart dend) (slime-property-bounds 'display)
 	  (unless (and (= start dstart) (= end dend))
 	    (remove-list-of-text-properties 
 	     dstart dend '(display modification-hooks))))))))


### PR DESCRIPTION
This fixes the batch compilation for the above mentioned file for me, which failed because `destructuring-bind`, `loop` and `lexical-let` weren't loaded.
