### PR TITLE
Fixed documentation bugs for the mrepl contrib.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2015-10-18  Jack Pugmire  <jep@openmailbox.org>
+
+	Fixed some documentation bugs for the mrepl contrib.
+
+	* doc/slime.texi (Contributed Packages) : Replace reference to
+	slime-open-listener with slime-new-mrepl
+
+	* contrib/slime-mrepl.el: Fixed outdated header comment
+
 2015-10-18  Helmut Eller  <heller@common-lisp.net>
 
 	Minor factorization.

--- a/contrib/slime-mrepl.el
+++ b/contrib/slime-mrepl.el
@@ -1,6 +1,5 @@
 ;; An experimental implementation of multiple REPLs multiplexed over a
-;; single Slime socket.  M-x slime-open-listener creates a new REPL
-;; buffer.
+;; single Slime socket.  M-x slime-new-mrepl creates a new REPL buffer.
 ;;
 (require 'slime)
 (require 'inferior-slime) ; inferior-slime-indent-lime

--- a/doc/slime.texi
+++ b/doc/slime.texi
@@ -2422,7 +2422,7 @@ Quit all Lisps and close all @SLIME{} buffers.
 @section Multiple REPLs
 
 The @code{slime-mrepl} package adds support for multiple listener
-buffers.  The command @kbd{M-x slime-open-listener} creates a new
+buffers.  The command @kbd{M-x slime-new-mrepl} creates a new
 buffer.  In a multi-threaded Lisp, each listener is associated with a
 separate thread.  In a single-threaded Lisp it's also possible to
 create multiple listener buffers but the commands are executed


### PR DESCRIPTION
This commit <https://github.com/slime/slime/commit/0eb7d96b108e4adc4205967db4530d2bc9f2f746> changed the name of the interactive slime-open-listener to slime-new-mrepl, however the documentation for the mrepl contrib was not updated to reflect this.