### PR TITLE
Fix stale sldbs not being removed.

### DIFF
--- a/slime.el
+++ b/slime.el
@@ -4228,7 +4228,7 @@ in Lisp when committed with \\[slime-edit-value-commit]."
                                                       ,value)
           (lambda (_)
             (with-current-buffer buffer
-              (quit-window t))))))))
+              (kill-buffer))))))))
 
 ;;;; Tracing
 
@@ -5352,7 +5352,7 @@ If LEVEL isn't the same as in the buffer reinitialize the buffer."
              ;; FIXME: remove when dropping Emacs23 support
              (let ((previous-window (window-parameter (selected-window)
                                                       'sldb-restore)))
-               (quit-window t)
+               (kill-buffer)
                (if (and (not (>= emacs-major-version 24))
                         (window-live-p previous-window))
                    (select-window previous-window))))))))
@@ -5361,7 +5361,7 @@ If LEVEL isn't the same as in the buffer reinitialize the buffer."
   (when (buffer-live-p buffer)
     (with-current-buffer buffer
       (when (not sldb-level)
-        (quit-window t)))))
+        (kill-buffer)))))
 
 
 ;;;;;; SLDB buffer insertion
@@ -6058,7 +6058,7 @@ was called originally."
 (defun slime-quit-threads-buffer ()
   (when slime-threads-buffer-timer
     (cancel-timer slime-threads-buffer-timer))
-  (quit-window t)
+  (kill-buffer)
   (slime-eval-async `(swank:quit-thread-browser)))
 
 (defun slime-update-threads-buffer ()
@@ -6503,7 +6503,7 @@ that value.
   "Quit the inspector and kill the buffer."
   (interactive)
   (slime-eval-async `(swank:quit-inspector))
-  (quit-window t))
+  (kill-buffer))
 
 ;; FIXME: first return value is just point.
 ;; FIXME: could probably use slime-search-property.


### PR DESCRIPTION
Two test cases follow. The first is

```
(defun test ()
  (restart-case (error "No value.")
    (input-value (value)
      :report "Input a value."
      :interactive (lambda ()
                     (format *query-io* "Enter value: ")
                     (finish-output *query-io*)
                     (multiple-value-list (eval (read *query-io*))))
      value)))
```

After a value is entered, the `test` function completes correctly, but sldb is still open and has focus. Attempting to interact with it results in various errors or hanging.

In the next test case, we try to remove sldbs by killing the corresponding threads.

```
#+quicklisp
(eval-when (:compile-toplevel :load-toplevel :execute)
  (ql:quickload :bordeaux-threads))

(defun test ()
  (let (threads)
    (labels ((kill-others ()
               (loop until threads)
               (dolist (thread threads)
                 (unless (eq thread (bt:current-thread))
                   (bt:destroy-thread thread))))
             (task ()
               (restart-case (error "Some error.")
                 (kill-others ()
                   :report "Kill other threads."
                   (kill-others)))))
      (setf threads (loop repeat 10
                          collect (bt:make-thread #'task))))))
```

After selecting the `kill-others` restart, some number of stale sldbs remain open.

Emacs 24.3.1. Confirmed on SBCL, CCL, Allegro, LispWorks.

Last unbroken state is 89528e796aca11a54243d0168b896caa1f9666ed.

It would seem that erroring CL threads more closely correspond to buffers than to windows. Replacing `(quit-window t)` with `(kill-buffer)` fixes the problem for me. `make test` results are the same as before.
