### PR TITLE
Revised ELI-style history option

### DIFF
--- a/contrib/slime-repl.el
+++ b/contrib/slime-repl.el
@@ -1057,8 +1057,15 @@ Otherwise use the current input as search pattern.
 With a prefix-arg, do replacement from the mark."
   (interactive)
   (let ((slime-repl-history-use-mark (or slime-repl-history-use-mark
-                                         current-prefix-arg)))
+                                         current-prefix-arg))
+        (slime-repl-eli-history-behavior nil))
     (slime-repl-history-replace 'backward (slime-repl-history-pattern t))))
+
+(defun slime-repl-previous-input-nomatch ()
+  "Cycle backwards through input history. Unlike `slime-repl-previous-input`,
+do not use the current input as a search pattern: simply walk the history."
+  (interactive)
+  (slime-repl-history-replace 'backward nil))
 
 (defun slime-repl-next-input ()
   "Cycle forwards through input history.
@@ -1067,8 +1074,15 @@ See `slime-repl-previous-input'.
 With a prefix-arg, do replacement from the mark."
   (interactive)
   (let ((slime-repl-history-use-mark (or slime-repl-history-use-mark
-                                         current-prefix-arg)))
+                                         current-prefix-arg))
+        (slime-repl-eli-history-behavior nil))
     (slime-repl-history-replace 'forward (slime-repl-history-pattern t))))
+
+(defun slime-repl-next-input-nomatch ()
+  "Cycle forwards through input history.
+See `slime-repl-previous-input-nomatch'."
+  (interactive)
+  (slime-repl-history-replace 'forward nil))
 
 (defun slime-repl-forward-input ()
   "Cycle forwards through input history."


### PR DESCRIPTION
Here's a new version of the Eli history option. This adds a pair of commands to cycle through the history _without_ prefix-matching. It also turns _off_ the Eli history option when cycling through history and prefix-matching.

Using the Eli history option, I bind the "no-match" variants to M-p and M-n and the matching variants to M-P and M-N. This roughly mirrors ELI, which had separate commands for matching in the history and cycling through the history.  See my earlier comments for why this is desirable: briefly, the key utility of the ELI style is the ability to build a new CL input line _around_ a previously-entered input.

I do not believe that this is a final version, but it should provide an illustration of a productive direction.
