### PR TITLE
:mips and :mipsel

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2015-08-14  Angelo Rossi <angelo.rossi.homelab@gmail.com>
+	* swank-loader.lisp: Added :mips and :mipsel keyword
+	to the *architecture-features*.
+	
+	
 2015-06-23  Christian Schafmeister <chris.schaf@verizon.net>
 	* swank/clasp.lisp: Made it compatible with the upcoming
 	release of clasp and this breaks compatibility with the

--- a/swank-loader.lisp
+++ b/swank-loader.lisp
@@ -61,6 +61,7 @@
   '(:powerpc :ppc :x86 :x86-64 :x86_64 :amd64 :i686 :i586 :i486 :pc386 :iapx386
     :sparc64 :sparc :hppa64 :hppa :arm :armv5l :armv6l :armv7l
     :pentium3 :pentium4
+    :mips :mipsel
     :java-1.4 :java-1.5 :java-1.6 :java-1.7))
 
 (defun q (s) (read-from-string s))


### PR DESCRIPTION
Added :mips and :mipsel keyword in swank-loader.lisp \*architecture-features\*.