### PR TITLE
Fixed autoload spec of ‘hyperspec-lookup’

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2015-07-18  Mark Karpov <markkarpov@openmailbox.org>
+
+	* slime-autoloads.el (hyperspec-lookup): Fix autoload spec of the
+	function.
+
 2015-07-17  Helmut Eller  <heller@common-lisp.net>
 
 	Start using completion-at-point.

--- a/slime-autoloads.el
+++ b/slime-autoloads.el
@@ -23,7 +23,7 @@
 (autoload 'slime-connect "slime"
   "Connect to a running Swank server." t)
 
-(autoload 'hyperspec-lookup "hyperspec" nil t)
+(autoload 'hyperspec-lookup "lib/hyperspec" nil t)
 
 (autoload 'slime-lisp-mode-hook "slime")
 


### PR DESCRIPTION
Previously name of file to load was incorrect.