### PR TITLE
Revive swank-listener-hooks contrib.

### DIFF
--- a/contrib/ChangeLog
+++ b/contrib/ChangeLog
@@ -1,3 +1,10 @@
+2014-11-30  Ivan Shvedunov  <ivan4th@gmail.com>
+
+	Revive swank-listener-hooks.
+
+	* swank-listener-hooks.lisp: updated to use repl-related symbols
+	from SWANK-REPL package, export *SLIME-REPL-EVAL-HOOKS*.
+
 2014-11-25  Ivan Shvedunov  <ivan4th@gmail.com>
 
 	Fix history behavior in REPL when using both presentations and


### PR DESCRIPTION
Noticed that swank-listener-hooks experienced some bit rot in recent SLIME due to swank-repl moving to its own package. swank-listener-hooks isn't as obscure as the comment at the top suggested, it's used for CommonQt REPL integration, also, it's going to be used for similar purpose in newer cl-async (currently in uv branch).
