### PR TITLE
Simple fix to anchor and cross-reference in texinfo manual

### DIFF
--- a/doc/slime.texi
+++ b/doc/slime.texi
@@ -1413,7 +1413,7 @@ Invoke the @code{ABORT} restart.
 @kbditem{q, sldb-quit}
 ``Quit'' -- For @SLIME{} evaluation requests, invoke a restart which
 restores to a known program state. For errors in other threads, see
-@ref{SWANK:*SLDB-QUIT-RESTART*}.
+@ref{*SLDB-QUIT-RESTART*}.
 
 @kbditem{c, sldb-continue}
 Invoke the @code{CONTINUE} restart.
@@ -1858,7 +1858,7 @@ globally set to @code{SWANK:SWANK-DEBUGGER-HOOK} and thus for @SLIME{}
 to handle all debugging in the Lisp image. This is for debugging
 multithreaded and callback-driven applications.
 
-@anchor{SWANK:*SLDB-QUIT-RESTART*}
+@anchor{*SLDB-QUIT-RESTART*}
 @vindex SWANK:*SLDB-QUIT-RESTART*
 @item SWANK:*SLDB-QUIT-RESTART*
 This variable names the restart that is invoked when pressing @kbd{q}


### PR DESCRIPTION
Makeinfo doesn't like colons in reference targets, so I removed 'SWANK:' from 'SWANK:_SLDB-QUIT-RESTART_'.

I don't believe there's any danger of ambiguity.
