### PR TITLE
Trivial fix to enable loading of swank-listener-hooks

### DIFF
--- a/contrib/slime-listener-hooks.el
+++ b/contrib/slime-listener-hooks.el
@@ -1,0 +1,11 @@
+(require 'slime)
+(require 'cl-lib)
+
+(define-slime-contrib slime-listener-hooks
+  "Enable slime integration in an application'w event loop"
+  (:authors "Alan Ruttenberg  <alanr-l@mumble.net>, R. Mattes <rm@seid-online.de>")
+  (:license "GPL")
+  (:slime-dependencies slime-repl)
+  (:swank-dependencies swank-listener-hooks))
+
+(provide 'slime-listener-hooks)


### PR DESCRIPTION
This patch makes it possible to activate the swank-listener-hooks from slime-setup 