### PR TITLE
The documentation cleanup

### DIFF
--- a/doc/slime.texi
+++ b/doc/slime.texi
@@ -166,7 +166,7 @@ Using @SLIME{} mode
 User-interface conventions
 
 * Temporary buffers::
-* Inferior-lisp::
+* Inferior-Lisp::
 * Multithreading::
 * Key bindings::
 
@@ -200,13 +200,13 @@ Lisp-side (Swank)
 
 Tips and Tricks
 
-* Connecting to a remote lisp::
+* Connecting to a remote Lisp::
 * Global IO Redirection::
 * Auto-SLIME::
 
-Connecting to a remote lisp
+Connecting to a remote Lisp
 
-* Setting up the lisp image::
+* Setting up the Lisp image::
 * Setting up Emacs::
 * Setting up pathname translations::
 
@@ -348,8 +348,9 @@ mailing list use the @Git{} version of the code.
 @node Git
 @subsection Downloading from Git
 
-@SLIME{} is available from the @Git{} repository on
-@file{github.com}. You have the option to use either the very latest
+@SLIME{} is available from the Github
+@url{https://github.com/slime/slime, repository}.
+You have the option to use either the very latest
 code or the tagged @code{FAIRLY-STABLE} snapshot.
 
 The latest version tends to have more features and fewer bugs than the
@@ -361,9 +362,9 @@ hacking). If you don't follow the mailing list you won't know the
 status of the latest code, so tracking @code{FAIRLY-STABLE} or using a
 released version is the safe option.
 
-If you download from @Git{} then remember to @code{git pull}
-occasionally.  Improvements are continually being committed, and the
-@code{FAIRLY-STABLE} tag is moved forward from time to time.
+Also remember to @code{git pull} occasionally. Improvements are continually
+being committed, and the @code{FAIRLY-STABLE} tag is moved forward from time
+to time.
 
 @c -----------------------
 @node Git Incantations
@@ -423,7 +424,7 @@ to add a few extra lines in your @file{.emacs}:
 @vindex inferior-lisp-program
 @vindex load-path
 @example
