### PR TITLE
Suggest downcase completions for downcase users by default.

### DIFF
--- a/contrib/swank-c-p-c.lisp
+++ b/contrib/swank-c-p-c.lisp
@@ -163,7 +163,9 @@ Return these values:
 INPUT is used to guess the preferred case."
   (ecase (readtable-case *readtable*)
     (:upcase (cond ((or with-escaping-p
-                        (not (some #'lower-case-p input)))
+                        (if (eq *print-case* :downcase)
+                            (some #'upper-case-p input)
+                            (not (some #'lower-case-p input))))
                     #'identity)
                    (t #'string-downcase)))
     (:invert (lambda (output)


### PR DESCRIPTION
This change makes SLIME suggest completions after `package:` in lower case when `*print-case*` is `:downcase`. The idea is that if the user has chosen printing symbols in lower case, he does not want to read them in upper case in the completion window.

Upcase users may also want lower case completions by default, and this can be handled by a new special variable in the `swank` package. If so, I can extend or provide another patch and document the new variable, but I think that `*print-case*`-based logic should be there, for the new variable may not be customized (unbound).