### PR TITLE
swank-presentation-streams/slime-stream-p fixes

### DIFF
--- a/contrib/swank-presentation-streams.lisp
+++ b/contrib/swank-presentation-streams.lisp
@@ -89,8 +89,9 @@ Two special return values:
 :DEDICATED -- Output ends up on a dedicated output stream
 :REPL-RESULT -- Output ends up on the :repl-results target.
 "
-    (if (eq stream t) 
-	(setq stream *standard-output*))
+    (case stream
+      ((nil) (setq stream *standard-output*))
+      ((t)  (setq stream *terminal-io*)))
 
     (if (eq last-stream stream)
 	last-answer

--- a/contrib/swank-presentation-streams.lisp
+++ b/contrib/swank-presentation-streams.lisp
@@ -89,12 +89,13 @@ Two special return values:
 :DEDICATED -- Output ends up on a dedicated output stream
 :REPL-RESULT -- Output ends up on the :repl-results target.
 "
+    (if (eq stream t) 
+	(setq stream *standard-output*))
+
     (if (eq last-stream stream)
 	last-answer
 	(progn
 	  (setq last-stream stream)
-	  (if (eq stream t) 
-	      (setq stream *standard-output*))
 	  (setq last-answer 
 		(or #+openmcl 
 		    (and (typep stream 'ccl::xp-stream) 


### PR DESCRIPTION
Hi,

looking at the sources swank-presentation-streams, I spotted some strangeness in `slime-stream-p`:
- It caches return value for `t` stream designator,
- It does not follow clhs convention for what `t` and `nil` stream designators mean.

On the other hand, I do not see whether this function is ever called with stream designator that is not a stream (`print-object` calls that indirectly, and it is specified in clhs to accept stream; so the only option is someone calling presenting-object directly with t or nil).

On the third hand. the caching could also fail on synonym streams. Does it make sense to resolve them as well?

Best regards,
Tomas