-;; @emph{Setup load-path, autoloads and your lisp system}
+;; @emph{Setup load-path, autoloads and your Lisp system}
 ;; @emph{Not needed if you install SLIME via MELPA}
 (add-to-list 'load-path "~/dir/to/cloned/slime")
 (require 'slime-autoloads)
@@ -456,7 +457,7 @@ how to configure @SLIME{} for multiple Lisp systems and how to reduce
 Please proceed with this section only if your basic setup works.  If
 you are happy with the basic setup, skip this section.
 
-For contrib modules @pxref{Loading Contribs}.
+See also @ref{Contributed Packages}.
 
 @menu
 * Basic customization::
@@ -468,18 +469,15 @@ For contrib modules @pxref{Loading Contribs}.
 @subsection Basic customization
 
 Once you have the basic no-frills setup working, you can enhance your
-@SLIME{} installation with bundled extensions:
+@SLIME{} installation with bundled extensions (@pxref{Loading Contribs}):
 
 @example
-;; @emph{Setup load-path, autoloads and your lisp system}
+;; @emph{Setup load-path, autoloads and your Lisp system}
 (add-to-list 'load-path "~/dir/to/cloned/slime")
 (require 'slime-autoloads)
 ;; @emph{Also setup the slime-fancy contrib}
 (add-to-list 'slime-contribs 'slime-fancy)
 @end example
-
-See @pxref{Loading Contribs} for more information on @SLIME{}'s
-contrib system.
 
 To customize a particular binding in one of @SLIME{}'s keymaps, you
 can add one of the following to your init file:
@@ -491,9 +489,10 @@ can add one of the following to your init file:
 @end example
 
 The former technique works only for @SLIME{}'s core keymaps, not it's
-contribs'. For those you can use the latter form which works for any
-Emacs library. See also @pxref{Customization} for more advanced
-configuration options.
+contribs. For those you can use the latter form which works for any
+Emacs library.
+
+For more advanced configuration options @pxref{Customization}.
 
 @node Multiple Lisps
 @subsection Multiple Lisps
@@ -533,7 +532,7 @@ spaces.
 @item PROGRAM-ARGS
 is a list of command line arguments.
 @item CODING-SYSTEM
-the coding system for the connection.  (@pxref{slime-net-coding-system})x
+the coding system for the connection. (@xref{slime-net-coding-system}.)
 @item INIT
 should be a function which takes two arguments: a filename and a
 character encoding.  The function should return a Lisp expression as a
@@ -636,7 +635,7 @@ principles are described in this section.
 
 @menu
 * Temporary buffers::
-* Inferior-lisp::
+* Inferior-Lisp::
 * Multithreading::
 * Key bindings::
 @end menu
@@ -669,12 +668,12 @@ function definitions, and so on.
 
 @vindex slime-description-autofocus
 Initial focus of those ``description'' buffers depends on the variable
-@code{slime-description-autofocus}. If @code{nil} (the default),
+@code{slime-description-autofocus}. If @code{NIL} (the default),
 description buffers do not receive focus automatically, and vice
 versa.
 
 @c -----------------------
-@node Inferior-lisp
+@node Inferior-Lisp
 @subsection @code{*inferior-lisp*} buffer
 
 @SLIME{} internally uses the @code{comint} package to start Lisp
@@ -686,9 +685,8 @@ The buffer @code{*inferior-lisp*} contains the Lisp process's own
 top-level. This direct access to Lisp is useful for troubleshooting,
 and some degree of @SLIME{} integration is available using the
 inferior-slime-mode.  Many people load the better integrated @SLIME{}
-@REPL{} contrib module (@pxref{REPL}) and ignore
-the @code{*inferior-lisp*} buffer.  (@pxref{Loading Contribs} for
-information on how to enable the REPL.)
+@REPL{} contrib module (@pxref{REPL}) and ignore the @code{*inferior-lisp*}
+buffer.
 
 @c -----------------------
 @node Multithreading
@@ -708,7 +706,7 @@ makes it sometimes difficult to change the printer or reader behaviour
 for new threads.  The variable
 @code{swank:*default-worker-thread-bindings*} was introduced for such
 situations: instead of modifying the global value of a variable, add a
-binding the @code{swank:*default-worker-thread-bindings*}.  E.g., with
+binding to the @code{swank:*default-worker-thread-bindings*}. E.g., with
 the following code, new threads will read floating point values as
 doubles by default:
 
@@ -842,7 +840,7 @@ Evaluate the expression before point and pretty-print the result in a
 fresh buffer.
 
 @kbditem{C-c E, slime-edit-value}
-Edit the value of a setf-able form in a new buffer @file{*Edit <form>*}.
+Edit the value of a setf-able form in a new buffer @code{*Edit <form>*}.
 The value is inserted into a temporary buffer for editing and then set
 in Lisp when committed with @kbd{C-c C-c}.
 
@@ -922,8 +920,8 @@ Remove all annotations from the buffer.
 @kbditem{C-x `, next-error}
 Visit the next-error message.  This is not actually a @SLIME{} command
 but @SLIME{} creates a hidden buffer so that most of the Compilation
-mode commands (@inforef{Compilation Mode,, emacs}) work similarly for
-Lisp as for batch compilers.
+Mode commands work similarly for Lisp as for batch compilers.
+(@inforef{Compilation Mode,, emacs}.)
 
 @end table
 
@@ -944,7 +942,7 @@ completion tries harder.
 @c @itemx C-M-i
 Complete the symbol at point. Note that three styles of completion are
 available in @SLIME{}; the default is similar to normal Emacs
-completion (@pxref{slime-completion-at-point-functions}).
+completion. (@xref{slime-completion-at-point-functions}.)
 
 @end table
 
@@ -992,7 +990,7 @@ Use an ETAGS table to find definition at point.
 
 @SLIME{}'s online documentation commands follow the example of Emacs
 Lisp. The commands all share the common prefix @kbd{C-c C-d} and allow
-the final key to be modified or unmodified (@pxref{Key bindings}.)
+the final key to be modified or unmodified. (@xref{Key bindings}.)
 
 @table @kbd
 
@@ -1053,7 +1051,7 @@ Repository} and bundled with @SLIME{}.
 Each command operates on the symbol at point, or prompts if there is
 none. With a prefix argument they always prompt. You can either enter
 the key bindings as shown here or with the control modified on the
-last key, @xref{Key bindings}.
+last key. (@xref{Key bindings}.)
 
 @menu
 * Xref buffer commands::
@@ -1132,10 +1130,10 @@ argument, use macroexpand instead of macroexpand-1.
 Fully macroexpand the expression at point.
 
 @cmditem{slime-compiler-macroexpand-1}
-Display the compiler-macro expansion of sexp at point.
+Display the compiler-macro expansion of S-expression at point.
 
 @cmditem{slime-compiler-macroexpand}
-Repeatedy expand compiler macros of sexp at point.
+Repeatedy expand compiler macros of S-expression at point.
 
 @end table
 
@@ -1291,7 +1289,7 @@ Show list of currently profiled functions.
 @table @kbd
 
 @kbditempair{C-c C-a, C-c C-v, slime-nop, slime-nop}
-This key-binding is shadowed from inf-lisp.
+This key-binding is shadowed from Inferior-Lisp.
 
 @end table
 
@@ -1499,7 +1497,7 @@ Inspect the condition currently being debugged.
 @kbditem{:, slime-interactive-eval}
 Evaluate an expression entered in the minibuffer.
 @kbditem{A, sldb-break-with-system-debugger}
-Attach debugger (e.g. gdb) to the current lisp process.
+Attach debugger (e.g. gdb) to the current Lisp process.
 
 @end table
 
@@ -1533,13 +1531,13 @@ The most recently activated @SLDB{} buffer for the current connection.
 @item l
 The most recently visited @code{lisp-mode} source buffer.
 @item s
-The @code{*slime-scratch*} buffer (@pxref{slime-scratch}).
+The @code{*slime-scratch*} buffer. (@xref{slime-scratch}.)
 @item c
-SLIME connections buffer (@pxref{Multiple connections}).
+SLIME connections buffer. (@xref{Multiple connections}.)
 @item n
-Cycle to the next Lisp connection (@pxref{Multiple connections}).
+Cycle to the next Lisp connection. (@xref{Multiple connections}.)
 @item t
-SLIME threads buffer (@pxref{Multiple connections}).
+SLIME threads buffer. (@xref{Multiple connections}.)
 @end table
 
 @code{slime-selector} doesn't have a key binding by default but we
@@ -1561,7 +1559,7 @@ buffers for @code{slime-selector} to find.
 @node slime-macroexpansion-minor-mode
 @section slime-macroexpansion-minor-mode
 
-Within a slime macroexpansion buffer some extra commands are provided
+Within a @SLIME{}'s macroexpansion buffer some extra commands are provided
 (these commands are always available but are only bound to keys in a
 macroexpansion buffer).
 
@@ -1683,17 +1681,17 @@ few important or obscure configuration options here in the manual.
 
 @item slime-truncate-lines
 The value to use for @code{truncate-lines} in line-by-line summary
-buffers popped up by @SLIME{}. This is @code{t} by default, which
+buffers popped up by @SLIME{}. This is @code{T} by default, which
 ensures that lines do not wrap in backtraces, apropos listings, and so
 on. It can however cause information to spill off the screen.
 
 @anchor{slime-completion-at-point-functions}
 @vindex slime-completion-at-point-functions
 @item slime-completion-at-point-functions
-A list of functions used for completion of Lisp symbols.  This works
+A list of functions used for completion of Lisp symbols. This works
 as the standard
 @code{completion-at-point-functions}
-(@pxref{Completion in Buffers,,,elisp}).  Three completion
+(@pxref{Completion in Buffers,,,elisp}). Three completion
 styles are available: @code{slime-simple-completion-at-point},
 @code{slime-complete-symbol*} (@pxref{Compound Completion}),
 and @code{slime-fuzzy-complete-symbol} (@pxref{Fuzzy Completion}).
@@ -1753,7 +1751,7 @@ buffers. An example use is to enable @code{slime-autodoc-mode}
 @vindex slime-connected-hook
 @item slime-connected-hook
 This hook is run when @SLIME{} establishes a connection to a Lisp
-server. An example use is to create a Typeout frame (@xref{Typeout frames}.)
+server. An example use is to create a Typeout frame (@pxref{Typeout frames}).
 
 @vindex sldb-hook
 @item sldb-hook
@@ -1870,11 +1868,11 @@ multithreaded and callback-driven applications.
 @vindex SWANK:*SLDB-QUIT-RESTART*
 @item SWANK:*SLDB-QUIT-RESTART*
 This variable names the restart that is invoked when pressing @kbd{q}
-(@pxref{sldb-quit}) in @SLDB{}. For @SLIME{} evaluation requests this
+in @SLDB{} (@pxref{sldb-quit}). For @SLIME{} evaluation requests this
 is @emph{unconditionally} bound to a restart that returns to a safe
 point. This variable is supposed to customize what @kbd{q} does if an
 application's thread lands into the debugger (see
-@code{SWANK:*GLOBAL-DEBUGGER*}).
+@code{SWANK:*GLOBAL-DEBUGGER*}), for example:
 @example
 (setf swank:*sldb-quit-restart* 'sb-thread:terminate-thread)
 @end example
@@ -1892,16 +1890,16 @@ situations.  The values of the variables are association lists of
 printer variable names with the corresponding value.  E.g., to enable
 the pretty printer for formatting backtraces in @SLDB{}, you can use:
 @example
-(push '(*print-pretty* . t) swank:*sldb-printer-bindings*).
+(push '(*print-pretty* . t) swank:*sldb-printer-bindings*)
 @end example
 
 @vindex SWANK:*USE-DEDICATED-OUTPUT-STREAM*
 @item SWANK:*USE-DEDICATED-OUTPUT-STREAM*
 This variable controls whether to use an unsafe efficiency hack for
-sending printed output from Lisp to Emacs.  The default is @code{nil},
+sending printed output from Lisp to Emacs.  The default is @code{NIL},
 don't use it, and is strongly recommended to keep.
 
-When @code{t}, a separate socket is established solely for Lisp to send
+When @code{T}, a separate socket is established solely for Lisp to send
 printed output to Emacs through, which is faster than sending the output
 in protocol-messages to Emacs.  However, as nothing can be guaranteed
 about the timing between the dedicated output stream and the stream of
@@ -1910,17 +1908,17 @@ after the corresponding REPL results.  Thus output and REPL results can
 end up in the wrong order, or even interleaved, in the REPL buffer.
 Using a dedicated output stream also makes it more difficult to
 communicate to a Lisp running on a remote host via SSH
-(@pxref{Connecting to a remote lisp}).
+(@pxref{Connecting to a remote Lisp}).
 
 @vindex SWANK:*DEDICATED-OUTPUT-STREAM-PORT*
 @item SWANK:*DEDICATED-OUTPUT-STREAM-PORT*
-When @code{*USE-DEDICATED-OUTPUT-STREAM*} is @code{t} the stream will
+When @code{*USE-DEDICATED-OUTPUT-STREAM*} is @code{T} the stream will
 be opened on this port. The default value, @code{0}, means that the
 stream will be opened on some random port.
 
 @vindex SWANK:*LOG-EVENTS*
 @item SWANK:*LOG-EVENTS*
-Setting this variable to @code{t} causes all protocol messages
+Setting this variable to @code{T} causes all protocol messages
 exchanged with Emacs to be printed to @code{*TERMINAL-IO*}. This is
 useful for low-level debugging and for observing how @SLIME{} works
 ``on the wire.'' The output of @code{*TERMINAL-IO*} can be found in
@@ -1934,34 +1932,34 @@ your Lisp system's own listener, usually in the buffer
 @chapter Tips and Tricks
 
 @menu
-* Connecting to a remote lisp::
+* Connecting to a remote Lisp::
 * Global IO Redirection::
 * Auto-SLIME::
 @end menu
 
 @c -----------------------
-@node Connecting to a remote lisp
-@section Connecting to a remote lisp
+@node Connecting to a remote Lisp
+@section Connecting to a remote Lisp
 
 One of the advantages of the way @SLIME{} is implemented is that we can
-easily run the Emacs side (slime.el) on one machine and the lisp backend
-(swank) on another. The basic idea is to start up lisp on the remote
-machine, load swank and wait for incoming @SLIME{} connections. On the
-local machine we start up emacs and tell @SLIME{} to connect to the
+easily run the Emacs side (slime.el) on one machine and the Lisp backend
+(Swank) on another. The basic idea is to start up Lisp on the remote
+machine, load Swank and wait for incoming @SLIME{} connections. On the
+local machine we start up Emacs and tell @SLIME{} to connect to the
 remote machine. The details are a bit messier but the underlying idea is
 that simple.
 
 @menu
-* Setting up the lisp image::
+* Setting up the Lisp image::
 * Setting up Emacs::
 * Setting up pathname translations::
 @end menu
 
 @c -----------------------
-@node Setting up the lisp image
-@subsection Setting up the lisp image
+@node Setting up the Lisp image
+@subsection Setting up the Lisp image
 
-When you want to load swank without going through the normal, Emacs
+When you want to load Swank without going through the normal, Emacs
 based, process just load the @file{swank-loader.lisp} file. Just
 execute
 
@@ -1970,19 +1968,19 @@ execute
 (swank-loader:init)
 @end example
 
-inside a running lisp image@footnote{@SLIME{} also provides an
+inside a running Lisp image@footnote{@SLIME{} also provides an
 @acronym{ASDF} system definition which does the same thing}. Now all we
-need to do is startup our swank server. The first example assumes we're
+need to do is startup our Swank server. The first example assumes we're
 using the default settings.
 
 @example
 (swank:create-server)
 @end example
 
-Since we're going to be tunneling our connection via ssh@footnote{there
-is a way to connect without an ssh tunnel, but it has the side-effect of
-giving the entire world access to your lisp image, so we're not going to
-talk about it} and we'll only have one port open we want to tell swank
+Since we're going to be tunneling our connection via SSH@footnote{there
+is a way to connect without an SSH tunnel, but it has the side-effect of
+giving the entire world access to your Lisp image, so we're not going to
+talk about it} and we'll only have one port open we want to tell Swank
 to not use an extra connection for output (this is actually the default
 in current @SLIME{}):
 
@@ -1992,7 +1990,7 @@ in current @SLIME{}):
 
 @c -----------------------
 If you need to do anything particular
-(like be able to reconnect to swank after you're done), look into
+(like be able to reconnect to Swank after you're done), look into
 @code{swank:create-server}'s other arguments. Some of these arguments
 are
 @table @code
@@ -2000,10 +1998,10 @@ are
 @item :PORT
 Port number for the server to listen on (default: 4005).
 @item :STYLE
-See @xref{Communication style}.
+@xref{Communication style}.
 @item :DONT-CLOSE
 Boolean indicating if the server will continue to accept connections
-after the first one (default: @code{NIL}). For ``long-running'' lisp processes
+after the first one (default: @code{NIL}). For ``long-running'' Lisp processes
 to which you want to be able to connect from time to time,
 specify @code{:dont-close t}
 @item :CODING-SYSTEM
@@ -2015,12 +2013,12 @@ So the more complete example will be
 @example
 (swank:create-server :port 4005  :dont-close t :coding-system "utf-8-unix")
 @end example
-On the emacs side you will use something like
+On the Emacs side you will use something like
 @example
 (setq slime-net-coding-system 'utf-8-unix)
-(slime-connect "127.0.0.1" 4005))
+(slime-connect "127.0.0.1" 4005)
 @end example
-to connect to this lisp image from the same machine.
+to connect to this Lisp image from the same machine.
 
 
 @node Setting up Emacs
@@ -2033,9 +2031,9 @@ remote machine.
 ssh -L4005:127.0.0.1:4005 username@@remote.example.com
 @end example
 
-That ssh invocation creates an ssh tunnel between the port 4005 on our
-local machine and the port 4005 on the remote machine@footnote{By
-default swank listens for incoming connections on port 4005, had we
+That @code{ssh} invocation creates an SSH tunnel between the port 4005 on
+our local machine and the port 4005 on the remote machine@footnote{By
+default Swank listens for incoming connections on port 4005, had we
 passed a @code{:port} parameter to @code{swank:create-server} we'd be
 using that port number instead}.
 
@@ -2047,15 +2045,15 @@ M-x slime-connect RET RET
 
 The @kbd{RET RET} sequence just means that we want to use the default
 host (@code{127.0.0.1}) and the default port (@code{4005}). Even
-though we're connecting to a remote machine the ssh tunnel fools Emacs
+though we're connecting to a remote machine the SSH tunnel fools Emacs
 into thinking it's actually @code{127.0.0.1}.
 
 @c -----------------------
 @node Setting up pathname translations
 @subsection Setting up pathname translations
 
-One of the main problems with running swank remotely is that Emacs
-assumes the files can be found using normal filenames. if we want
+One of the main problems with running Swank remotely is that Emacs
+assumes the files can be found using normal filenames. If we want
 things like @code{slime-compile-and-load-file} (@kbd{C-c C-k}) and
 @code{slime-edit-definition} (@kbd{M-.}) to work correctly we need to
 find a way to let our local Emacs refer to remote files.
@@ -2065,9 +2063,8 @@ NFS or similar, the remote machine's hard disk on the local machine's
 file system in such a fashion that a filename like
 @file{/opt/project/source.lisp} refers to the same file on both
 machines. Unfortunately NFS is usually slow, often buggy, and not
-always feasible, fortunately we have an ssh connection and Emacs'
-@code{tramp-mode} can do the rest.
-(See @inforef{Top, TRAMP User Manual,tramp}.)
+always feasible. Fortunately we have an SSH connection and Emacs'
+@code{tramp-mode} can do the rest. (@inforef{Top, TRAMP User Manual, tramp}.)
 
 What we do is teach Emacs how to take a filename on the remote machine
 and translate it into something that tramp can understand and access
@@ -2100,10 +2097,10 @@ often than not this is inconvenient. So, if you want code such as this:
     (write-line "In some random thread.~%" *standard-output*)))
 @end example
 
-to send its output to @SLIME{}'s repl buffer, as opposed to
-@code{*inferior-lisp*}, set @code{swank:*globally-redirect-io*} to T.
+to send its output to @SLIME{}'s REPL buffer, as opposed to
+@code{*inferior-lisp*}, set @code{swank:*globally-redirect-io*} to @code{T}.
 
-Note that the value of this variable is only checked when swank
+Note that the value of this variable is only checked when Swank
 accepts the connection so you should set it via
 @file{~/.swank.lisp}. Otherwise you will need to call
 @code{swank::globally-redirect-io-to-connection} yourself, but you
@@ -2113,7 +2110,7 @@ shouldn't do that unless you know what you're doing.
 @node Auto-SLIME
 @section Connecting to SLIME automatically
 
-To make @SLIME{} connect to your lisp whenever you open a lisp file
+To make @SLIME{} connect to your Lisp whenever you open a Lisp file
 just add this to your @file{.emacs}:
 
 @example
@@ -2174,7 +2171,7 @@ packages looks like:
 (add-to-list 'load-path "~/dir/to/cloned/slime")
 (require 'slime-autoloads)
 
-;; @emph{Set your lisp system and some contribs}
+;; @emph{Set your Lisp system and some contribs}
 (setq inferior-lisp-program "/opt/sbcl/bin/sbcl")
 (setq slime-contribs '(slime-scratch slime-editing-commands))
 @end example
@@ -2182,14 +2179,13 @@ packages looks like:
 After starting @SLIME{}, the commands of both packages should be
 available.
 
-The REPL and @code{slime-fancy} modules deserve special mention.  Many
-users consider the REPL (@pxref{REPL}) essential
-while @code{slime-fancy} (@pxref{slime-fancy}) loads the REPL and
-almost all of the popular contribs.  So, if you aren't sure what to
-choose start with:
+The REPL (@pxref{REPL}) and @code{slime-fancy} (@pxref{slime-fancy})
+modules deserve special mention. Many users consider the REPL essential
+while @code{slime-fancy} loads the REPL and almost all of the popular
+contribs. So, if you aren't sure what to choose start with:
 
 @example
-(setq slime-contribs '(slime-repl)) ; repl only
+(setq slime-contribs '(slime-repl)) ; REPL only
 @end example
 
 If you like what you see try this:
@@ -2378,7 +2374,7 @@ Change the current directory.
 Change the current package.
 
 @item compile-and-load (aka cl)
-Compile (if necessary) and load a lisp file.
+Compile (if necessary) and load a Lisp file.
 
 @item defparameter (aka !)
 Define a new global, special, variable.
@@ -2432,7 +2428,7 @@ sequentially by the same process.
 @section @code{inferior-slime-mode}
 
 The @code{inferior-slime-mode} is a minor mode is intended to use with
-the @code{*inferior-lisp*} lisp buffer.  It provides some of the
+the @code{*inferior-lisp*} Lisp buffer.  It provides some of the
 @SLIME{} commands, like symbol completion and documentation lookup. It
 also tracks the current directory of the Lisp process.  To install it,
 add something like this to user @file{.emacs}:
@@ -2481,7 +2477,7 @@ point should be placed after completion.  E.g. the possible
 completions for @code{f-o} are @code{finish-output} and
 @code{force-output}.  By the default point is moved after the
 @code{f}, because that is the unambiguous prefix.  If
-@code{slime-c-p-c-unambiguous-prefix-p} is nil, point moves to
+@code{slime-c-p-c-unambiguous-prefix-p} is @code{NIL}, point moves to
 the end of the inserted text, after the @code{o} in this case.
 
 In addition, @code{slime-c-p-c} provides completion for character names
@@ -2551,8 +2547,8 @@ completion heuristic.
 @anchor{slime-fuzzy-complete-symbol}
 @kbditem{C-c M-i, slime-fuzzy-complete-symbol}
 Presents a list of likely completions to choose from for an
-abbreviation at point.  If you set the
-variable @code{slime-complete-symbol-function} to this command, fuzzy
+abbreviation at point.  If you add this command to the
+variable @code{slime-completion-at-point-functions}, fuzzy
 completion will also be used for @kbd{M-TAB}.
 @end table
 
@@ -2584,7 +2580,7 @@ matches, all other things being equal.
 @subsection Duplicate Symbols
 
 In case a symbol is accessible via several packages, duplicate symbol
-filter specified via @code{*fuzzy-duplicate-symbol-filter*} swank
+filter specified via @code{*fuzzy-duplicate-symbol-filter*} Swank
 variable is applied. @code{:nearest-package} value specifies that only
 symbols in the package with highest score should be kept.
 @code{:home-package} specifies that only the match that represents the home
@@ -2653,7 +2649,7 @@ starts a timer, otherwise the information is only displayed after
 pressing SPC.
 
 @vindex slime-autodoc-use-multiline-p
-If @code{slime-autodoc-use-multiline-p} is set to non-nil,
+If @code{slime-autodoc-use-multiline-p} is set to non-@code{NIL},
 allow long autodoc messages to resize echo area display.
 
 @node ASDF
@@ -2673,7 +2669,7 @@ from the first file matching *.asd in the current directory.
 @cmditem{slime-reload-system NAME}
 Recompile and load an ASDF system without recompiling its dependencies.
 @cmditem{slime-open-system NAME &optional LOAD}
-Open all files in a system, optionally load it if LOAD is non-nil.
+Open all files in a system, optionally load it if LOAD is non-@code{NIL}.
 @cmditem{slime-browse-system NAME}
 Browse files in a system using Dired.
 @cmditem{slime-delete-system-fasls NAME}
@@ -2708,15 +2704,14 @@ Delete FASLs produced by compiling a system.
 
 @node Banner
 @section Banner
-The package @code{slime-banner} installs a window header line (
-@inforef{Header Lines, , elisp}.) in the REPL buffer.  It also runs an
-animation at startup.
+The package @code{slime-banner} installs a window header line in the REPL
+buffer. (@inforef{Header Lines,, elisp}.) It also runs an animation at startup.
 
 @vindex slime-startup-animation
 @vindex slime-header-line-p
-By setting the variable @code{slime-startup-animation} to nil you can
-disable the animation respectively with the
-variable @code{slime-header-line-p} the header line.
+By setting the variable @code{slime-startup-animation} to @code{NIL} you can
+disable the animation respectively with the variable @code{slime-header-line-p}
+the header line.
 
 @node Editing Commands
 @section Editing Commands
@@ -2734,20 +2729,20 @@ will be reindented.  If the current defun has unbalanced parens,
 an attempt will be made to fix it before reindenting.
 
 @kbditem{C-c C-], slime-close-all-parens-in-sexp}
-Balance parentheses of open s-expressions at point.
+Balance parentheses of open S-expressions at point.
 Insert enough right parentheses to balance unmatched left parentheses.
 Delete extra left parentheses.  Reformat trailing parentheses
 Lisp-stylishly.
 
 If REGION is true, operate on the region. Otherwise operate on
-the top-level sexp before point.
+the top-level S-expression before point.
 
 @cmditem{slime-insert-balanced-comments}
-Insert a set of balanced comments around the s-expression containing
+Insert a set of balanced comments around the S-expression containing
 the point.  If this command is invoked repeatedly (without any other
 command occurring between invocations), the comment progressively
 moves outward over enclosing expressions.  If invoked with a positive
-prefix argument, the s-expression arg expressions out is enclosed in a
+prefix argument, the S-expression arg expressions out is enclosed in a
 set of balanced comments.
 
 @kbditem{M-C-a, slime-beginning-of-defun}
@@ -2952,11 +2947,11 @@ If the typeout frame is closed then the echo area will be used again
 as usual.
 
 To have a typeout frame created automatically at startup you should
-load the @code{slime-typeout-frame} package. (@pxref{Loading Contribs}.)
+load the @code{slime-typeout-frame} package. (@xref{Loading Contribs}.)
 
 The variable @code{slime-typeout-frame-properties} specifies the
 height and possibly other properties of the frame.  Its value is
-passed to @code{make-frame}. (@inforef{Creating Frames, ,elisp}.)
+passed to @code{make-frame}. (@inforef{Creating Frames,,elisp}.)
 
 @node TRAMP
 @section TRAMP
@@ -2964,8 +2959,7 @@ passed to @code{make-frame}. (@inforef{Creating Frames, ,elisp}.)
 @cindex TRAMP
 
 The package @code{slime-tramp} provides some functions to set up
-filename translations for TRAMP. (@pxref{Setting up pathname
-translations})
+filename translations for TRAMP (@pxref{Setting up pathname translations}).
 
 @node Documentation Links
 @section Documentation Links
@@ -2983,8 +2977,7 @@ the @code{slime-xref-browser} package.
 
 @table @kbd
 @cmditem{slime-browse-classes}
-This command asks for a class name and displays inheritance tree of
-for the class.
+This command asks for a class name and displays it's inheritance tree.
 
 @cmditem{slime-browse-xrefs}
 This command prompts for a symbol and the kind of cross reference,
@@ -3011,22 +3004,22 @@ Turns @code{slime-highlight-edits-mode} on or off.
 @section Scratch Buffer
 
 @anchor{slime-scratch}
-The @SLIME{} scratch buffer, in contrib package @code{slime-scratch},
-imitates Emacs' usual @code{*scratch*} buffer.
-If @code{slime-scratch-file} is set, it is used to back the scratch
-buffer, making it persistent. The buffer is like any other Lisp
-buffer, except for the command bound to @kbd{C-j}.
+The SLIME's @code{*slime-scratch*} buffer imitates Emacs' usual
+@code{*scratch*} buffer. If @code{slime-scratch-file} is set, it
+is used to back the @code{*slime-scratch*} buffer, making it persistent.
+The buffer is like any other Lisp buffer, except for the command bound
+to @kbd{C-j}.
 
 @table @kbd
 
 @kbditem{C-j, slime-eval-print-last-expression}
-Evaluate the expression sexp before point and insert print value into
+Evaluate the S-expression before point and insert print value into
 the current buffer.
 
 @cmditem{slime-scratch}
-Create a @file{*slime-scratch*} buffer. In this
+Create a @code{*slime-scratch*} buffer. In this
 buffer you can enter Lisp expressions and evaluate them with
-@kbd{C-j}, like in Emacs's @file{*scratch*} buffer.
+@kbd{C-j}, like in Emacs' @code{*scratch*} buffer.
 
 @end table
 
@@ -3043,8 +3036,8 @@ function, calling it causes interesting information about that
 particular call to be reported.
 
 However, instead of printing the trace results to the
-the @code{*trace-output*} stream (usually the REPL), the @SLIME{}
-Trace Dialog collects and stores them in your lisp environment until,
+@code{*trace-output*} stream (usually the REPL), the @SLIME{}
+Trace Dialog collects and stores them in your Lisp environment until,
 on user's request, they are fetched into Emacs and displayed in a
 dialog-like interactive view.
 
@@ -3066,7 +3059,7 @@ adds two new commands, with respective key-bindings:
 If point is on a symbol name, toggle tracing of its function
 definition. If point is not on a symbol, prompt user for a function.
 
-With a @kbd{C-u} prefix argument, and if your lisp implementation
+With a @kbd{C-u} prefix argument, and if your Lisp implementation
 allows it, attempt to decipher lambdas, methods and other complicated
 function signatures.
 
@@ -3127,13 +3120,12 @@ outstanding.
 @end table
 
 The arguments and return values below each entry are interactive
-buttons. Clicking them opens the inspector
-(@pxref{Inspector}). Invoking @kbd{M-RET}
-(@code{slime-trace-dialog-copy-down-to-repl}) returns them to the REPL
-for manipulation (@pxref{REPL}). The number left of each entry
-indicates its absolute position in the calling order, which might
-differ from display order in case multiple threads call the same
-traced function.
+buttons. Clicking them opens the inspector (@pxref{Inspector}).
+Invoking @kbd{M-RET} (@code{slime-trace-dialog-copy-down-to-repl})
+returns them to the REPL for manipulation (@pxref{REPL}). The number
+left of each entry indicates its absolute position in the calling order,
+which might differ from display order in case multiple threads call the
+same traced function.
 
 @code{slime-trace-dialog-hide-details-mode} hides arguments and return
 values so you can concentrate on the calling logic. Additionally,
@@ -3147,7 +3139,7 @@ it.
 @code{slime-sprof} is a package for integrating SBCL's statistical profiler, sb-sprof.
 
 The variable @code{slime-sprof-exclude-swank} controls whether to
-display swank functions. The default value is NIL.
+display Swank's functions. The default value is @code{NIL}.
 
 @table @kbd
 
@@ -3164,13 +3156,13 @@ The following keys are defined in slime-sprof-browser mode:
 @table @kbd
 
 @kbditem{RET, slime-sprof-browser-toggle}
-Expand / collapse function details (callers, calls to)
+Expand / collapse function details (callers, callees)
 @kbditem{v, slime-sprof-browser-view-source}
 View function sources.
 @kbditem{d, slime-sprof-browser-disassemble-function}
 Disassemble function.
 @kbditem{s, slime-sprof-toggle-swank-exclusion}
-Toggle exclusion of swank functions from the report.
+Toggle exclusion of Swank's functions from the report.
 
 @end table
 


### PR DESCRIPTION
Replacements:
  lisp -> Lisp
  Inferior-lisp -> Inferior-Lisp
  emacs -> Emacs
  slime -> SLIME
  repl -> REPL
  ssh -> SSH
  swank -> Swank
  sexp -> S-expression
  nil -> NIL
  t -> T

Use @code instead of @file where appropriate.

Appropriate use of @xref and @pxref.

Text improvements.

Fix typos.