### PR TITLE
Add the option to look for history from (mark).

### DIFF
--- a/contrib/slime-presentations.el
+++ b/contrib/slime-presentations.el
@@ -805,7 +805,7 @@ output; otherwise the new input is appended."
   "Return the current input as string.
 The input is the region from after the last prompt to the end of
 buffer. Presentations of old results are expanded into code."
-  (slime-buffer-substring-with-reified-output slime-repl-input-start-mark
+  (slime-buffer-substring-with-reified-output (slime-repl-history-yank-start)
                                               (if until-point-p
                                                   (point)
                                                 (point-max))))


### PR DESCRIPTION
The behaviour is controlled through slime-repl-history-use-mark -- when
nil, the original history replacement is done.
- Add a `slime-repl-history-yank-start' function that returns the
  furthermost position from (mark) and the start of the current input.
- Replace input from slime-r-h-yank-start instead of the beggining.

For example:

> CL-USER> (foo (bar :baz 23))
> 42
> CL-USER> (let ((x **C-SPC** (foo **M-p**
>         ;; will replace from `(foo' to yield:
> CL-USER> (let ((x (foo (bar :baz 23))
