### PR TITLE
Fix source locations when recompiling from an xref buffer.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2014-07-19  Bart Botta  <00003b@gmail.com>
+	Fix source locations when recompiling from an xref buffer.
+
+	* slime.el (slime-recompile-locations): pass full filenames to
+	swank:compile-multiple-strings-for-emacs
+
 2014-06-17  Stas Boukarev  <stassats@gmail.com>
 
 	* swank-sbcl.lisp (emacs-inspect sb-kernel:code-component):

--- a/slime.el
+++ b/slime.el
@@ -2644,7 +2644,7 @@ PREDICATE is executed in the buffer to test."
                              (slime-current-package)
                              start
                              (if (buffer-file-name)
-                                 (file-name-directory (buffer-file-name))
+                                 (slime-to-lisp-filename (buffer-file-name))
                                nil)))))
         ',slime-compilation-policy)
     cont))


### PR DESCRIPTION
- slime.el (slime-recompile-locations): pass full filenames to
  swank:compile-multiple-strings-for-emacs
