### PR TITLE
* slime-media.el: Base64-decode literal image data

### DIFF
--- a/contrib/slime-media.el
+++ b/contrib/slime-media.el
@@ -10,11 +10,17 @@
   (:on-load
    (add-hook 'slime-event-hooks 'slime-dispatch-media-event)))
 
+(defun slime-media-decode-image (image)
+  (mapcar (lambda (image)
+	    (if (plist-get image :data)
+		(plist-put image :data (base64-decode-string (plist-get image :data)))
+	      image))
+	  image))
 (defun slime-dispatch-media-event (event)
   (slime-dcase event
     ((:write-image image string)
-     (let ((image (find-image image)))
-       (slime-media-insert-image image string))
+     (let ((img (find-image (slime-media-decode-image image))))
+       (slime-media-insert-image img string))
      t)
     ((:popup-buffer bufname string mode)
      (slime-with-popup-buffer (bufname :connection t :package t)


### PR DESCRIPTION
If image data is passed as :data, assume it is base64-encoded and decode
it. If there is no :data, don't change anything.

This fixes problems with sending actual binary data over the wire.