### PR TITLE
* slime.el (slime-log-event): Use lisp-mode in *slime-events*. It's convenient.

### DIFF
--- a/slime.el
+++ b/slime.el
@@ -2354,6 +2354,9 @@ Debugged requests are ignored."
 (defvar slime-log-events t
   "*Log protocol events to the *slime-events* buffer.")
 
+(defvar slime-lisp-mode-in-events-buffer nil
+  "*Non-nil means use lisp-mode in *slime-events*.")
+
 (defvar slime-outline-mode-in-events-buffer nil
   "*Non-nil means use outline-mode in *slime-events*.")
 
@@ -2393,6 +2396,8 @@ Debugged requests are ignored."
           (set (make-local-variable 'outline-regexp) "^(")
           (set (make-local-variable 'comment-start) ";")
           (set (make-local-variable 'comment-end) "")
+          (when slime-lisp-mode-in-events-buffer
+            (lisp-mode))
           (when slime-outline-mode-in-events-buffer
             (outline-minor-mode)))
         buffer)))


### PR DESCRIPTION
![screenshot - 2015 09 29 - 04 41 06](https://cloud.githubusercontent.com/assets/192655/10147369/8446c6ae-6668-11e5-8364-7488dcb97e1c.png)
