### PR TITLE
Draft / PoC: bind swank to a unix socket

### DIFF
--- a/swank/ccl.lisp
+++ b/swank/ccl.lisp
@@ -102,12 +102,13 @@
   :spawn)
 
 (defimplementation create-socket (host port &key backlog)
-  (ccl:make-socket :connect :passive :local-port port
-                   :local-host host :reuse-address t
-                   :backlog (or backlog 5)))
+  (multiple-value-call #'ccl:make-socket
+    :connect :passive :local-host host :backlog (or backlog 5)
+    (if (typep port 'integer) (values :reuse-address t :local-port port)
+        (values :local-filename port :address-family :file))))
 
 (defimplementation local-port (socket)
-  (ccl:local-port socket))
+  (or (ccl:local-port socket) (ccl:local-filename socket)))
 
 (defimplementation close-socket (socket)
   (close socket))


### PR DESCRIPTION
The functionality works (on CCL), but this PR is not intended to be merged as-is; it's more of an RFC. If this is useful to you, please at least "ACK"; better yet, submit code for missing backends and/or fix [the `socket-quest` restart](https://github.com/slime/slime/blob/2cca7e/swank.lisp#L789-L793) to support non-integer "ports".
