### PR TITLE
Update swank-loader.lisp

### DIFF
--- a/swank-loader.lisp
+++ b/swank-loader.lisp
@@ -61,6 +61,7 @@
   '(:powerpc :ppc :x86 :x86-64 :x86_64 :amd64 :i686 :i586 :i486 :pc386 :iapx386
     :sparc64 :sparc :hppa64 :hppa :arm :armv5l :armv6l :armv7l
     :pentium3 :pentium4
+    :mips :mipsel
     :java-1.4 :java-1.5 :java-1.6 :java-1.7))
 
 (defun q (s) (read-from-string s))


### PR DESCRIPTION
Missing architecture features for mips and mipsel.