### PR TITLE
swank-loader.lisp (*architecture-features*): add armv5l, armv6l and armv7l

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2014-12-23  Daniel Kochmański  <dkochmanski@gmail.com>
+
+	* swank-loader.lisp (*architecture-features*): Add ARM architectures
+	as reported by ECL (armv5l, armv6l and armv7l) to mentioned variable.
+
 2014-12-17  Luís Oliveira  <loliveira@common-lisp.net>
 
 	* swank-loader.lisp (delete-packages): Robustify in case some

--- a/swank-loader.lisp
+++ b/swank-loader.lisp
@@ -58,7 +58,7 @@
 
 (defparameter *architecture-features*
   '(:powerpc :ppc :x86 :x86-64 :x86_64 :amd64 :i686 :i586 :i486 :pc386 :iapx386
-    :sparc64 :sparc :hppa64 :hppa :arm
+    :sparc64 :sparc :hppa64 :hppa :arm :armv5l :armv6l :armv7l
     :pentium3 :pentium4
     :java-1.4 :java-1.5 :java-1.6 :java-1.7))
 


### PR DESCRIPTION
These architectures are reported by ecl (as result of uname) on appropriate machines.
