### PR TITLE
replaced call to values with cl-values.  There is no such function as values

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2015-06-30 Jim Newton <jimka.issy@gmail.com>
+
+	* contrib/slime-enclosing-context.el
+	slime-edit-definition was broken because of a call to (values ...)
+	rather than (cl-values ...)
+	
 2015-06-01  Luís Oliveira  <loliveira@common-lisp.net>
 
 	* swank/sbcl.lisp: Added workaround for a bug in SBCL 1.2.12's

--- a/contrib/slime-enclosing-context.el
+++ b/contrib/slime-enclosing-context.el
@@ -186,7 +186,7 @@ Examples:
                     (push arg-index arg-indices)
                     (push (point) points))))
                 (backward-up-list 1)))))))
-    (values
+    (cl-values
      (nreverse result)
      (nreverse arg-indices)
  (nreverse points))))


### PR DESCRIPTION
This PR fixes broken slime-edit-definition