### PR TITLE
Swank-presentation-streams needs to update is wrapper for sb-impl::%print-unreadable-object.

### DIFF
--- a/contrib/ChangeLog
+++ b/contrib/ChangeLog
@@ -1,3 +1,9 @@
+2015-03-11  Russ Tyndall  <russ@acceleration.net>
+
+	* swank-presentation-streams.lisp:
+	updated sb-impl::%print-unreadable-object wrapper
+	to accept body optionally, as per new SBCL
+
 2015-03-04  Luís Oliveira  <loliveira@common-lisp.net>
 
 	* slime-enclosing-context.el (slime-variable-binding-ops-alist):

--- a/contrib/swank-presentation-streams.lisp
+++ b/contrib/swank-presentation-streams.lisp
@@ -295,7 +295,7 @@ says that I am starting to print an object with this id. The second says I am fi
     (fdefinition 'sb-impl::%print-unreadable-object))
   (sb-ext:without-package-locks 
     (setf (fdefinition 'sb-impl::%print-unreadable-object)
-	  (lambda (object stream type identity body)
+	  (lambda (object stream type identity &optional body)
 	    (presenting-object object stream
 	      (funcall *saved-%print-unreadable-object* 
 		       object stream type identity body))))


### PR DESCRIPTION
The body argument is optional now in sb-impl::%print-unreadable-object and calls to this were erroring in new SBCL(1.2.9).