### PR TITLE
Enumerate fasls for building a swank-server binary on Allegro CL.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2015-07-07  YOKOTA Yuki  <y2q.actionman@gmail.com>
+
+	* swank-loader.lisp (list-fasls): New function.
+
 2015-06-27  Stas Boukarev  <stassats@gmail.com>
 
 	* swank.lisp (*pre-reply-hook*): Don't add


### PR DESCRIPTION

Hello.
I use slime on Allegro CL.

I have recently tried to make a standalone binary includes
swank-server fasls.  Because Allegro's `EXCL:GENERATE-APPLICATION`
requires paths of fasls and they must be arranged by their
dependencies, I needed to enumarate them using internal functions of
`slime-loader`.

So, I want a good way to enumerate fasls of swank in the correct order.

This pull-request addes a function to do it, named *list-fasls*.
Using this, I successfully created a swank-server binary like below:

```
; SLIME 2015-06-27
CL-USER> (current-directory)

#P"/tmp/"
CL-USER> (excl:generate-application
	  "test-swank-server"
	  "./acl-swank-server/"
	  (swank-loader:list-fasls)
	  :include-compiler nil
	  :restart-init-function 'swank:create-server)

; Autoloading for GENERATE-APPLICATION:
; Fast loading /usr/local/acl90-smp.64/code/genapp.fasl
;   Fast loading from bundle code/fileutil.fasl.
;   Fast loading /usr/local/acl90-smp.64/code/build.001
;;; Installing build patch, version 1.
;   Autoloading for package "REGEXP":
;     Fast loading /usr/local/acl90-smp.64/code/regexp2-s.001
;;; Installing regexp2-s patch, version 1.
;   Autoloading for REGEXP::MAKE-VM-CLOSURE:
;     Fast loading /usr/local/acl90-smp.64/code/regexp2.002
;;; Installing regexp2 patch, version 2.
;       Fast loading /usr/local/acl90-smp.64/code/yacc.fasl
;; Autoloading locale from #P"/usr/local/acl90-smp.64/locales/en_US"
Bundle is up to date.
T
CL-USER> (exit)
```

And, it runs well:

```
pharos:tmp$ pwd
/tmp
pharos:tmp$ cd acl-swank-server/
pharos:acl-swank-server$ ./test-swank-server 
International Allegro CL Enterprise Edition
9.0 [64-bit Linux (x86-64) *SMP*] (Jul 3, 2015 17:32)
Copyright (C) 1985-2012, Franz Inc., Oakland, CA, USA.  All Rights Reserved.

This standard runtime copy of Allegro CL was built by:
   ***********************************************  ;; (Sorry, Licence information is hidden..)

;   Loading /home/yokotay-local/quicklisp/setup.lisp
;   Autoloading for EXCL::COMPLEX-LOOP-EXPANDER:
;     Fast loading from bundle code/loop.fasl.
;   Autoloading for REVAPPEND:
;     Fast loading from bundle code/list2.fasl.
;;---
;; The compiler is not loaded into this lisp.
;; Swank started at port: 4005.
CL-USER(1): (swank/backend:all-threads)
(#<MULTIPROCESSING:PROCESS Swank 4005(6) waiting for input @
   #x1000114bf52>
 #<MULTIPROCESSING:PROCESS Swank Sentinel(4) receive-if @
   #x1000114a562>
 #<MULTIPROCESSING:PROCESS Initial Lisp Listener(2) @ #x10000df2bf2>)

;; At here, I tried 'M-x slime-connect' from emacs.

CL-USER(2): (swank/backend:all-threads)
(#<MULTIPROCESSING:PROCESS repl-thread(11) receive-if @ #x10001252402>
 #<MULTIPROCESSING:PROCESS auto-flush-thread(10) Sleeping @
   #x10001252572>
 #<MULTIPROCESSING:PROCESS swank-indentation-cache-thread(8) receive-if
   @ #x100011248f2>
 #<MULTIPROCESSING:PROCESS reader-thread(6) waiting-for-input @
   #x10001124972>
 #<MULTIPROCESSING:PROCESS control-thread(7) receive-if @
   #x100011249f2>
 #<MULTIPROCESSING:PROCESS Swank Sentinel(4) receive-if @
   #x10001124ad2>
 #<MULTIPROCESSING:PROCESS Initial Lisp Listener(2) @ #x10000df2bf2>)
 
;; At here, I did 'M-x slime-disconnect'.

CL-USER(3):  .. ..
;; swank:close-connection: #<END-OF-FILE @ #x10001295422>

CL-USER(3): (swank/backend:all-threads)
(#<MULTIPROCESSING:PROCESS [weak] Domain Name Server Client(9)
   waiting for input @ #x10001292462>
 #<MULTIPROCESSING:PROCESS Initial Lisp Listener(2) @ #x10000df2bf2>)
CL-USER(4): 

```

Thank you for your attention.
