### PR TITLE
Macrostep contrib

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -38,6 +38,30 @@
 	* swank/clasp.lisp (source-location): clasp now uses the same
 	method for c-function source location as for lisp functions.
 
+2015-12-07  Jon Oddie  <j.j.oddie@gmail.com>
+
+	Add `slime-macrostep' contrib.
+
+	* slime.el: Depend on macrostep 0.9.
+
+	* lib/macrostep.el: New file.  This is a bundled version of the
+	library developed at http://github.com/joddie/macrostep and also
+	available via MELPA.  The bundled copy will be used as a fallback
+	if it is not installed separately.
+
+	* swank/backend.lisp (collect-macro-forms): New backend helper
+	used by `slime-macrostep', and a generic implementation.
+	(with-collected-macro-forms): New macro to ease implementing
+	`collect-macro-forms' by let-binding *MACROEXPAND-HOOK*
+	* swank/sbcl.lisp (collect-macro-forms): SBCL implementation using
+	a code-walker.
+	* swank/abcl.lisp (collect-macro-forms): ABCL implementation using
+	WITH-COLLECTED-MACRO-FORMS.
+	* swank/clisp.lisp (collect-macro-forms): CLISP implementation
+	using WITH-COLLECTED-MACRO-FORMS.
+
+	* swank-loader.lisp (*contribs*): Add `swank-macrostep'.
+
 2015-12-06  Stas Boukarev  <stassats@gmail.com>
 
 	* swank-loader.lisp (compile-files): Don't abort on errors,

--- a/contrib/ChangeLog
+++ b/contrib/ChangeLog
@@ -1,3 +1,12 @@
+2015-12-07  Jon Oddie  <j.j.oddie@gmail.com>
+
+	Add `slime-macrostep' contrib (fancy in-place macroexpansion).
+
+	* slime-macrostep.el: New file.
+	* swank-macrostep.lisp: New file.
+	* test/slime-macrostep-tests.el: New file.
+	* slime-fancy.el (slime-fancy): Add `slime-macrostep'.
+
 2015-11-29  Stas Boukarev  <stassats@gmail.com>
 
 	* swank-fancy-inspector.lisp (inspect-type-specifier): The latest

--- a/contrib/slime-fancy.el
+++ b/contrib/slime-fancy.el
@@ -13,6 +13,7 @@
                        slime-fancy-trace
                        slime-fuzzy
                        slime-mdot-fu
+                       slime-macrostep
                        slime-presentations
                        slime-scratch
                        slime-references

