### PR TITLE
Fix byte-compile warnings in contrib/slime-fontifying-fu.el.

### DIFF
--- a/contrib/ChangeLog
+++ b/contrib/ChangeLog
@@ -1,3 +1,8 @@
+2014-10-22  Robert Brown  <robert.brown@gmail.com>
+
+	* slime-fontifying-fu.el: Do not byte compile functions that are
+	already compiled.
+
 2014-10-10  Luís Oliveira  <loliveira@common-lisp.net>
 
 	* slime-repl.el (sldb-copy-down-to-repl): Use SWANK/BACKEND.

--- a/contrib/slime-fontifying-fu.el
+++ b/contrib/slime-fontifying-fu.el
@@ -204,7 +204,11 @@ position, or nil."
                               'slime-extend-region-for-font-lock t t)))))
 
 (let ((byte-compile-warnings '()))
-  (mapc #'byte-compile
+  (mapc (lambda (sym)
+          (cond ((fboundp sym)
+                 (unless (byte-code-function-p (symbol-function sym))
+                   (byte-compile sym)))
+                (t (error "%S is not fbound" sym))))
         '(slime-extend-region-for-font-lock
           slime-compute-region-for-font-lock
           slime-search-directly-preceding-reader-conditional


### PR DESCRIPTION
When loading a Slime that has already been byte compiled, the explicit
byte compilation code in contrib/slime-fontifying-fu.el generates
warnings.  Use the same technique as slime-parse.el -- do not byte
compile if it's unnecessary.
