### PR TITLE
Fix slime-all-xrefs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,9 @@
 2014-07-19  Bart Botta  <00003b@gmail.com>
+
+	* slime.el (slime-next-line/not-add-newlines): Delete unused
+	function.
+
+2014-07-19  Bart Botta  <00003b@gmail.com>
 	Fix slime-all-xrefs.
 
 	* slime.el (slime-all-xrefs): slime-next-line/not-add-newlines

--- a/doc/slime.texi
+++ b/doc/slime.texi
@@ -3361,7 +3361,6 @@ keybinding (if there is one) refer to the function description.
 @c @fcnindex{slime-make-default-connection}
 @c @fcnindex{slime-make-typeout-frame}
 @fcnindex{slime-mode}
-@c @fcnindex{slime-next-line/not-add-newlines}
 @c @fcnindex{slime-next-location}
 @fcnindex{slime-next-note}
 @fcnindex{slime-nop}

--- a/slime.el
+++ b/slime.el
@@ -4539,11 +4539,6 @@ The most important commands:
   ([remap previous-line] 'slime-xref-prev-line)
   )
 
-(defun slime-next-line/not-add-newlines ()
-  (interactive)
-  (let ((next-line-add-newlines nil))
-    (forward-line 1)))
-
 
 ;;;;; XREF results buffer and window management
 


### PR DESCRIPTION
Commit 6779941dc364666fef3b705ed8cf8bf97022d4b9 changed the behaviour of `slime-next-line/not-add-newlines` so that it returns 1 at end of buffer instead of erroring, which broke `slime-all-xrefs`.

`slime-next-line/not-add-newlines` seemed otherwise unused, so deleted that and just used `forward-line` directly.
