### PR TITLE
Don't mess with slime-path at compile time

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,16 @@
+2015-01-02  Luís Oliveira  <loliveira@common-lisp.net>
+
+	* slime.el (slime-path): Only set slime-path at load-time. Setting
+	at compile time is potentially premature if compilation is not
+	immediately followed by loading. (See gh issue #125 for more
+	discussion.)
+	(slime--changelog-file-name): New function. Computes
+	the location of the SLIME ChangeLog based on
+	byte-compile-current-file at compile time, or based on slime-path
+	at load time when slime.el is not compiled.
+	(slime-changelog-date): Use slime--changelog-file-name. No longer
+	looks at slime-path at compile time.
+
 2014-12-23  Daniel Kochmański  <dkochmanski@gmail.com>
 
 	* swank-loader.lisp (*architecture-features*): Add ARM architectures

--- a/slime.el
+++ b/slime.el
@@ -88,10 +88,7 @@
 This is used to load the supporting Common Lisp library, Swank.
 The default value is automatically computed from the location of
 the Emacs Lisp package.")
-
-(eval-and-compile
- (let ((path (or (locate-library "slime") load-file-name)))
-   (setq slime-path (and path (file-name-directory path)))))
+(setq slime-path (file-name-directory load-file-name))
 
 (defvar slime-lisp-modes '(lisp-mode))
 (defvar slime-contribs nil
@@ -130,11 +127,17 @@ CONTRIBS is a list of contrib packages to load. If `nil', use
        'common-lisp-indent-function))
 
 (eval-and-compile
+  (defun slime--changelog-file-name ()
+    (expand-file-name "ChangeLog"
+                      (if byte-compile-current-file
+                          (file-name-directory byte-compile-current-file)
+                          slime-path)))
+
   (defun slime-changelog-date (&optional interactivep)
     "Return the datestring of the latest entry in the ChangeLog file.
 Return nil if the ChangeLog file cannot be found."
     (interactive "p")
-    (let ((changelog (expand-file-name "ChangeLog" slime-path))
+    (let ((changelog (slime--changelog-file-name))
           (date nil))
       (when (file-exists-p changelog)
         (with-temp-buffer

--- a/slime.el
+++ b/slime.el
@@ -129,7 +129,8 @@ CONTRIBS is a list of contrib packages to load. If `nil', use
 (eval-and-compile
   (defun slime--changelog-file-name ()
     (expand-file-name "ChangeLog"
-                      (if byte-compile-current-file
+                      (if (and (boundp 'byte-compile-current-file)
+                               byte-compile-current-file)
                           (file-name-directory byte-compile-current-file)
                           slime-path)))
 


### PR DESCRIPTION
Hey @ellerh,

João suggested a nicer approach to `slime-path` and `slime-protocol-version` that seems more robust than my previous attempt. (Issue #125 has a bunch of details.) Since this is somewhat subtle and tricky, I'd like to get your input before pushing this one. Does this look sane to you?