--- a/contrib/slime-macrostep.el
+++ b/contrib/slime-macrostep.el
@@ -1,0 +1,129 @@
+;;; slime-macrostep.el -- fancy macro-expansion via macrostep.el
+
+;; Authors: Luís Oliveira <luismbo@gmail.com>
+;;          Jon Oddie <j.j.oddie@gmail.com
+;;
+;; License: GNU GPL (same license as Emacs)
+
+;;; Description:
+
+;; Fancier in-place macro-expansion using macrostep.el (originally
+;; written for Emacs Lisp).  To use, position point before the
+;; open-paren of the macro call in a SLIME source or REPL buffer, and
+;; type `C-c M-e' or `M-x macrostep-expand'.  The pretty-printed
+;; result of `macroexpand-1' will be inserted inline in the current
+;; buffer, which is temporarily read-only while macro expansions are
+;; visible.  If the expansion is itself a macro call, expansion can be
+;; continued by typing `e'.  Expansions are collapsed to their
+;; original macro forms by typing `c' or `q'.  Other macro- and
+;; compiler-macro calls in the expansion will be font-locked
+;; differently, and point can be moved there quickly by typing `n' or
+;; `p'.  For more details, see the documentation of
+;; `macrostep-expand'.
+
+;;; Code:
+
+(require 'slime)
+(eval-and-compile
+  (require 'macrostep nil t)
+  ;; Use bundled version if not separately installed
+  (require 'macrostep "../lib/macrostep"))
+(eval-when-compile (require 'cl-lib))
+
+(defvar slime-repl-mode-hook)
+(defvar slime-repl-mode-map)
+
+(define-slime-contrib slime-macrostep
+  "Interactive macro expansion via macrostep.el."
+  (:authors "Luís Oliveira       <luismbo@gmail.com>"
+            "Jon Oddie           <j.j.oddie@gmail.com>")
+  (:license "GPL")
+  (:swank-dependencies swank-macrostep)
+  (:on-load
+   (easy-menu-add-item slime-mode-map '(menu-bar SLIME Debugging)
+                       ["Macro stepper..." macrostep-expand (slime-connected-p)]
+                       "Create Trace Buffer")
+   (add-hook 'slime-mode-hook #'macrostep-slime-mode-hook)
+   (define-key slime-mode-map (kbd "C-c M-e") #'macrostep-expand)
+   (eval-after-load 'slime-repl
+     '(progn
+       (add-hook 'slime-repl-mode-hook #'macrostep-slime-mode-hook)
+       (define-key slime-repl-mode-map (kbd "C-c M-e") #'macrostep-expand)))))
+
+(defun macrostep-slime-mode-hook ()
+  (setq macrostep-sexp-at-point-function #'macrostep-slime-sexp-at-point)
+  (setq macrostep-environment-at-point-function #'macrostep-slime-context)
+  (setq macrostep-expand-1-function #'macrostep-slime-expand-1)
+  (setq macrostep-print-function #'macrostep-slime-insert)
+  (setq macrostep-macro-form-p-function #'macrostep-slime-macro-form-p))
+
+(defun macrostep-slime-sexp-at-point (&rest _ignore)
+  (slime-sexp-at-point))
+
+(defun macrostep-slime-context ()
+  (let (defun-start defun-end)
+    (save-excursion
+      (while
+          (condition-case nil
+              (progn (backward-up-list) t)
+            (scan-error nil)))
+      (setq defun-start (point))
+      (setq defun-end (scan-sexps (point) 1)))
+    (list (buffer-substring-no-properties
+           defun-start (point))
+          (buffer-substring-no-properties
+           (scan-sexps (point) 1) defun-end))))
+
+(defun macrostep-slime-expand-1 (string context)
+  (slime-dcase
+      (slime-eval
+       `(swank-macrostep:macrostep-expand-1
+         ,string ,macrostep-expand-compiler-macros ',context))
+    ((:error error-message)
+     (error "%s" error-message))
+    ((:ok expansion positions)
+     (list expansion positions))))
+
+(defun macrostep-slime-insert (result _ignore)
+  "Insert RESULT at point, indenting to match the current column."
+  (cl-destructuring-bind (expansion positions) result
+    (let ((start (point))
+          (column-offset (current-column)))
+      (insert expansion)
+      (macrostep-slime--propertize-macros start positions)
+      (indent-rigidly start (point) column-offset))))
+
+(defun macrostep-slime--propertize-macros (start-offset positions)
+  "Put text properties on macro forms."
+  (dolist (position positions)
+    (cl-destructuring-bind (operator type start)
+        position
+      (let ((open-paren-position
+              (+ start-offset start)))
+        (put-text-property open-paren-position
+                           (1+ open-paren-position)
+                           'macrostep-macro-start
+                           t)
+        ;; this assumes that the operator starts right next to the
+        ;; opening parenthesis. We could probably be more robust.
+        (let ((op-start (1+ open-paren-position)))
+          (put-text-property op-start
+                             (+ op-start (length operator))
+                             'font-lock-face
+                             (if (eq type :macro)
+                                 'macrostep-macro-face
+                                 'macrostep-compiler-macro-face)))))))
+
+(defun macrostep-slime-macro-form-p (string context)
+  (slime-dcase
+      (slime-eval
+       `(swank-macrostep:macro-form-p
+         ,string ,macrostep-expand-compiler-macros ',context))
+    ((:error error-message)
+     (error "%s" error-message))
+    ((:ok result)
+     result)))
+
+
+
+(provide 'slime-macrostep)

--- a/contrib/swank-macrostep.lisp
+++ b/contrib/swank-macrostep.lisp
@@ -1,0 +1,227 @@
+;;; swank-macrostep.lisp -- fancy macro-expansion via macrostep.el
+;;
+;; Authors: Luís Oliveira <luismbo@gmail.com>
+;;          Jon Oddie <j.j.oddie@gmail.com>
+;;
+;; License: Public Domain
+
+(defpackage swank-macrostep
+  (:use cl swank)
+  (:import-from swank
+		#:*macroexpand-printer-bindings*
+                #:with-buffer-syntax
+		#:with-bindings
+                #:to-string
+                #:macroexpand-all
+                #:compiler-macroexpand-1
+                #:defslimefun
+                #:collect-macro-forms)
+  (:export #:macrostep-expand-1
+           #:macro-form-p))
+
+(in-package #:swank-macrostep)
+
+(defslimefun macrostep-expand-1 (string compiler-macros? context)
+  (with-buffer-syntax ()
+    (let ((form (read-from-string string)))
+      (multiple-value-bind (expansion error-message)
+	  (expand-form-once form compiler-macros? context)
+	(if error-message
+            `(:error ,error-message)
+	    (multiple-value-bind (macros compiler-macros)
+		(collect-macro-forms-in-context expansion context)
+	      (let* ((all-macros (append macros compiler-macros))
+		     (pretty-expansion (pprint-to-string expansion))
+		     (positions (collect-form-positions expansion
+							pretty-expansion
+							all-macros))
+                     (subform-info
+                      (loop
+                         for form in all-macros
+                         for (start end) in positions
+                         when (and start end)
+                         collect (let ((op-name (to-string (first form)))
+                                       (op-type
+                                        (if (member form macros)
+                                            :macro
+                                            :compiler-macro)))
+                                   (list op-name
+                                         op-type
+                                         start)))))
+		`(:ok ,pretty-expansion ,subform-info))))))))
+
+(defun expand-form-once (form compiler-macros? context)
+  (multiple-value-bind (expansion expanded?)
+      (macroexpand-1-in-context form context)
+    (if expanded?
+	(values expansion nil)
+	(if (not compiler-macros?)
+	    (values nil "Not a macro form")
+	    (multiple-value-bind (expansion expanded?)
+		(compiler-macroexpand-1 form)
+	      (if expanded?
+		  (values expansion nil)
+		  (values nil "Not a macro or compiler-macro form")))))))
+
+(defslimefun macro-form-p (string compiler-macros? context)
+  (with-buffer-syntax ()
+    (let ((form
+           (handler-case
+               (read-from-string string)
+             (error (condition)
+               (unless (debug-on-swank-error)
+                 (return-from macro-form-p
+                   `(:error ,(format nil "Read error: ~A" condition))))))))
+      `(:ok ,(macro-form-type form compiler-macros? context)))))
+
+(defun macro-form-type (form compiler-macros? context)
+  (cond
+    ((or (not (consp form))
+         (not (symbolp (car form))))
+     nil)
+    ((multiple-value-bind (expansion expanded?)
+         (macroexpand-1-in-context form context)
+       (declare (ignore expansion))
+       expanded?)
+     :macro)
+    ((and compiler-macros?
+          (multiple-value-bind (expansion expanded?)
+              (compiler-macroexpand-1 form)
+            (declare (ignore expansion))
+            expanded?))
+     :compiler-macro)
+    (t
+     nil)))
+
+
+;;;; Hacks to support macro-expansion within local context
+
+(defparameter *macrostep-tag* (gensym))
+
+(defparameter *macrostep-placeholder* '*macrostep-placeholder*)
+
+(define-condition expansion-in-context-failed (simple-error)
+  ())
+
+(defmacro throw-expansion (form &environment env)
+  (throw *macrostep-tag* (macroexpand-1 form env)))
+
+(defmacro throw-collected-macro-forms (form &environment env)
+  (throw *macrostep-tag* (collect-macro-forms form env)))
+
+(defun macroexpand-1-in-context (form context)
+  (handler-case
+      (macroexpand-and-catch
+       `(throw-expansion ,form) context)
+    (error ()
+      (macroexpand-1 form))))
+
+(defun collect-macro-forms-in-context (form context)
+  (handler-case
+      (macroexpand-and-catch
+       `(throw-collected-macro-forms ,form) context)
+    (error ()
+      (collect-macro-forms form))))
+
+(defun macroexpand-and-catch (form context)
+  (catch *macrostep-tag*
+    (macroexpand-all (enclose-form-in-context form context))
+    (error 'expansion-in-context-failed)))
+
+(defun enclose-form-in-context (form context)
+  (with-buffer-syntax ()
+    (destructuring-bind (prefix suffix) context
+      (let* ((placeholder-form
+              (read-from-string
+               (concatenate
+                'string
+                prefix (prin1-to-string *macrostep-placeholder*) suffix)))
+             (substituted-form (subst form *macrostep-placeholder*
+                                      placeholder-form)))
+        (if (not (equal placeholder-form substituted-form))
+            substituted-form
+            (error 'expansion-in-context-failed))))))
+
+
+;;;; Tracking Pretty Printer
+
+(defun marker-char-p (char)
+  (<= #xe000 (char-code char) #xe8ff))
+
+(defun make-marker-char (id)
+  ;; using the private-use characters U+E000..U+F8FF as markers, so
+  ;; that's our upper limit for how many we can use.
+  (assert (<= 0 id #x8ff))
+  (code-char (+ #xe000 id)))
+
+(defun marker-char-id (char)
+  (assert (marker-char-p char))
+  (- (char-code char) #xe000))
+
+(defparameter +whitespace+ (mapcar #'code-char '(9 13 10 32)))
+
+(defun whitespacep (char)
+  (member char +whitespace+))
+
+(defun pprint-to-string (object &optional pprint-dispatch)
+  (let ((*print-pprint-dispatch* (or pprint-dispatch *print-pprint-dispatch*)))
+    (with-bindings *macroexpand-printer-bindings*
+      (to-string object))))
+
+#-clisp
+(defun collect-form-positions (expansion printed-expansion forms)
+  (loop for (start end)
+     in (collect-marker-positions
+         (pprint-to-string expansion (make-tracking-pprint-dispatch forms))
+         (length forms))
+     collect (when (and start end)
+               (list (find-non-whitespace-position printed-expansion start)
+                     (find-non-whitespace-position printed-expansion end)))))
+
+;; The pprint-dispatch table constructed by
+;; MAKE-TRACKING-PPRINT-DISPATCH causes an infinite loop and stack
+;; overflow under CLISP version 2.49.  Make the COLLECT-FORM-POSITIONS
+;; entry point a no-op in thi case, so that basic macro-expansion will
+;; still work (without detection of inner macro forms)
+#+clisp
+(defun collect-form-positions (expansion printed-expansion forms)
+  nil)
+
+(defun make-tracking-pprint-dispatch (forms)
+  (let ((original-table *print-pprint-dispatch*)
+        (table (copy-pprint-dispatch)))
+    (flet ((maybe-write-marker (position stream)
+             (when position
+               (write-char (make-marker-char position) stream))))
+      (set-pprint-dispatch 'cons
+                           (lambda (stream cons)
+                             (let ((pos (position cons forms)))
+                               (maybe-write-marker pos stream)
+                               ;; delegate printing to the original table.
+                               (funcall (pprint-dispatch cons original-table)
+                                        stream
+                                        cons)
+                               (maybe-write-marker pos stream)))
+                           most-positive-fixnum
+                           table))
+    table))
+
+(defun collect-marker-positions (string position-count)
+  (let ((positions (make-array position-count :initial-element nil)))
+    (loop with p = 0
+          for char across string
+          unless (whitespacep char)
+            do (if (marker-char-p char)
+                   (push p (aref positions (marker-char-id char)))
+                   (incf p)))
+    (map 'list #'reverse positions)))
+
+(defun find-non-whitespace-position (string position)
+  (loop with non-whitespace-position = -1
+        for i from 0 and char across string
+        unless (whitespacep char)
+          do (incf non-whitespace-position)
+        until (eql non-whitespace-position position)
+        finally (return i)))
+
+(provide :swank-macrostep)

--- a/contrib/test/slime-macrostep-tests.el
+++ b/contrib/test/slime-macrostep-tests.el
@@ -1,0 +1,287 @@
+;; Tests for slime-macrostep.  The following are expected failures:
+
+;; - Under CLISP, highlighting of macro sub-forms fails because our
+;;   pretty-printer dispatch table hacking causes infinite recursion:
+;;   see comment in swank-macrostep.lisp
+
+;; - COLLECT-MACRO-FORMS does not catch compiler macros under CLISP
+;;   and ABCL
+
+;; - Under CCL and ECL, compiler macro calls returned by
+;;   COLLECT-MACRO-FORMS are not EQ to the original form, and so are
+;;   not detected by the tracking pretty-printer mechanism.  This
+;;   could be fixed by adding :TEST #'EQUAL to the POSITION call
+;;   within MAKE-TRACKING-PPRINT-DISPATCH, at the cost of introducing
+;;   false positives.
+
+;; ECL has two other issues:
+
+;;   - it currently lacks a working SLIME defimplementation for
+;;     MACROEXPAND-ALL (Github issue #157), without which none of the
+;;     expand-in-context stuff works.
+
+;;   - the environments consed up by its WALKER:MACROEXPAND-ALL
+;;     function are slightly broken, and do not work when passed to
+;;     MACROEXPAND-1 unless fixed up via
+
+;;         (subst 'si::macro 'walker::macro env)
+
+(require 'slime-macrostep)
+(require 'slime-tests)
+(require 'cl-lib)
+
+(defun slime-macrostep-eval-definitions (definitions)
+  (slime-check-top-level)
+  (slime-compile-string definitions 0)
+  (slime-sync-to-top-level 5))
+
+(defmacro slime-macrostep-with-text (buffer-text &rest body)
+  (declare (indent 1))
+  `(with-temp-buffer
+     (lisp-mode)
+     (save-excursion
+       (insert ,buffer-text))
+     ,@body))
+
+(defun slime-macrostep-search (form)
+  "Search forward for FORM, leaving point at its first character."
+  (let ((case-fold-search t)
+        (search-spaces-regexp "\\s-+"))
+    (re-search-forward (regexp-quote form)))
+  (goto-char (match-beginning 0)))
+
+
+
+(def-slime-test (slime-macrostep-expand-defmacro)
+    (definition buffer-text original expansion)
+  "Test that simple macrostep expansion works."
+  '(("(defmacro macrostep-dummy-macro (&rest args)
+        `(expansion of ,@args))"
+
+     "(progn
+        (first body form)
+        (second body form)
+        (macrostep-dummy-macro (first (argument)) second (third argument))
+        (remaining body forms))"
+
+     "(macrostep-dummy-macro (first (argument)) second (third argument))"
+
+     "(expansion of (first (argument)) second (third argument))"))
+  (slime-macrostep-eval-definitions definition)
+  (slime-macrostep-with-text buffer-text
+    (slime-macrostep-search original)
+    (macrostep-expand)
+    (slime-test-expect "Macroexpansion is correct"
+                       expansion
+                       (downcase (slime-sexp-at-point))
+                       #'slime-test-macroexpansion=)))
+
+(def-slime-test (slime-macrostep-fontify-macros
+                 (:fails-for "clisp" "ECL"))
+    (definition buffer-text original subform)
+  "Test that macro forms in expansions are font-locked"
+  '(("(defmacro macrostep-dummy-1 (&rest args)
+        `(expansion including (macrostep-dummy-2 ,@args)))
+      (defmacro macrostep-dummy-2 (&rest args)
+        `(final expansion of ,@args))"
+
+     "(progn
+        (first body form)
+        (second body form)
+        (macrostep-dummy-1 (first (argument)) second (third argument))
+        (remaining body forms))"
+
+     "(macrostep-dummy-1 (first (argument)) second (third argument))"
+
+     "(macrostep-dummy-2 (first (argument)) second (third argument))"))
+  (slime-macrostep-eval-definitions definition)
+  (slime-macrostep-with-text buffer-text
+    (slime-macrostep-search original)
+    (macrostep-expand)
+    (slime-macrostep-search subform)
+    (forward-char)                      ; move over open paren
+    (slime-check "Head of macro form in expansion is fontified correctly"
+        (eq (get-char-property (point) 'font-lock-face)
+         'macrostep-macro-face))))
+
+(def-slime-test (slime-macrostep-fontify-compiler-macros
+                 (:fails-for "armedbear" "clisp" "ccl" "ECL"))
+    (definition buffer-text original subform)
+  "Test that compiler-macro forms in expansions are font-locked"
+  '(("(defmacro macrostep-dummy-3 (&rest args)
+        `(expansion including (macrostep-dummy-4 ,@args)))
+      (defun macrostep-dummy-4 (&rest args)
+        args)
+      (define-compiler-macro macrostep-dummy-4 (&rest args)
+        `(compile-time expansion of ,@args))"
+
+     "(progn
+        (first body form)
+        (second body form)
+        (macrostep-dummy-3 first second third)
+        (remaining body forms))"
+
+     "(macrostep-dummy-3 first second third)"
+
+     "(macrostep-dummy-4 first second third)"))
+  (slime-macrostep-eval-definitions definition)
+  (slime-macrostep-with-text buffer-text
+    (slime-macrostep-search original)
+    (let ((macrostep-expand-compiler-macros t))
+      (macrostep-expand))
+    (slime-macrostep-search subform)
+    (forward-char)                      ; move over open paren
+    (slime-check "Head of compiler-macro in expansion is fontified correctly"
+        (eq (get-char-property (point) 'font-lock-face)
+         'macrostep-compiler-macro-face))))
+
+(def-slime-test (slime-macrostep-expand-macrolet
+                 (:fails-for "ECL"))
+    (definitions buffer-text expansions)
+    "Test that calls to macrolet-defined macros are expanded."
+    '((nil
+       "(macrolet
+            ((test (&rest args) `(expansion of ,@args)))
+          (first body form)
+          (second body form)
+          (test (strawberry pie) and (apple pie))
+          (final body form))"
+       (("(test (strawberry pie) and (apple pie))"
+         "(EXPANSION OF (STRAWBERRY PIE) AND (APPLE PIE))")))
+
+      ;; From swank.lisp:
+      (nil
+       "(macrolet ((define-xref-action (xref-type handler)
+                     `(defmethod xref-doit ((type (eql ,xref-type)) thing)
+                        (declare (ignorable type))
+                        (funcall ,handler thing))))
+          (define-xref-action :calls        #'who-calls)
+          (define-xref-action :calls-who    #'calls-who)
+          (define-xref-action :references   #'who-references)
+          (define-xref-action :binds        #'who-binds)
+          (define-xref-action :macroexpands #'who-macroexpands)
+          (define-xref-action :specializes  #'who-specializes)
+          (define-xref-action :callers      #'list-callers)
+          (define-xref-action :callees      #'list-callees))"
+       (("(define-xref-action :calls        #'who-calls)"
+         "(DEFMETHOD XREF-DOIT ((TYPE (EQL :CALLS)) THING)
+            (DECLARE (IGNORABLE TYPE))
+            (FUNCALL #'WHO-CALLS THING))")
+        ("(define-xref-action :macroexpands #'who-macroexpands)"
+         "(DEFMETHOD XREF-DOIT ((TYPE (EQL :MACROEXPANDS)) THING)
+            (DECLARE (IGNORABLE TYPE))
+            (FUNCALL #'WHO-MACROEXPANDS THING))")
+        ("(define-xref-action :callees      #'list-callees)"
+         "(DEFMETHOD XREF-DOIT ((TYPE (EQL :CALLEES)) THING)
+            (DECLARE (IGNORABLE TYPE))
+            (FUNCALL #'LIST-CALLEES THING))")))
+
+      ;; Test expansion of shadowed definitions
+      (nil
+       "(macrolet
+            ((test-macro (&rest forms) (cons 'outer-definition forms)))
+          (test-macro first (call))
+          (macrolet
+              ((test-macro (&rest forms) (cons 'inner-definition forms)))
+            (test-macro (second (call)))))"
+       (("(test-macro first (call))"
+         "(OUTER-DEFINITION FIRST (CALL))")
+        ("(test-macro (second (call)))"
+         "(INNER-DEFINITION (SECOND (CALL)))")))
+
+      ;; Expansion of macro-defined local macros
+      ("(defmacro with-local-dummy-macro (&rest body)
+          `(macrolet ((dummy (&rest args) `(expansion (of) ,@args)))
+             ,@body))"
+       "(with-local-dummy-macro
+           (dummy form (one))
+           (dummy (form two)))"
+       (("(dummy form (one))"
+         "(EXPANSION (OF) FORM (ONE))")
+        ("(dummy (form two))"
+         "(EXPANSION (OF) (FORM TWO))"))))
+
+  (when definitions
+    (slime-macrostep-eval-definitions definitions))
+  (slime-macrostep-with-text buffer-text
+    ;; slime-test-macroexpansion= does not expect tab characters,
+    ;; so make sure that Emacs does not insert them
+    (let ((indent-tabs-mode nil))
+      (cl-loop
+       for (original expansion) in expansions
+       do
+       (goto-char (point-min))
+       (slime-macrostep-search original)
+       (macrostep-expand)
+       (slime-test-expect "Macroexpansion is correct"
+                          expansion
+                          (slime-sexp-at-point)
+                          #'slime-test-macroexpansion=)))))
+
+(def-slime-test (slime-macrostep-fontify-local-macros
+                 (:fails-for "clisp" "ECL"))
+    ()
+    "Test that locally-bound macros are highlighted in expansions."
+    '(())
+    (slime-macrostep-with-text
+        "(macrolet ((frob (&rest args)
+                      (if (zerop (length args))
+                          nil
+                          `(cons ,(car args) (frob ,@(cdr args))))))
+           (frob 1 2 3 4 5))"
+      (let ((expansions
+             '(("(frob 1 2 3 4 5)"
+                "(CONS 1 (FROB 2 3 4 5))"
+                "(FROB 2 3 4 5)")
+               ("(FROB 2 3 4 5)"
+                "(CONS 2 (FROB 3 4 5))"
+                "(FROB 3 4 5)")
+               ("(FROB 3 4 5)"
+                "(CONS 3 (FROB 4 5))"
+                "(FROB 4 5)")
+               ("(FROB 4 5)"
+                "(CONS 4 (FROB 5))"
+                "(FROB 5)")
+               ("(FROB 5)"
+                "(CONS 5 (FROB))"
+                "(FROB)")
+               ;; ("(FROB)"
+               ;;  "NIL"
+               ;;  nil)
+               )))
+        (cl-loop for (original expansion subform) in expansions
+                 do
+                 (goto-char (point-min))
+                 (slime-macrostep-search original)
+                 (macrostep-expand)
+                 (slime-test-expect "Macroexpansion is correct"
+                                    expansion
+                                    (slime-sexp-at-point)
+                                    #'slime-test-macroexpansion=)
+                 (when subform
+                   (slime-macrostep-search subform)
+                   (forward-char)
+                   (slime-check "Head of macro form in expansion is fontified correctly"
+                       (eq (get-char-property (point) 'font-lock-face)
+                        'macrostep-macro-face)))))))
+
+(def-slime-test (slime-macrostep-handle-unreadable-objects)
+    (definitions buffer-text subform expansion)
+    "Check that macroexpansion succeeds in a context containing unreadable objects."
+    '(("(defmacro macrostep-dummy-5 (&rest args)
+          `(expansion of ,@args))"
+       "(progn
+          #<unreadable object>
+          (macrostep-dummy-5 quux frob))"
+       "(macrostep-dummy-5 quux frob)"
+       "(EXPANSION OF QUUX FROB)"))
+    (slime-macrostep-eval-definitions definitions)
+    (slime-macrostep-with-text buffer-text
+      (slime-macrostep-search subform)
+      (macrostep-expand)
+      (slime-test-expect "Macroexpansion is correct"
+                         expansion
+                         (slime-sexp-at-point)
+                         #'slime-test-macroexpansion=)))
+
+(provide 'slime-macrostep-tests)

--- a/lib/macrostep.el
+++ b/lib/macrostep.el
@@ -804,7 +804,8 @@ value of DEFINITION in the result will be nil."
           `(macro . ,local-definition)
         (let ((compiler-macro-definition
                (and macrostep-expand-compiler-macros
-                    (get head 'compiler-macro))))
+                    (or (get head 'compiler-macro)
+			(get head 'cl-compiler-macro)))))
           (if (and compiler-macro-definition
                    (not (eq form
                             (apply compiler-macro-definition form (cdr form)))))
@@ -835,12 +836,12 @@ expansion until a non-macro-call results."
        form)
       ((macro)
        (apply definition (cdr form)))
-      ((compiler-macro
-        (let ((expansion
-               (apply definition form (cdr form))))
-          (if (equal form expansion)
-              (error "Form left unchanged by compiler macro")
-            expansion)))))))
+      ((compiler-macro)
+       (let ((expansion
+	      (apply definition form (cdr form))))
+	 (if (equal form expansion)
+	     (error "Form left unchanged by compiler macro")
+	   expansion))))))
 
 (put 'macrostep-grab-environment-failed 'error-conditions
      '(macrostep-grab-environment-failed error))

--- a/lib/macrostep.el
+++ b/lib/macrostep.el
@@ -1,0 +1,1121 @@
+;;; macrostep.el --- interactive macro expander
+
+;; Copyright (C) 2012-2015 Jon Oddie <j.j.oddie@gmail.com>
+
+;; Author:     joddie <j.j.oddie@gmail.com>
+;; Maintainer: joddie <j.j.oddie@gmail.com>
+;; Created:    16 January 2012
+;; Updated:    07 December 2015
+;; Version:    0.9
+;; Keywords:   lisp, languages, macro, debugging
+;; Url:        https://github.com/joddie/macrostep
+;; Package-Requires: ((cl-lib "0.5"))
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; `macrostep' is an Emacs minor mode for interactively stepping through
+;; the expansion of macros in Emacs Lisp source code.  It lets you see
+;; exactly what happens at each step of the expansion process by
+;; pretty-printing the expanded forms inline in the source buffer, which is
+;; temporarily read-only while macro expansions are visible.  You can
+;; expand and collapse macro forms one step at a time, and evaluate or
+;; instrument the expansions for debugging with Edebug as normal (but see
+;; "Bugs and known limitations", below).  Single-stepping through the
+;; expansion is particularly useful for debugging macros that expand into
+;; another macro form.  These can be difficult to debug with Emacs'
+;; built-in `macroexpand', which continues expansion until the top-level
+;; form is no longer a macro call.
+
+;; Both globally-visible macros as defined by `defmacro' and local macros
+;; bound by `(cl-)macrolet' or another macro-defining form can be expanded.
+;; Within macro expansions, calls to macros and compiler macros are
+;; fontified specially: macro forms using `macrostep-macro-face', and
+;; functions with compiler macros using `macrostep-compiler-macro-face'.
+;; Uninterned symbols (gensyms) are fontified based on which step in the
+;; expansion created them, to distinguish them both from normal symbols and
+;; from other gensyms with the same print name.
+
+;; As of version 0.9, it is also possible to extend `macrostep' to work
+;; with other languages with macro systems in addition to Emacs Lisp.  An
+;; extension for Common Lisp (via SLIME) is in the works; contributions for
+;; other languages are welcome.  See "Extending macrostep" below for
+;; details.
+
+
+;; 1 Key-bindings and usage
+;; ========================
+
+;;   The standard keybindings in `macrostep-mode' are the following:
+
+;;   e, =, RET : expand the macro form following point one step
+;;   c, u, DEL : collapse the form following point
+;;   q, C-c C-c: collapse all expanded forms and exit macrostep-mode
+;;   n, TAB    : jump to the next macro form in the expansion
+;;   p, M-TAB  : jump to the previous macro form in the expansion
+
+;;   It's not very useful to enable and disable macrostep-mode directly.
+;;   Instead, bind `macrostep-expand' to a key in `emacs-lisp-mode-map',
+;;   for example C-c e:
+
+;;   ,----
+;;   | (define-key emacs-lisp-mode-map (kbd "C-c e") 'macrostep-expand)
+;;   `----
+
+;;   You can then enter macrostep-mode and expand a macro form completely
+;;   by typing `C-c e e e ...' as many times as necessary.
+
+;;   Exit macrostep-mode by typing `q' or `C-c C-c', or by successively
+;;   typing `c' to collapse all surrounding expansions.
+
+
+;; 2 Customization options
+;; =======================
+
+;;   Type `M-x customize-group RET macrostep RET' to customize options and
+;;   faces.
+
+;;   To display macro expansions in a separate window, instead of inline in
+;;   the source buffer, customize `macrostep-expand-in-separate-buffer' to
+;;   `t'.  The default is `nil'.  Whichever default behavior is selected,
+;;   the alternative behavior can be obtained temporarily by giving a
+;;   prefix argument to `macrostep-expand'.
+
+;;   To have `macrostep' ignore compiler macros, customize
+;;   `macrostep-expand-compiler-macros' to `nil'.  The default is `t'.
+
+;;   Customize the faces `macrostep-macro-face',
+;;   `macrostep-compiler-macro-face', and `macrostep-gensym-1' through
+;;   `macrostep-gensym-5' to alter the appearance of macro expansions.
+
+
+;; 3 Locally-bound macros
+;; ======================
+
+;;   As of version 0.9, `macrostep' can expand calls to a locally-bound
+;;   macro, whether defined by a surrounding `(cl-)macrolet' form, or by
+;;   another macro-defining macro.  In other words, it is possible to
+;;   expand the inner `local-macro' forms in both the following examples,
+;;   whether `local-macro' is defined by an enclosing `cl-macrolet' --
+
+;;   ,----
+;;   | (cl-macrolet ((local-macro (&rest args)
+;;   |                 `(expansion of ,args)))
+;;   |   (local-macro (do-something)))
+;;   `----
+
+;;   -- or by a macro which expands into `cl-macrolet', provided that its
+;;   definition of macro is evaluated prior to calling `macrostep-expand':
+
+;;   ,----
+;;   | (defmacro with-local-macro (&rest body)
+;;   |   `(cl-macrolet ((local-macro (&rest args)
+;;   |                    `(expansion of ,args)))
+;;   |      ,@body))
+;;   | 
+;;   | (with-local-macro
+;;   |     (local-macro (do something (else)))
+;;   `----
+
+;;   See the `with-js' macro in Emacs's `js.el' for a real example of the
+;;   latter kind of macro.
+
+;;   Expansion of locally-bound macros is implemented by instrumenting
+;;   Emacs Lisp's macro-expander to capture the environment at point.  A
+;;   similar trick is used to detect macro- and compiler-macro calls within
+;;   expanded text so that they can be fontified accurately.
+
+
+;; 4 Expanding sub-forms
+;; =====================
+
+;;   By moving point around in the macro expansion using
+;;   `macrostep-next-macro' and `macrostep-prev-macro' (bound to the `n'
+;;   and `p' keys), it is possible to expand other macro calls within the
+;;   expansion before expanding the outermost form.  This can sometimes be
+;;   useful, although it does not correspond to the real order of macro
+;;   expansion in Emacs Lisp, which proceeds by fully expanding the outer
+;;   form to a non-macro form before expanding sub-forms.
+
+;;   The main reason to expand sub-forms out of order is to help with
+;;   debugging macros which programmatically expand their arguments in
+;;   order to rewrite them.  Expanding the arguments of such a macro lets
+;;   you visualise what the macro definition would compute via
+;;   `macroexpand-all'.
+
+
+;; 5 Extending macrostep for other languages
+;; =========================================
+
+;;   Since version 0.9, it is possible to extend macrostep to work with
+;;   other languages besides Emacs Lisp.  In typical Emacs fashion, this is
+;;   implemented by setting buffer-local variables to different function
+;;   values.  Six buffer-local variables define the language-specific part
+;;   of the implementation:
+
+;;   - `macrostep-sexp-bounds-function'
+;;   - `macrostep-sexp-at-point-function'
+;;   - `macrostep-environment-at-point-function'
+;;   - `macrostep-expand-1-function'
+;;   - `macrostep-print-function'
+;;   - `macrostep-macro-form-p-function'
+
+;;   Typically, an implementation for another language would set these
+;;   variables in a major-mode hook.  See the docstrings of each variable
+;;   for details on how each one is called and what it should return.  At a
+;;   minimum, another language implementation needs to provide
+;;   `macrostep-sexp-at-point-function', `macrostep-expand-1-function', and
+;;   `macrostep-print-function'.  Lisp-like languages may be able to reuse
+;;   the default `macrostep-sexp-bounds-function' if they provide another
+;;   implementation of `macrostep-macro-form-p-function'.  Languages which
+;;   do not implement locally-defined macros can set
+;;   `macrostep-environment-at-point-function' to `ignore'.
+
+;;   Note that the core `macrostep' machinery only interprets the return
+;;   value of `macrostep-sexp-bounds-function', so implementations for
+;;   other languages can use any internal representations of code and
+;;   environments which is convenient.  Although the terminology is
+;;   Lisp-specific, there is no reason that implementations could not be
+;;   provided for non-Lisp languages with macro systems, provided there is
+;;   some way of identifying macro calls and calling the compiler /
+;;   preprocessor to obtain their expansions.
+
+
+;; 6 Bugs and known limitations
+;; ============================
+
+;;   You can evaluate and edebug macro-expanded forms and step through the
+;;   macro-expanded version, but the form that `eval-defun' and friends
+;;   read from the buffer won't have the uninterned symbols of the real
+;;   macro expansion.  This will probably work OK with CL-style gensyms,
+;;   but may cause problems with `make-symbol' symbols if they have the
+;;   same print name as another symbol in the expansion. It's possible that
+;;   using `print-circle' and `print-gensym' could get around this.
+
+;;   Please send other bug reports and feature requests to the author.
+
+
+;; 7 Acknowledgements
+;; ==================
+
+;;   Thanks to:
+;;   - John Wiegley for fixing a bug with the face definitions under Emacs
+;;     24 & for plugging macrostep in his [EmacsConf presentation]!
+;;   - George Kettleborough for bug reports, and patches to highlight the
+;;     expanded region and properly handle backquotes.
+;;   - Nic Ferrier for suggesting support for local definitions within
+;;     macrolet forms
+;;   - Luís Oliveira for suggesting and implementing SLIME support
+
+;;   `macrostep' was originally inspired by J. V. Toups's 'Deep Emacs Lisp'
+;;   articles ([part 1], [part 2], [screencast]).
+
+;;   [EmacsConf presentation] http://youtu.be/RvPFZL6NJNQ
+
+;;   [part 1]
+;;   http://dorophone.blogspot.co.uk/2011/04/deep-emacs-part-1.html
+
+;;   [part 2]
+;;   http://dorophone.blogspot.co.uk/2011/04/deep-emacs-lisp-part-2.html
+
+;;   [screencast]
+;;   http://dorophone.blogspot.co.uk/2011/05/monadic-parser-combinators-in-elisp.html
+
+
+;; 8 Changelog
+;; ===========
+
+;;   - v0.9, 2015-10-01:
+;;     - separate into Elisp-specific and generic components
+;;     - highlight and expand compiler macros
+;;     - improve local macro expansion and macro form identification by
+;;       instrumenting `macroexpand(-all)'
+;;   - v0.8, 2014-05-29: fix a bug with printing the first element of lists
+;;   - v0.7, 2014-05-11: expand locally-defined macros within
+;;     `(cl-)macrolet' forms
+;;   - v0.6, 2013-05-04: better handling of quote and backquote
+;;   - v0.5, 2013-04-16: highlight region, maintain cleaner buffer state
+;;   - v0.4, 2013-04-07: only enter macrostep-mode on successful
+;;     macro-expansion
+;;   - v0.3, 2012-10-30: print dotted lists correctly. autoload
+;;     definitions.
+
+;;; Code:
+
+(require 'pp)
+(require 'ring)
+(eval-and-compile
+  (require 'cl-lib nil t)
+  (require 'cl-lib "lib/cl-lib"))
+
+
+;;; Constants and dynamically bound variables
+(defvar macrostep-overlays nil
+  "List of all macro stepper overlays in the current buffer.")
+(make-variable-buffer-local 'macrostep-overlays)
+
+(defvar macrostep-gensym-depth nil
+  "Number of macro expansion levels that have introduced gensyms so far.")
+(make-variable-buffer-local 'macrostep-gensym-depth)
+
+(defvar macrostep-gensyms-this-level nil
+  "t if gensyms have been encountered during current level of macro expansion.")
+(make-variable-buffer-local 'macrostep-gensyms-this-level)
+
+(defvar macrostep-saved-undo-list nil
+  "Saved value of buffer-undo-list upon entering macrostep mode.")
+(make-variable-buffer-local 'macrostep-saved-undo-list)
+
+(defvar macrostep-saved-read-only nil
+  "Saved value of buffer-read-only upon entering macrostep mode.")
+(make-variable-buffer-local 'macrostep-saved-read-only)
+
+(defvar macrostep-expansion-buffer nil
+  "Non-nil if the current buffer is a macro-expansion buffer.")
+(make-variable-buffer-local 'macrostep-expansion-buffer)
+
+(defvar macrostep-outer-environment nil
+  "Outermost macro-expansion environment to use in a dedicated macro-expansion buffers.
+
+This variable is used to save information about any enclosing
+`cl-macrolet' context when a macro form is expanded in a separate
+buffer.")
+(make-variable-buffer-local 'macrostep-outer-environment)
+
+;;; Customization options and faces
+(defgroup macrostep nil
+  "Interactive macro stepper for Emacs Lisp."
+  :group 'lisp
+  :link '(emacs-commentary-link :tag "commentary" "macrostep.el")
+  :link '(emacs-library-link :tag "lisp file" "macrostep.el")
+  :link '(url-link :tag "web page" "https://github.com/joddie/macrostep"))
+
+(defface macrostep-gensym-1
+  '((((min-colors 16581375)) :foreground "#8080c0" :box t :bold t)
+    (((min-colors 8)) :background "cyan")
+    (t :inverse-video t))
+  "Face for gensyms created in the first level of macro expansion."
+  :group 'macrostep)
+
+(defface macrostep-gensym-2
+  '((((min-colors 16581375)) :foreground "#8fbc8f" :box t :bold t)
+    (((min-colors 8)) :background "#00cd00")
+    (t :inverse-video t))
+  "Face for gensyms created in the second level of macro expansion."
+  :group 'macrostep)
+
+(defface macrostep-gensym-3
+  '((((min-colors 16581375)) :foreground "#daa520" :box t :bold t)
+    (((min-colors 8)) :background "yellow")
+    (t :inverse-video t))
+  "Face for gensyms created in the third level of macro expansion."
+  :group 'macrostep)
+
+(defface macrostep-gensym-4
+  '((((min-colors 16581375)) :foreground "#cd5c5c" :box t :bold t)
+    (((min-colors 8)) :background "red")
+    (t :inverse-video t))
+  "Face for gensyms created in the fourth level of macro expansion."
+  :group 'macrostep)
+
+(defface macrostep-gensym-5
+  '((((min-colors 16581375)) :foreground "#da70d6" :box t :bold t)
+    (((min-colors 8)) :background "magenta")
+    (t :inverse-video t))
+  "Face for gensyms created in the fifth level of macro expansion."
+  :group 'macrostep)
+
+(defface macrostep-expansion-highlight-face
+  '((((min-colors 16581375) (background light)) :background "#eee8d5")
+    (((min-colors 16581375) (background dark)) :background "#222222"))
+  "Face for macro-expansion highlight."
+  :group 'macrostep)
+
+(defface macrostep-macro-face
+  '((t :underline t))
+  "Face for macros in macro-expanded code."
+  :group 'macrostep)
+
+(defface macrostep-compiler-macro-face
+  '((t :slant italic))
+  "Face for compiler macros in macro-expanded code."
+  :group 'macrostep)
+
+(defcustom macrostep-expand-in-separate-buffer nil
+  "When non-nil, show expansions in a separate buffer instead of inline."
+  :group 'macrostep
+  :type 'boolean)
+
+(defcustom macrostep-expand-compiler-macros t
+  "When non-nil, expand compiler macros as well as `defmacro' and `macrolet' macros."
+  :group 'macrostep
+  :type 'boolean)
+
+;; Need the following for making the ring of faces
+(defun macrostep-make-ring (&rest items)
+  "Make a ring containing all of ITEMS with no empty slots."
+  (let ((ring (make-ring (length items))))
+    (mapc (lambda (item) (ring-insert ring item)) (reverse items))
+    ring))
+
+(defvar macrostep-gensym-faces
+  (macrostep-make-ring
+   'macrostep-gensym-1 'macrostep-gensym-2 'macrostep-gensym-3
+   'macrostep-gensym-4 'macrostep-gensym-5)
+  "Ring of all macrostepper faces for fontifying gensyms.")
+
+;; Other modes can enable macrostep by redefining these functions to
+;; language-specific versions.
+(defvar macrostep-sexp-bounds-function
+  #'macrostep-sexp-bounds
+  "Function to return the bounds of the macro form nearest point.
+
+It will be called with no arguments and should return a cons of
+buffer positions, (START . END).  It should use `save-excursion'
+to avoid changing the position of point.
+
+The default value, `macrostep-sexp-bounds', implements this for
+Emacs Lisp, and may be suitable for other Lisp-like languages.")
+(make-variable-buffer-local 'macrostep-sexp-bounds-function)
+
+(defvar macrostep-sexp-at-point-function
+  #'macrostep-sexp-at-point
+  "Function to return the macro form at point for expansion.
+
+It will be called with two arguments, the values of START and END
+returned by `macrostep-sexp-bounds-function', and with point
+positioned at START.  It should return a value suitable for
+passing as the first argument to `macrostep-expand-1-function'.
+
+The default value, `macrostep-sexp-at-point', implements this for
+Emacs Lisp, and may be suitable for other Lisp-like languages.")
+(make-variable-buffer-local 'macrostep-sexp-at-point-function)
+
+(defvar macrostep-environment-at-point-function
+  #'macrostep-environment-at-point
+  "Function to return the local macro-expansion environment at point.
+
+It will be called with no arguments, and should return a value
+suitable for passing as the second argument to
+`macrostep-expand-1-function'.
+
+The default value, `macrostep-environment-at-point', is specific
+to Emacs Lisp.  For languages which do not implement local
+macro-expansion environments, this should be set to `ignore'
+or `(lambda () nil)'.")
+(make-variable-buffer-local 'macrostep-environment-at-point-function)
+
+(defvar macrostep-expand-1-function
+  #'macrostep-expand-1
+  "Function to perform one step of macro-expansion.
+
+It will be called with two arguments, FORM and ENVIRONMENT, the
+return values of `macrostep-sexp-at-point-function' and
+`macrostep-environment-at-point-function' respectively.  It
+should return the result of expanding FORM by one step as a value
+which is suitable for passing as the argument to
+`macrostep-print-function'.
+
+The default value, `macrostep-expand-1', is specific to Emacs Lisp.")
+(make-variable-buffer-local 'macrostep-expand-1-function)
+
+(defvar macrostep-print-function
+  #'macrostep-pp
+  "Function to pretty-print macro expansions.
+
+It will be called with two arguments, FORM and ENVIRONMENT, the
+return values of `macrostep-sexp-at-point-function' and
+`macrostep-environment-at-point-function' respectively.  It
+should insert a pretty-printed representation at point in the
+current buffer, leaving point just after the inserted
+representation, without altering any other text in the current
+buffer.
+
+The default value, `macrostep-pp', is specific to Emacs Lisp.")
+(make-variable-buffer-local 'macrostep-print-function)
+
+(defvar macrostep-macro-form-p-function
+  #'macrostep-macro-form-p
+  "Function to check whether a form is a macro call.
+
+It will be called with two arguments, FORM and ENVIRONMENT -- the
+return values of `macrostep-sexp-at-point-function' and
+`macrostep-environment-at-point-function' respectively -- and
+should return non-nil if FORM would undergo macro-expansion in
+ENVIRONMENT.
+
+This is called only from `macrostep-sexp-bounds', so it need not
+be provided if a different value is used for
+`macrostep-sexp-bounds-function'.
+
+The default value, `macrostep-macro-form-p', is specific to Emacs Lisp.")
+(make-variable-buffer-local 'macrostep-macro-form-p-function)
+
+
+;;; Define keymap and minor mode
+(defvar macrostep-keymap
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "RET") 'macrostep-expand)
+    (define-key map "=" 'macrostep-expand)
+    (define-key map "e" 'macrostep-expand)
+
+    (define-key map (kbd "DEL") 'macrostep-collapse)
+    (define-key map "u" 'macrostep-collapse)
+    (define-key map "c" 'macrostep-collapse)
+
+    (define-key map (kbd "TAB") 'macrostep-next-macro)
+    (define-key map "n" 'macrostep-next-macro)
+    (define-key map (kbd "M-TAB") 'macrostep-prev-macro)
+    (define-key map "p" 'macrostep-prev-macro)
+
+    (define-key map "q" 'macrostep-collapse-all)
+    (define-key map (kbd "C-c C-c") 'macrostep-collapse-all)
+    map)
+  "Keymap for `macrostep-mode'.")
+
+;;;###autoload
+(define-minor-mode macrostep-mode
+  "Minor mode for inline expansion of macros in Emacs Lisp source buffers.
+
+\\<macrostep-keymap>Progressively expand macro forms with \\[macrostep-expand], collapse them with \\[macrostep-collapse],
+and move back and forth with \\[macrostep-next-macro] and \\[macrostep-prev-macro].
+Use \\[macrostep-collapse-all] or collapse all visible expansions to
+quit and return to normal editing.
+
+\\{macrostep-keymap}"
+  nil " Macro-Stepper"
+  :keymap macrostep-keymap
+  :group macrostep
+  (if macrostep-mode
+      (progn
+        ;; Disable recording of undo information
+        (setq macrostep-saved-undo-list buffer-undo-list
+              buffer-undo-list t)
+        ;; Remember whether buffer was read-only
+        (setq macrostep-saved-read-only buffer-read-only
+              buffer-read-only t)
+        ;; Set up post-command hook to bail out on leaving read-only
+        (add-hook 'post-command-hook 'macrostep-command-hook nil t)
+        (message
+         (substitute-command-keys
+          "\\<macrostep-keymap>Entering macro stepper mode. Use \\[macrostep-expand] to expand, \\[macrostep-collapse] to collapse, \\[macrostep-collapse-all] to exit.")))
+
+    ;; Exiting mode
+    (if macrostep-expansion-buffer
+        ;; Kill dedicated expansion buffers
+        (quit-window t)
+      ;; Collapse any remaining overlays
+      (when macrostep-overlays (macrostep-collapse-all))
+      ;; Restore undo info & read-only state
+      (setq buffer-undo-list macrostep-saved-undo-list
+            buffer-read-only macrostep-saved-read-only
+            macrostep-saved-undo-list nil)
+      ;; Remove our post-command hook
+      (remove-hook 'post-command-hook 'macrostep-command-hook t))))
+
+;; Post-command hook: bail out of macrostep-mode if the user types C-x
+;; C-q to make the buffer writable again.
+(defun macrostep-command-hook ()
+  (if (not buffer-read-only)
+      (macrostep-mode 0)))
+
+
+;;; Interactive functions
+;;;###autoload
+(defun macrostep-expand (&optional toggle-separate-buffer)
+  "Expand the macro form following point by one step.
+
+Enters `macrostep-mode' if it is not already active, making the
+buffer temporarily read-only. If macrostep-mode is active and the
+form following point is not a macro form, search forward in the
+buffer and expand the next macro form found, if any.
+
+With a prefix argument, the expansion is displayed in a separate
+buffer instead of inline in the current buffer.  Setting
+`macrostep-expand-in-separate-buffer' to non-nil swaps these two
+behaviors."
+  (interactive "P")
+  (cl-destructuring-bind (start . end)
+      (funcall macrostep-sexp-bounds-function)
+    (goto-char start)
+    (let* ((sexp (funcall macrostep-sexp-at-point-function start end))
+           (end (copy-marker end))
+           (text (buffer-substring start end))
+           (env (funcall macrostep-environment-at-point-function))
+           (expansion (funcall macrostep-expand-1-function sexp env)))
+
+      ;; Create a dedicated macro-expansion buffer and copy the text to
+      ;; be expanded into it, if required
+      (let ((separate-buffer-p
+             (if toggle-separate-buffer
+                 (not macrostep-expand-in-separate-buffer)
+               macrostep-expand-in-separate-buffer)))
+        (when (and separate-buffer-p (not macrostep-expansion-buffer))
+          (let ((mode major-mode)
+                (buffer
+                 (get-buffer-create (generate-new-buffer-name "*macro expansion*"))))
+            (set-buffer buffer)
+            (funcall mode)
+            (setq macrostep-expansion-buffer t)
+            (setq macrostep-outer-environment env)
+            (save-excursion
+              (setq start (point))
+              (insert text)
+              (setq end (point-marker)))
+            (pop-to-buffer buffer))))
+
+      (unless macrostep-mode (macrostep-mode t))
+      (let ((existing-overlay (macrostep-overlay-at-point))
+            (macrostep-gensym-depth macrostep-gensym-depth)
+            (macrostep-gensyms-this-level nil)
+            priority)
+        (if existing-overlay
+            (progn        ; Expanding part of a previous macro-expansion
+              (setq priority (1+ (overlay-get existing-overlay 'priority)))
+              (setq macrostep-gensym-depth
+                    (overlay-get existing-overlay 'macrostep-gensym-depth)))
+          ;; Expanding source buffer text
+          (setq priority 1)
+          (setq macrostep-gensym-depth -1))
+
+        (with-silent-modifications
+          (atomic-change-group
+            (let ((inhibit-read-only t))
+              (save-excursion
+                ;; Insert expansion
+                (funcall macrostep-print-function expansion env)
+                ;; Delete the original form
+                (macrostep-collapse-overlays-in (point) end)
+                (delete-region (point) end)
+                ;; Create a new overlay
+                (let ((overlay
+                       (make-overlay start
+                                     (if (looking-at "\n")
+                                         (1+ (point))
+                                       (point)))))
+                  (unless macrostep-expansion-buffer
+                    ;; Highlight the overlay in original source buffers only
+                    (overlay-put overlay 'face 'macrostep-expansion-highlight-face))
+                  (overlay-put overlay 'priority priority)
+                  (overlay-put overlay 'macrostep-original-text text)
+                  (overlay-put overlay 'macrostep-gensym-depth macrostep-gensym-depth)
+                  (push overlay macrostep-overlays))))))))))
+
+(defun macrostep-collapse ()
+  "Collapse the innermost macro expansion near point to its source text.
+
+If no more macro expansions are visible after this, exit
+`macrostep-mode'."
+  (interactive)
+  (let ((overlay (macrostep-overlay-at-point)))
+    (when (not overlay) (error "No macro expansion at point"))
+    (let ((inhibit-read-only t))
+      (with-silent-modifications
+        (atomic-change-group
+          (macrostep-collapse-overlay overlay)))))
+  (if (not macrostep-overlays)
+      (macrostep-mode 0)))
+
+(defun macrostep-collapse-all ()
+  "Collapse all visible macro expansions and exit `macrostep-mode'."
+  (interactive)
+  (let ((inhibit-read-only t))
+    (with-silent-modifications
+      (dolist (overlay macrostep-overlays)
+        (let ((outermost (= (overlay-get overlay 'priority) 1)))
+          ;; We only need restore the original text for the outermost
+          ;; overlays
+          (macrostep-collapse-overlay overlay (not outermost))))))
+  (setq macrostep-overlays nil)
+  (macrostep-mode 0))
+
+(defun macrostep-next-macro ()
+  "Move point forward to the next macro form in macro-expanded text."
+  (interactive)
+  (let* ((start 
+	 (if (get-text-property (point) 'macrostep-macro-start)
+	     (1+ (point))
+	   (point)))
+	 (next (next-single-property-change start 'macrostep-macro-start)))
+    (if next
+	(goto-char next)
+      (error "No more macro forms found"))))
+
+(defun macrostep-prev-macro ()
+  "Move point back to the previous macro form in macro-expanded text."
+  (interactive)
+  (let (prev)
+    (save-excursion
+      (while
+	  (progn
+	    (setq prev
+		  (previous-single-property-change (point) 'macrostep-macro-start))
+	    (if (or (not prev)
+		    (get-text-property (1- prev) 'macrostep-macro-start))
+		nil
+	      (prog1 t (goto-char prev))))))
+    (if prev
+	(goto-char (1- prev))
+      (error "No previous macro form found"))))
+
+
+;;; Utility functions (not language-specific)
+
+(defun macrostep-overlay-at-point ()
+  "Return the innermost macro stepper overlay at point."
+  (let ((result
+	 (get-char-property-and-overlay (point) 'macrostep-original-text)))
+    (cdr result)))
+
+(defun macrostep-collapse-overlay (overlay &optional no-restore-p)
+  "Collapse a macro-expansion overlay and restore the unexpanded source text.
+
+As a minor optimization, does not restore the original source
+text if NO-RESTORE-P is non-nil. This is safe to do when
+collapsing all the sub-expansions of an outer overlay, since the
+outer overlay will restore the original source itself.
+
+Also removes the overlay from `macrostep-overlays'."
+  (with-current-buffer (overlay-buffer overlay)
+    ;; If we're cleaning up we don't need to bother restoring text
+    ;; or checking for inner overlays to delete
+    (unless no-restore-p
+      (let* ((start (overlay-start overlay))
+             (end (overlay-end overlay))
+             (text (overlay-get overlay 'macrostep-original-text))
+             (sexp-end
+              (copy-marker
+               (if (equal (char-before end) ?\n) (1- end) end))))
+        (macrostep-collapse-overlays-in start end)
+        (goto-char (overlay-start overlay))
+        (save-excursion
+          (insert text)
+          (delete-region (point) sexp-end))))
+    ;; Remove overlay from the list and delete it
+    (setq macrostep-overlays
+          (delq overlay macrostep-overlays))
+    (delete-overlay overlay)))
+
+(defun macrostep-collapse-overlays-in (start end)
+  "Collapse all macrostepper overlays that are strictly between START and END.
+
+Will not collapse overlays that begin at START and end at END."
+  (dolist (ol (overlays-in start end))
+    (if (and (> (overlay-start ol) start)
+	     (< (overlay-end ol) end)
+	     (overlay-get ol 'macrostep-original-text))
+	(macrostep-collapse-overlay ol t))))
+
+
+;;; Emacs Lisp implementation
+
+(defun macrostep-sexp-bounds ()
+  "Find the bounds of the macro form nearest point.
+
+If point is not before an open-paren, moves up to the nearest
+enclosing list.  If the form at point is not a macro call,
+attempts to move forward to the next macro form as determined by
+`macrostep-macro-form-p-function'.
+
+Returns a cons of buffer positions, (START . END)."
+  (save-excursion
+    (if (not (looking-at "[(`]"))
+        (backward-up-list 1))
+    (if (equal (char-before) ?`)
+        (backward-char))
+    (let ((sexp (funcall macrostep-sexp-at-point-function))
+          (env (funcall macrostep-environment-at-point-function)))
+      ;; If this isn't a macro form, try to find the next one in the buffer
+      (unless (funcall macrostep-macro-form-p-function sexp env)
+        (condition-case nil
+            (macrostep-next-macro)
+          (error
+           (if (consp sexp)
+               (error "(%s ...) is not a macro form" (car sexp))
+             (error "Text at point is not a macro form."))))))
+    (cons (point) (scan-sexps (point) 1))))
+
+(defun macrostep-sexp-at-point (&rest ignore)
+  "Return the sexp near point for purposes of macro-stepper expansion.
+
+If the sexp near point is part of a macro expansion, returns the
+saved text of the macro expansion, and does not read from the
+buffer.  This preserves uninterned symbols in the macro
+expansion, so that they can be fontified consistently.  (See
+`macrostep-print-sexp'.)"
+  (or (get-text-property (point) 'macrostep-expanded-text)
+      (sexp-at-point)))
+
+(defun macrostep-macro-form-p (form environment)
+  "Return non-nil if FORM would be evaluated via macro expansion.
+
+If FORM is an invocation of a macro defined by `defmacro' or an
+enclosing `cl-macrolet' form, return the symbol `macro'.
+
+If `macrostep-expand-compiler-macros' is non-nil and FORM is a
+call to a function with a compiler macro, return the symbol
+`compiler-macro'.
+
+Otherwise, return nil."
+  (car (macrostep--macro-form-info form environment t)))
+
+(defun macrostep--macro-form-info (form environment &optional inhibit-autoload)
+  "Return information about macro definitions that apply to FORM.
+
+If no macros are involved in the evaluation of FORM within
+ENVIRONMENT, returns nil.  Otherwise, returns a cons (TYPE
+. DEFINITION).
+
+If FORM would be evaluated by a macro defined by `defmacro',
+`cl-macrolet', etc., TYPE is the symbol `macro' and DEFINITION is
+the macro definition, as a function.
+
+If `macrostep-expand-compiler-macros' is non-nil and FORM would
+be compiled using a compiler macro, TYPE is the symbol
+`compmiler-macro' and DEFINITION is the function that implements
+the compiler macro.
+
+If FORM is an invocation of an autoloaded macro, the behavior
+depends on the value of INHIBIT-AUTOLOAD.  If INHIBIT-AUTOLOAD is
+nil, the file containing the macro definition will be loaded
+using `load-library' and the macro definition returned as normal.
+If INHIBIT-AUTOLOAD is non-nil, no files will be loaded, and the
+value of DEFINITION in the result will be nil."
+  (if (not (and (consp form)
+                (symbolp (car form))))
+      `(nil . nil)
+    (let* ((head (car form))
+           (local-definition (assoc-default head environment #'eq)))
+      (if local-definition
+          `(macro . ,local-definition)
+        (let ((compiler-macro-definition
+               (and macrostep-expand-compiler-macros
+                    (get head 'compiler-macro))))
+          (if (and compiler-macro-definition
+                   (not (eq form
+                            (apply compiler-macro-definition form (cdr form)))))
+              `(compiler-macro . ,compiler-macro-definition)
+            (condition-case nil
+                (let ((fun (indirect-function head)))
+                  (cl-case (car-safe fun)
+                    ((macro)
+                     `(macro . ,(cdr fun)))
+                    ((autoload)
+                     (when (eq (nth 4 fun) 'macro)
+                       (if inhibit-autoload
+                           `(macro . nil)
+                         (load-library (nth 1 fun))
+                         (macrostep--macro-form-info form nil))))
+                    (t
+                     `(nil . nil))))
+              (void-function nil))))))))
+
+(defun macrostep-expand-1 (form environment)
+  "Return result of macro-expanding the top level of FORM by exactly one step.
+Unlike `macroexpand', this function does not continue macro
+expansion until a non-macro-call results."
+  (cl-destructuring-bind (type . definition)
+      (macrostep--macro-form-info form environment)
+    (cl-ecase type
+      ((nil)
+       form)
+      ((macro)
+       (apply definition (cdr form)))
+      ((compiler-macro
+        (let ((expansion
+               (apply definition form (cdr form))))
+          (if (equal form expansion)
+              (error "Form left unchanged by compiler macro")
+            expansion)))))))
+
+(put 'macrostep-grab-environment-failed 'error-conditions
+     '(macrostep-grab-environment-failed error))
+
+(defun macrostep-environment-at-point ()
+  "Return the local macro-expansion environment at point, if any.
+
+The local environment includes macros declared by any `macrolet'
+or `cl-macrolet' forms surrounding point, as well as by any macro
+forms which expand into a `macrolet'.
+
+The return value is an alist of elements (NAME . FUNCTION), where
+NAME is the symbol locally bound to the macro and FUNCTION is the
+lambda expression that returns its expansion."
+  ;; If point is on a macro form within an expansion inserted by
+  ;; `macrostep-print-sexp', a local environment may have been
+  ;; previously saved as a text property.
+  (let ((saved-environment
+         (get-text-property (point) 'macrostep-environment)))
+    (if saved-environment
+        saved-environment
+      ;; Otherwise, we (ab)use the macro-expander to return the
+      ;; environment at point.  If point is not at an evaluated
+      ;; position in the containing form,
+      ;; `macrostep-environment-at-point-1' will raise an error, and
+      ;; we back up progressively through the containing forms until
+      ;; it succeeds.
+      (save-excursion
+	(catch 'done
+	  (while t
+	    (condition-case nil
+		(throw 'done (macrostep-environment-at-point-1))
+	      (macrostep-grab-environment-failed
+	       (condition-case nil
+		   (backward-sexp)
+		 (scan-error (backward-up-list)))))))))))
+
+(defun macrostep-environment-at-point-1 ()
+  "Attempt to extract the macro environment that would be active at point.
+
+If point is not at an evaluated position within the containing
+form, raise an error."
+  ;; Macro environments are extracted using Emacs Lisp's builtin
+  ;; macro-expansion machinery.  The form containing point is copied
+  ;; to a temporary buffer, and a call to
+  ;; `--macrostep-grab-environment--' is inserted at point.  This
+  ;; altered form is then fully macro-expanded, in an environment
+  ;; where `--macrostep-grab-environment--' is defined as a macro
+  ;; which throws the environment to a uniquely-generated tag.
+  (let* ((point-at-top-level
+          (save-excursion
+            (while (ignore-errors (backward-up-list) t))
+            (point)))
+         (enclosing-form
+          (buffer-substring point-at-top-level
+                            (scan-sexps point-at-top-level 1)))
+         (position (- (point) point-at-top-level))
+         (tag (make-symbol "macrostep-grab-environment-tag"))
+         (grab-environment '--macrostep-grab-environment--))
+    (if (= position 0)
+        nil
+      (with-temp-buffer
+        (emacs-lisp-mode)
+        (insert enclosing-form)
+        (goto-char (+ (point-min) position))
+        (prin1 `(,grab-environment) (current-buffer))
+        (let ((form (read (copy-marker (point-min)))))
+          (catch tag
+            (cl-letf (((symbol-function #'message) (symbol-function #'format)))
+              (with-no-warnings
+                (ignore-errors
+                  (macroexpand-all
+                   `(cl-macrolet ((,grab-environment (&environment env)
+                                    (throw ',tag env)))
+                      ,form)))))
+            (signal 'macrostep-grab-environment-failed nil)))))))
+
+(defun macrostep-collect-macro-forms (form &optional environment)
+  "Identify sub-forms of FORM which undergo macro-expansion.
+
+FORM is an Emacs Lisp form. ENVIRONMENT is a local environment of
+macro definitions.
+
+The return value is a list of two elements, (MACRO-FORM-ALIST
+COMPILER-MACRO-FORMS).
+
+MACRO-FORM-ALIST is an alist of elements of the form (SUBFORM
+. ENVIRONMENT), where SUBFORM is a form which undergoes
+macro-expansion in the course of expanding FORM, and ENVIRONMENT
+is the local macro environment in force when it is expanded.
+
+COMPILER-MACRO-FORMS is a list of subforms which would be
+compiled using a compiler macro.  Since there is no standard way
+to provide a local compiler-macro definition in Emacs Lisp, no
+corresponding local environments are collected for these.
+
+Forms and environments are extracted from FORM by instrumenting
+Emacs's builtin `macroexpand' function and calling
+`macroexpand-all'."
+  (let ((real-macroexpand (indirect-function #'macroexpand))
+        (macro-form-alist '())
+        (compiler-macro-forms '()))
+    (cl-letf
+        (((symbol-function #'macroexpand)
+          (lambda (form environment &rest args)
+            (let ((expansion
+                   (apply real-macroexpand form environment args)))
+              (cond ((not (eq expansion form))
+                     (setq macro-form-alist
+                           (cons (cons form environment)
+                                 macro-form-alist)))
+                    ((and (consp form)
+                          (symbolp (car form))
+                          macrostep-expand-compiler-macros
+                          (not (eq form
+                                   (cl-compiler-macroexpand form))))
+                     (setq compiler-macro-forms
+                           (cons form compiler-macro-forms))))
+              expansion))))
+      (ignore-errors
+        (macroexpand-all form environment)))
+    (list macro-form-alist compiler-macro-forms)))
+
+(defvar macrostep-collected-macro-form-alist nil
+  "An alist of macro forms and environments.
+Controls the printing of sub-forms in `macrostep-print-sexp'.")
+
+(defvar macrostep-collected-compiler-macro-forms nil
+  "A list of compiler-macro forms to be highlighted in `macrostep-print-sexp'.")
+
+(defun macrostep-pp (sexp environment)
+  "Pretty-print SEXP, fontifying macro forms and uninterned symbols."
+  (cl-destructuring-bind
+        (macrostep-collected-macro-form-alist
+         macrostep-collected-compiler-macro-forms)
+      (macrostep-collect-macro-forms sexp environment)
+    (let ((print-quoted t))
+      (macrostep-print-sexp sexp)
+      ;; Point is now after the expanded form; pretty-print it
+      (save-restriction
+        (narrow-to-region (scan-sexps (point) -1) (point))
+        (save-excursion
+          (pp-buffer)
+          ;; Remove the extra newline inserted by pp-buffer
+          (goto-char (point-max))
+          (delete-region
+           (point)
+           (save-excursion (skip-chars-backward " \t\n") (point))))
+        ;; Indent the newly-inserted form in context
+        (widen)
+        (save-excursion
+          (backward-sexp)
+          (indent-sexp))))))
+
+;; This must be defined before `macrostep-print-sexp':
+(defmacro macrostep-propertize (form &rest plist)
+  "Evaluate FORM, applying syntax properties in PLIST to any inserted text."
+  (declare (indent 1)
+           (debug (&rest form)))
+  (let ((start (make-symbol "start")))
+    `(let ((,start (point)))
+       (prog1
+           ,form
+         ,@(cl-loop for (key value) on plist by #'cddr
+                    collect `(put-text-property ,start (point)
+                                                ,key ,value))))))
+
+(defun macrostep-print-sexp (sexp)
+  "Insert SEXP like `print', fontifying macro forms and uninterned symbols.
+
+Fontifies uninterned symbols and macro forms using
+`font-lock-face' property, and saves the actual text of SEXP's
+sub-forms as the `macrostep-expanded-text' text property so that
+any uninterned symbols can be reused in macro expansions of the
+sub-forms.  See also `macrostep-sexp-at-point'.
+
+Macro and compiler-macro forms within SEXP are identified by
+comparison with the `macrostep-collected-macro-form-alist' and
+`macrostep-collected-compiler-macro-forms' variables, which
+should be dynamically let-bound around calls to this function."
+  (cond
+   ((symbolp sexp)
+    ;; Fontify gensyms
+    (if (not (eq sexp (intern-soft (symbol-name sexp))))
+        (macrostep-propertize
+            (prin1 sexp (current-buffer))
+          'font-lock-face (macrostep-get-gensym-face sexp))
+      ;; Print other symbols as normal
+      (prin1 sexp (current-buffer))))
+
+   ((listp sexp)
+    ;; Print quoted and quasiquoted forms nicely.
+    (let ((head (car sexp)))
+      (cond ((and (eq head 'quote)	; quote
+		  (= (length sexp) 2))
+	     (insert "'")
+	     (macrostep-print-sexp (cadr sexp)))
+
+            ((and (eq head '\`)         ; backquote
+                  (= (length sexp) 2))
+             (if (assq sexp macrostep-collected-macro-form-alist)
+                 (macrostep-propertize
+                     (insert "`")
+                   'macrostep-expanded-text sexp
+                   'macrostep-macro-start t
+                   'font-lock-face 'macrostep-macro-face)
+               (insert "`"))
+             (macrostep-print-sexp (cadr sexp)))
+
+	    ((and (memq head '(\, \,@)) ; unquote
+		  (= (length sexp) 2))
+	     (princ head (current-buffer))
+	     (macrostep-print-sexp (cadr sexp)))
+
+	    (t				; other list form
+             (cl-destructuring-bind (macro? . environment)
+                 (or (assq sexp macrostep-collected-macro-form-alist)
+                     '(nil . nil))
+               (let
+                   ((compiler-macro?
+                     (memq sexp macrostep-collected-compiler-macro-forms)))
+                 (if (or macro? compiler-macro?)
+                     (progn
+                       ;; Save the real expansion as a text property on the
+                       ;; opening paren
+                       (macrostep-propertize
+                        (insert "(")
+                        'macrostep-macro-start t
+                        'macrostep-expanded-text sexp
+                        'macrostep-environment environment)
+                       ;; Fontify the head of the macro
+                       (macrostep-propertize
+                        (macrostep-print-sexp head)
+                        'font-lock-face
+                        (if macro?
+                            'macrostep-macro-face
+                          'macrostep-compiler-macro-face)))
+                   ;; Not a macro form
+                   (insert "(")
+                   (macrostep-print-sexp head))))
+
+             ;; Print remaining list elements
+             (setq sexp (cdr sexp))
+             (when sexp (insert " "))
+             (while sexp
+               (if (listp sexp)
+                   (progn
+                     (macrostep-print-sexp (car sexp))
+                     (when (cdr sexp) (insert " "))
+                     (setq sexp (cdr sexp)))
+                 ;; Print tail of dotted list
+                 (insert ". ")
+                 (macrostep-print-sexp sexp)
+                 (setq sexp nil)))
+             (insert ")")))))
+
+   ;; Print everything except symbols and lists as normal
+   (t (prin1 sexp (current-buffer)))))
+
+(defun macrostep-get-gensym-face (symbol)
+  "Return the face to use in fontifying SYMBOL in printed macro expansions.
+
+All symbols introduced in the same level of macro expansion are
+fontified using the same face (modulo the number of faces; see
+`macrostep-gensym-faces')."
+  (or (get symbol 'macrostep-gensym-face)
+      (progn
+	(if (not macrostep-gensyms-this-level)
+	    (setq macrostep-gensym-depth (1+ macrostep-gensym-depth)
+		  macrostep-gensyms-this-level t))
+	(let ((face (ring-ref macrostep-gensym-faces macrostep-gensym-depth)))
+	  (put symbol 'macrostep-gensym-face face)
+	  face))))
+
+
+(provide 'macrostep)
+
+;;; macrostep.el ends here

--- a/packages.lisp
+++ b/packages.lisp
@@ -55,7 +55,9 @@
            unprofile-all
            profile-report
            profile-reset
-           profile-package))
+           profile-package
+
+           with-collected-macro-forms))
 
 (defpackage swank/rpc
   (:use :cl)

--- a/slime.el
+++ b/slime.el
@@ -1,7 +1,7 @@
 ;;; slime.el --- Superior Lisp Interaction Mode for Emacs -*-lexical-binding:t-*-
 
 ;; URL: https://github.com/slime/slime
-;; Package-Requires: ((cl-lib "0.5"))
+;; Package-Requires: ((cl-lib "0.5") (macrostep "0.9"))
 ;; Keywords: languages, lisp, slime
 ;; Version: 2.15
 

--- a/swank-loader.lisp
+++ b/swank-loader.lisp
@@ -246,7 +246,8 @@ If LOAD is true, load the fasl file."
     swank-hyperdoc
     #+sbcl swank-sbcl-exts
     swank-mrepl
-    swank-trace-dialog)
+    swank-trace-dialog
+    swank-macrostep)
   "List of names for contrib modules.")
 
 (defun append-dir (absolute name)

--- a/swank/abcl.lisp
+++ b/swank/abcl.lisp
@@ -281,8 +281,8 @@
 (defimplementation function-name (function)
   (nth-value 2 (function-lambda-expression function)))
 
-(defimplementation macroexpand-all (form)
-  (ext:macroexpand-all form))
+(defimplementation macroexpand-all (form &optional env)
+  (ext:macroexpand-all form env))
 
 (defimplementation describe-symbol-for-emacs (symbol)
   (let ((result '()))

--- a/swank/abcl.lisp
+++ b/swank/abcl.lisp
@@ -284,6 +284,15 @@
 (defimplementation macroexpand-all (form &optional env)
   (ext:macroexpand-all form env))
 
+(defimplementation collect-macro-forms (form &optional env)
+  ;; Currently detects only normal macros, not compiler macros.
+  (declare (ignore env))
+  (with-collected-macro-forms (macro-forms)
+      (handler-bind ((warning #'muffle-warning))
+        (ignore-errors
+          (compile nil `(lambda () ,(macroexpand-all form env)))))
+    (values macro-forms nil)))
+
 (defimplementation describe-symbol-for-emacs (symbol)
   (let ((result '()))
     (flet ((doc (kind &optional (sym symbol))

--- a/swank/abcl.lisp
+++ b/swank/abcl.lisp
@@ -282,7 +282,7 @@
   (nth-value 2 (function-lambda-expression function)))
 
 (defimplementation macroexpand-all (form)
-  (macroexpand form))
+  (ext:macroexpand-all form))
 
 (defimplementation describe-symbol-for-emacs (symbol)
   (let ((result '()))

--- a/swank/allegro.lisp
+++ b/swank/allegro.lisp
@@ -110,7 +110,8 @@
   (handler-case (excl:arglist symbol)
     (simple-error () :not-available)))
 
-(defimplementation macroexpand-all (form)
+(defimplementation macroexpand-all (form &optional env)
+  (declare (ignore env))
   #+(version>= 8 0)
   (excl::walk-form form)
   #-(version>= 8 0)

--- a/swank/backend.lisp
+++ b/swank/backend.lisp
@@ -699,7 +699,7 @@ available."
         (and (consp form) (length=2 form)
              (eq (first form) 'setf) (symbolp (second form))))))
 
-(definterface macroexpand-all (form)
+(definterface macroexpand-all (form &optional env)
    "Recursively expand all macros in FORM.
 Return the resulting form.")
 

--- a/swank/backend.lisp
+++ b/swank/backend.lisp
@@ -727,42 +727,45 @@ NIL."
                    (values new-form expanded)))))
     (frob form env)))
 
-(defmacro with-collected-macro-forms ((var) instrumented-form &body body)
+(defmacro with-collected-macro-forms
+    ((forms &optional result) instrumented-form &body body)
   "Collect macro forms by locally binding *MACROEXPAND-HOOK*.
 
-Evaluates INSTRUMENTED-FORM, with *MACROEXPAND-HOOK* bound to a
-function which collects all forms that undergo macro-expansion into a
-list stored in VAR.  Then evaluates BODY, with VAR still bound to the
-list of forms."
-  (assert (symbolp var))
-  (assert (not (null var)))
-  (let ((real-macroexpand-hook (gensym))
-        (instrumented-macroexpand-hook (gensym)))
-    `(let* ((,real-macroexpand-hook *macroexpand-hook*)
-            (,var '())
-            (,instrumented-macroexpand-hook
-             (lambda (macro-function form environment)
-               (let ((result (funcall ,real-macroexpand-hook
-                                      macro-function form environment)))
-                 (unless (eq result form)
-                   (setq ,var (cons form ,var)))
-                 result))))
-       (let ((*macroexpand-hook* ,instrumented-macroexpand-hook))
-         ,instrumented-form)
-       ,@body)))
+Evaluates INSTRUMENTED-FORM and collects any forms which undergo
+macro-expansion into a list.  Then evaluates BODY with FORMS bound to
+the list of forms, and RESULT (optionally) bound to the value of
+INSTRUMENTED-FORM."
+  (assert (and (symbolp forms) (not (null forms))))
+  (assert (symbolp result))
+  `(call-with-collected-macro-forms
+    (lambda (,forms ,(or result (gensym))) ,@body)
+    (lambda () ,instrumented-form)))
+
+(defun call-with-collected-macro-forms (body-fn instrumented-fn)
+  (let ((return-value nil)
+        (collected-forms '()))
+    (let* ((real-macroexpand-hook *macroexpand-hook*)
+           (*macroexpand-hook*
+            (lambda (macro-function form environment)
+              (let ((result (funcall real-macroexpand-hook
+                                     macro-function form environment)))
+                (unless (eq result form)
+                  (push form collected-forms))
+                result))))
+      (setf return-value (funcall instrumented-fn)))
+    (funcall body-fn collected-forms return-value)))
 
 (definterface collect-macro-forms (form &optional env)
   "Collect subforms of FORM which undergo (compiler-)macro expansion.
 Returns two values: a list of macro forms and a list of compiler macro
 forms."
-  (let ((expansion nil))
-    (with-collected-macro-forms (macro-forms)
-        (setq expansion (ignore-errors (macroexpand-all form env)))
-      (with-collected-macro-forms (compiler-macro-forms)
-          (handler-bind ((warning #'muffle-warning))
-            (ignore-errors
-              (compile nil `(lambda () ,expansion))))
-        (values macro-forms compiler-macro-forms)))))
+  (with-collected-macro-forms (macro-forms expansion)
+      (ignore-errors (macroexpand-all form env))
+    (with-collected-macro-forms (compiler-macro-forms)
+        (handler-bind ((warning #'muffle-warning))
+          (ignore-errors
+            (compile nil `(lambda () ,expansion))))
+      (values macro-forms compiler-macro-forms))))
 
 (definterface format-string-expand (control-string)
   "Expand the format string CONTROL-STRING."

--- a/swank/ccl.lisp
+++ b/swank/ccl.lisp
@@ -654,8 +654,8 @@
 
 ;;; Macroexpansion
 
-(defimplementation macroexpand-all (form)
-  (ccl:macroexpand-all form))
+(defimplementation macroexpand-all (form &optional env)
+  (ccl:macroexpand-all form env))
 
 ;;;; Inspection
 

--- a/swank/clasp.lisp
+++ b/swank/clasp.lisp
@@ -325,7 +325,8 @@
     (function (ext:compiled-function-name f))))
 
 ;; FIXME
-(defimplementation macroexpand-all (form)
+(defimplementation macroexpand-all (form &optional env)
+  (declare (ignore env))
   (macroexpand form))
 
 (defimplementation describe-symbol-for-emacs (symbol)

--- a/swank/clisp.lisp
+++ b/swank/clisp.lisp
@@ -260,7 +260,8 @@
           (return (ext:arglist fname)))
         :not-available)))
 
-(defimplementation macroexpand-all (form)
+(defimplementation macroexpand-all (form &optional env)
+  (declare (ignore env))
   (ext:expand-form form))
 
 (defimplementation describe-symbol-for-emacs (symbol)

--- a/swank/clisp.lisp
+++ b/swank/clisp.lisp
@@ -264,6 +264,15 @@
   (declare (ignore env))
   (ext:expand-form form))
 
+(defimplementation collect-macro-forms (form &optional env)
+  ;; Currently detects only normal macros, not compiler macros.
+  (declare (ignore env))
+  (with-collected-macro-forms (macro-forms)
+      (handler-bind ((warning #'muffle-warning))
+        (ignore-errors
+          (compile nil `(lambda () ,form))))
+    (values macro-forms nil)))
+
 (defimplementation describe-symbol-for-emacs (symbol)
   "Return a plist describing SYMBOL.
 Return NIL if the symbol is unbound."

--- a/swank/cmucl.lisp
+++ b/swank/cmucl.lisp
@@ -1396,8 +1396,8 @@ A utility for debugging DEBUG-FUNCTION-ARGLIST."
 
 ;;;; Miscellaneous.
 
-(defimplementation macroexpand-all (form)
-  (walker:macroexpand-all form))
+(defimplementation macroexpand-all (form &optional env)
+  (walker:macroexpand-all form env))
 
 (defimplementation compiler-macroexpand-1 (form &optional env)
   (ext:compiler-macroexpand-1 form env))

--- a/swank/corman.lisp
+++ b/swank/corman.lisp
@@ -265,7 +265,8 @@
 (defimplementation default-directory ()
   (directory-namestring (ccl:current-directory)))
 
-(defimplementation macroexpand-all (form)
+(defimplementation macroexpand-all (form &optional env)
+  (declare (ignore env))
   (ccl:macroexpand-all form))
 
 ;;; Documentation

--- a/swank/ecl.lisp
+++ b/swank/ecl.lisp
@@ -331,6 +331,15 @@
 ;; (defimplementation macroexpand-all (form &optional env)
 ;; (declare (ignore env))
 
+(defimplementation collect-macro-forms (form &optional env)
+  ;; Currently detects only normal macros, not compiler macros.
+  (declare (ignore env))
+  (with-collected-macro-forms (macro-forms)
+    (handler-bind ((warning #'muffle-warning))
+      (ignore-errors
+        (compile nil `(lambda () ,form))))
+    (values macro-forms nil)))
+
 (defimplementation describe-symbol-for-emacs (symbol)
   (let ((result '()))
     (flet ((frob (type boundp)

--- a/swank/ecl.lisp
+++ b/swank/ecl.lisp
@@ -328,7 +328,8 @@
     (function (si:compiled-function-name f))))
 
 ;; FIXME
-;; (defimplementation macroexpand-all (form))
+;; (defimplementation macroexpand-all (form &optional env)
+;; (declare (ignore env))
 
 (defimplementation describe-symbol-for-emacs (symbol)
   (let ((result '()))

--- a/swank/lispworks.lisp
+++ b/swank/lispworks.lisp
@@ -235,7 +235,8 @@
 (defimplementation function-name (function)
   (nth-value 2 (function-lambda-expression function)))
 
-(defimplementation macroexpand-all (form)
+(defimplementation macroexpand-all (form &optional env)
+  (declare (ignore env))
   (walker:walk-form form))
 
 (defun generic-function-p (object)

--- a/swank/mkcl.lisp
+++ b/swank/mkcl.lisp
@@ -348,7 +348,8 @@
   ;; It is a bit a shame we have to load the entire module to get that.
   (require 'walker))
 
-(defimplementation macroexpand-all (form)
+(defimplementation macroexpand-all (form &optional env)
+  (declare (ignore env))
   (walker:macroexpand-all form))
 
 (defimplementation describe-symbol-for-emacs (symbol)

--- a/swank/sbcl.lisp
+++ b/swank/sbcl.lisp
@@ -1076,6 +1076,27 @@ Return a list of the form (NAME LOCATION)."
 (defimplementation macroexpand-all (form &optional env)
   (sb-cltl2:macroexpand-all form env))
 
+(defimplementation collect-macro-forms (form &optional environment)
+  (let ((macro-forms '())
+        (compiler-macro-forms '())
+        (function-quoted-forms '()))
+    (sb-walker:walk-form
+     form environment
+     (lambda (form context environment)
+       (declare (ignore context))
+       (when (and (consp form)
+                  (symbolp (car form)))
+         (cond ((eq (car form) 'function)
+                (push (cadr form) function-quoted-forms))
+               ((member form function-quoted-forms)
+                nil)
+               ((macro-function (car form) environment)
+                (push form macro-forms))
+               ((not (eq form (compiler-macroexpand-1 form environment)))
+                (push form compiler-macro-forms))))
+       form))
+    (values macro-forms compiler-macro-forms)))
+
 
 ;;; Debugging
 

--- a/swank/sbcl.lisp
+++ b/swank/sbcl.lisp
@@ -1073,8 +1073,8 @@ Return a list of the form (NAME LOCATION)."
 
 ;;; macroexpansion
 
-(defimplementation macroexpand-all (form)
-  (sb-cltl2:macroexpand-all form))
+(defimplementation macroexpand-all (form &optional env)
+  (sb-cltl2:macroexpand-all form env))
 
 
 ;;; Debugging

--- a/swank/scl.lisp
+++ b/swank/scl.lisp
@@ -995,7 +995,8 @@ Signal an error if no constructor can be found."
 
 ;;;; Miscellaneous.
 
-(defimplementation macroexpand-all (form)
+(defimplementation macroexpand-all (form &optional env)
+  (declare (ignore env))
   (macroexpand form))
 
 (defimplementation set-default-directory (directory)


### PR DESCRIPTION
This is a hack @luismbo and I have been working on, which I hope is close to being ready for inclusion.  It provides a slightly fancier way of doing inline macro-expansion by integrating with the `macrostep` library (http://github.com/joddie/macrostep), originally written for working with Emacs Lisp.  The main features are:

- minor-mode for expanding and collapsing inline expansions in the source buffer
- syntax highlighting of macro and compiler-macro forms within the expansion
- expansion of locally-defined macros in context, as requested in issue #200 

If desired, the context-sensitive expansion feature could be factored out of this patch so that it could also be used by the builtin `slime-macroexpand-1-inplace`.

Except where noted, the included ERT tests pass under Emacs 24.4 on Mac OS X with Lisp implementations CMUCL, SBCL, CLISP, CCL and ABCL.  I have a patch which provides fuller functionality under ECL, but it requires issue #157 to be fixed.

Two (hopefully minimal) changes were made to the core SWANK machinery to support this (primarily for context-sensitive expansion):

- `macroexpand-all` needs to take an optional second `environment` argument for the initial macro-expansion environment.  Working implementations have been added for SBCL, CMUCL, CCL and ABCL.  Other implementations currently, ignore the optional argument, so they should function as before.

- `macroexpand-all` under ABCL, which previously just called `macroexpand`, is redefined to use the implementation's `EXT:MACROEXPAND-ALL`, which has seemingly been available since 2009 (see, e.g. http://armedbear-devel.common-lisp.narkive.com/0TR5ZaAt/macroexpand-all ).
