### PR TITLE
Application hints using not-hash-tables

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2015-04-21  Lucien Pullen  <drurowin@gmail.com>
+
+	* contrib/swank-indent.lisp (has-application-indentation-hint-p):
+	Use get-indentation-hint instead of hardcoding hash tables.
+	(*application-hints*): Type-independent name of the hints list.
+	(*application-hints-tables*): Backwards-compatible name for
+	*application-hints*.
+	(get-indentation-hint): Dispatch function to allow easy addition
+	of new types of things for looking up hints with.
+
 2015-04-19  Stas Boukarev  <stassats@gmail.com>
 
 	* swank/sbcl.lisp (*definition-types*): Add new type, :alien-type.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 2015-04-21  Lucien Pullen  <drurowin@gmail.com>
 
+	* contrib/slime-cl-indent.el (common-lisp-get-indentation)
+	(common-lisp-indent-function-1): Query swank when the function
+	name has not been interned.
+
 	* contrib/swank-indent.lisp (has-application-indentation-hint-p):
 	Use get-indentation-hint instead of hardcoding hash tables.
 	(*application-hints*): Type-independent name of the hints list.

--- a/contrib/swank-indentation.lisp
+++ b/contrib/swank-indentation.lisp
@@ -1,15 +1,34 @@
 (in-package :swank)
 
-(defvar *application-hints-tables* '()
-  "A list of hash tables mapping symbols to indentation hints (lists 
-of symbols and numbers as per cl-indent.el). Applications can add hash 
-tables to the list to change the auto indentation slime sends to 
-emacs.")
+(defvar *application-hints* '()
+  "A list of rules mapping symbols to indentation hints (lists of
+symbols and numbers as per cl-indent.el).  Applications can add rules to
+the list to change the auto indentation slime sends to emacs.
+
+See methods of `get-indentation-hint' for acceptable rule types.")
+
+(define-symbol-macro *application-hints-tables* *application-hints*)
+(setf (documentation '*application-hints-tables* 'variable)
+      "Backwards-compatible name.  Use `*application-hints*' instead.")
+
+(defgeneric get-indentation-hint (rule symbol &optional default)
+  (:documentation "The indentation hint for SYMBOL or DEFAULT.")
+  (:method ((o hash-table) s &optional default) (gethash s o default))
+  (:method ((o symbol) s &optional default)
+    "When RULE is fbound, call it.  Otherwise if RULE is bound, dereference it.
+Otherwise return DEFAULT."
+    (get-indentation-hint (cond ((fboundp o) (fdefinition o))
+                                ((boundp o) (symbol-value o))
+                                (t (return-from get-indentation-hint default)))
+                          s default))
+  (:method ((o function) s &optional default)
+    (handler-case (funcall o s default)
+      (error () default))))
 
 (defun has-application-indentation-hint-p (symbol)
   (let ((default (load-time-value (gensym))))
-    (dolist (table *application-hints-tables*)
-      (let ((indentation (gethash symbol table default)))
+    (dolist (table *application-hints*)
+      (let ((indentation (get-indentation-hint table symbol default)))
         (unless (eq default indentation)
           (return-from has-application-indentation-hint-p
             (values indentation t))))))

--- a/contrib/swank-indentation.lisp
+++ b/contrib/swank-indentation.lisp
@@ -22,6 +22,7 @@ Otherwise return DEFAULT."
                                 (t (return-from get-indentation-hint default)))
                           s default))
   (:method ((o function) s &optional default)
+    "Should be ready to accept strings and symbols."
     (handler-case (funcall o s default)
       (error () default))))
 


### PR DESCRIPTION
Swank can store indentation hints in things other than just hash tables. In addition to allowing symbol name subsequence matching, this allows Slime to do indentation for forms that have not been interned yet for things like automatic macros.