### PR TITLE
ABCL: swank/abcl.lisp (frame-locals frame-var-value)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2015-04-03  Mark Evenson  <evenson@quoth>
+
+	* swank/abcl.lisp (frame-locals frame-var-value): Fix off by one
+	errors in inspecting arguments across stack frames.  Attempt to
+	match arguments to parameters recorded at compile time.
+
 2015-04-02  Stas Boukarev  <stassats@gmail.com>
 
 	* swank.lisp (format-values-for-echo-area): Present a float

--- a/swank/abcl.lisp
+++ b/swank/abcl.lisp
@@ -375,16 +375,40 @@
   (write-string (sys:frame-to-string frame)
                 stream))
 
+;;; Sorry, but can't seem to declare DEFIMPLENTATION under FLET.  
+;;; --ME 20150403
+(defun nth-frame-list (index)
+  (java:jcall "toLispList" (nth-frame index)))
+
+(defun match-lambda (operator values)
+  (jvm::match-lambda-list
+   (multiple-value-list
+    (jvm::parse-lambda-list (ext:arglist operator)))
+   values))
+
 (defimplementation frame-locals (index)
- (loop
-    :with name = "??"
-    :for id :upfrom 0
-    :for value :in (java:jcall "toLispList" (nth-frame index))
-    :collecting  (list :name name :id id :value value)))
+  (loop
+     :for id :upfrom 0
+     :with frame = (nth-frame-list index)
+     :with operator = (first frame)
+     :with values = (rest frame)
+     :with arglist = (if (and operator (consp values) (not (null values)))
+                         (handler-case
+                             (match-lambda operator values)
+                           (jvm::lambda-list-mismatch (e)
+                             :lambda-list-mismatch))
+                         :not-available)
+     :for value :in values
+     :collecting (list
+                  :name (if (not (keywordp arglist))
+                            (first (nth id arglist))
+                            (format nil "arg~A" id))
+                  :id id
+                  :value value)))
 
 (defimplementation frame-var-value (index id)
- (elt (java:jcall "toLispList" (nth-frame index)) id))
-
+  (elt (rest (java:jcall "toLispList" (nth-frame index))) id))
+ 
 
 #+nil
 (defimplementation disassemble-frame (index)


### PR DESCRIPTION
@luismbo Squashing patches as requested.  

Fix off by one errors in inspecting arguments across stack frames.  Attempt to match
arguments to parameters names as recorded at compile time.