### PR TITLE
 Add support for UNIX domain sockets

### DIFF
--- a/PROBLEMS
+++ b/PROBLEMS
@@ -1,16 +1,23 @@
 Known problems with SLIME                                   -*- outline -*-
 
-* Common to all backends
+* Common to all backendsh
 
 ** Caution: network security
 
-The `M-x slime' command has Lisp listen on a TCP socket and wait for
-Emacs to connect, which typically takes on the order of one second. If
-someone else were to connect to this socket then they could use the
-SLIME protocol to control the Lisp process.
+On Windows systems, and on Lisps that do not support Unix domain
+sockets, the `M-x slime' command has Lisp listen on a TCP socket and
+wait for Emacs to connect, which typically takes on the order of one
+second. If someone else were to connect to this socket then they could
+use the SLIME protocol to control the Lisp process.
 
 The listen socket is bound on the loopback interface in all Lisps that
 support this. This way remote hosts are unable to connect.
+
+Note that this is not a problem on Unix hosts for Lisps that support
+Unix domain sockets.  Unix domain sockets are secured by filesystem
+permissions and SLIME is thus immune to this attack on such systems.
+Currently, Unix domain sockets are supported on Unix systems with all
+supported Lisps except ABCL and LispWorks.
 
 ** READ-CHAR-NO-HANG is broken
 

--- a/swank/allegro.lisp
+++ b/swank/allegro.lisp
@@ -50,10 +50,16 @@
 (defimplementation preferred-communication-style ()
   :spawn)
 
+#+mswindows
 (defimplementation create-socket (host port &key backlog)
   (socket:make-socket :connect :passive :local-port port
-                      :local-host host :reuse-address t
+                      :local-host host :reuse-address nil
                       :backlog (or backlog 5)))
+#-mswindows
+(defimplementation create-socket (host port &key backlog)
+  (socket:make-socket :connect :passive
+                      :local-host port :reuse-address nil
+                      :address-family :file))
 
 (defimplementation local-port (socket)
   (socket:local-port socket))

--- a/swank/backend.lisp
+++ b/swank/backend.lisp
@@ -325,9 +325,11 @@ This will be used like so:
 
 ;;;; TCP server
 
-(definterface create-socket (host port &key backlog)
-  "Create a listening TCP socket on interface HOST and port PORT.
-BACKLOG queue length for incoming connections.")
+(definterface create-socket (host port filename &key backlog)
+  "Create a listening Unix domain socket with filename FILENAME.
+If Unix domain sockets are not supported, create a TCP socket on
+interface HOST and port PORT.  BACKLOG is the queue length for
+incoming connections.")
 
 (definterface local-port (socket)
   "Return the local port number of SOCKET.")

--- a/swank/ccl.lisp
+++ b/swank/ccl.lisp
@@ -97,10 +97,18 @@
 (defimplementation preferred-communication-style ()
   :spawn)
 
+#-windows-target
 (defimplementation create-socket (host port &key backlog)
-  (ccl:make-socket :connect :passive :local-port port
-                   :local-host host :reuse-address t
-                   :backlog (or backlog 5)))
+  (declare (ignore host))
+  (ccl:make-socket :connect :passive :reuse-address nil
+                   :auto-close t :backlog (or backlog 5)
+                   :local-filename port :address-family :file))
+
+#+windows-target
+(defimplementation create-socket (host port &key backlog)
+  (ccl:make-socket :connect :passive :reuse-address nil
+                   :auto-close t :backlog (or backlog 5)
+                   :local-port port :local-host host))
 
 (defimplementation local-port (socket)
   (ccl:local-port socket))

--- a/swank/clasp.lisp
+++ b/swank/clasp.lisp
@@ -61,11 +61,22 @@
   (car (sb-bsd-sockets:host-ent-addresses
         (sb-bsd-sockets:get-host-by-name name))))
 
+#-win32
 (defimplementation create-socket (host port &key backlog)
-  (let ((socket (make-instance 'sb-bsd-sockets:inet-socket
-			       :type :stream
-			       :protocol :tcp)))
-    (setf (sb-bsd-sockets:sockopt-reuse-address socket) t)
+  (declare (ignore host))
+  (let ((socket (make-instance 'sb-bsd-sockets:local-socket
+                               :type :stream)))
+    (sb-bsd-sockets:socket-bind socket port)
+    (sb-bsd-sockets:socket-listen socket (or backlog 5))
+    socket))
+
+#+win32
+(defimplementation create-socket (host port &key backlog)
+  (let ((socket
+         (make-instance 'sb-bsd-sockets:inet-socket
+                        :type :stream
+                        :protocol :tcp)))
+    (setf (sb-bsd-sockets:sockopt-reuse-address socket) nil)
     (sb-bsd-sockets:socket-bind socket (resolve-hostname host) port)
     (sb-bsd-sockets:socket-listen socket (or backlog 5))
     socket))

--- a/swank/clisp.lisp
+++ b/swank/clisp.lisp
@@ -156,7 +156,14 @@
     (ext:convert-string-from-bytes octets enc)))
 
 ;;;; TCP Server
+#+unix
+(defimplementation create-socket (host port &key backlog)
+  (multiple-value-bind (socket address)
+      (rawsock:open-unix-socket port)
+    (declare (ignore address)) ;; FIXME: should we do something with the address?
+    (socket:socket-server 0 :interface socket :backlog (or backlog 5)))
 
+#-unix
 (defimplementation create-socket (host port &key backlog)
   (socket:socket-server port :interface host :backlog (or backlog 5)))
 

--- a/swank/cmucl.lisp
+++ b/swank/cmucl.lisp
@@ -52,20 +52,22 @@
 (defimplementation preferred-communication-style ()
   :sigio)
 
-#-(or darwin mips)
+#+win32
 (defimplementation create-socket (host port &key backlog)
+  ;; (assert (null port))
   (let* ((addr (resolve-hostname host))
          (addr (if (not (find-symbol "SOCKET-ERROR" :ext))
                    (ext:htonl addr)
                    addr)))
-    (ext:create-inet-listener port :stream :reuse-address t :host addr
+    (ext:create-inet-listener port :stream
+                              :reuse-address nil
+                              :host addr
                               :backlog (or backlog 5))))
 
-;; There seems to be a bug in create-inet-listener on Mac/OSX and Irix.
-#+(or darwin mips)
+#-win32
 (defimplementation create-socket (host port &key backlog)
-  (declare (ignore host))
-  (ext:create-inet-listener port :stream :reuse-address t))
+  (assert (null host))
+  (ext:create-unix-listener port :stream :backlog backlog))
 
 (defimplementation local-port (socket)
   (nth-value 1 (ext::get-socket-host-and-port (socket-fd socket))))
@@ -74,6 +76,7 @@
   (let ((fd (socket-fd socket)))
     (sys:invalidate-descriptor fd)
     (ext:close-socket fd)))
+
 
 (defimplementation accept-connection (socket &key
                                       external-format buffering timeout)

--- a/swank/ecl.lisp
+++ b/swank/ecl.lisp
@@ -73,17 +73,35 @@
   (car (sb-bsd-sockets:host-ent-addresses
         (sb-bsd-sockets:get-host-by-name name))))
 
-(defimplementation create-socket (host port &key backlog)
-  (let ((socket (make-instance 'sb-bsd-sockets:inet-socket
-			       :type :stream
-			       :protocol :tcp)))
-    (setf (sb-bsd-sockets:sockopt-reuse-address socket) t)
+#-windows
+(defimplementation create-socket (host port filename &key backlog)
+  (declare (ignore host port))
+  (let ((socket (make-instance 'sb-bsd-sockets:local-socket
+                               :type :stream)))
+    (sb-bsd-sockets:socket-bind socket filename)
+    (sb-bsd-sockets:socket-listen socket (or backlog 5))
+    socket))
+
+#+windows
+(defimplementation create-socket (host port filename &key backlog)
+  (declare (ignore filename))
+  (let ((socket
+         (make-instance 'sb-bsd-sockets:inet-socket
+                        :type :stream
+                        :protocol :tcp)))
+    (setf (sb-bsd-sockets:sockopt-reuse-address socket) nil)
     (sb-bsd-sockets:socket-bind socket (resolve-hostname host) port)
     (sb-bsd-sockets:socket-listen socket (or backlog 5))
     socket))
 
+#+windows
 (defimplementation local-port (socket)
   (nth-value 1 (sb-bsd-sockets:socket-name socket)))
+
+#-windows
+(defimplementation local-port (socket)
+  (declare (ignore socket))
+  nil)
 
 (defimplementation close-socket (socket)
   (sb-bsd-sockets:socket-close socket))
@@ -100,7 +118,7 @@
                                                   ((nil) :none)
                                                   (:line :line))
                                      :element-type (if external-format
-                                                       'character 
+                                                       'character
                                                        '(unsigned-byte 8))
                                      :external-format external-format))
 (defun accept (socket)
@@ -118,7 +136,7 @@
 
 (defvar *external-format-to-coding-system*
   '((:latin-1
-     "latin-1" "latin-1-unix" "iso-latin-1-unix" 
+     "latin-1" "latin-1-unix" "iso-latin-1-unix"
      "iso-8859-1" "iso-8859-1-unix")
     (:utf-8 "utf-8" "utf-8-unix")))
 
@@ -209,7 +227,7 @@
             (timeout (return (poll-streams streams 0)))
             (t
              (when-let (ready (poll-streams streams 0.2))
-               (return ready))))))  
+               (return ready))))))
 
 ) ; #+serve-event (progn ...
 
@@ -635,7 +653,7 @@
     (error "ECL's source directory ~A does not exist. ~
             You can specify a different location via the environment ~
             variable `ECLSRCDIR'."
-           (namestring (translate-logical-pathname #P"SYS:"))))) 
+           (namestring (translate-logical-pathname #P"SYS:")))))
 
 (defun assert-TAGS-file ()
   (unless (probe-file +TAGS+)

--- a/swank/mkcl.lisp
+++ b/swank/mkcl.lisp
@@ -54,11 +54,22 @@
   (car (sb-bsd-sockets:host-ent-addresses
         (sb-bsd-sockets:get-host-by-name name))))
 
+#-win32
 (defimplementation create-socket (host port &key backlog)
-  (let ((socket (make-instance 'sb-bsd-sockets:inet-socket
-			       :type :stream
-			       :protocol :tcp)))
-    (setf (sb-bsd-sockets:sockopt-reuse-address socket) t)
+  (declare (ignore host))
+  (let ((socket (make-instance 'sb-bsd-sockets:local-socket
+                               :type :stream)))
+    (sb-bsd-sockets:socket-bind socket port)
+    (sb-bsd-sockets:socket-listen socket (or backlog 5))
+    socket))
+
+#+win32
+(defimplementation create-socket (host port &key backlog)
+  (let ((socket
+         (make-instance 'sb-bsd-sockets:inet-socket
+                        :type :stream
+                        :protocol :tcp)))
+    (setf (sb-bsd-sockets:sockopt-reuse-address socket) nil)
     (sb-bsd-sockets:socket-bind socket (resolve-hostname host) port)
     (sb-bsd-sockets:socket-listen socket (or backlog 5))
     socket))

--- a/swank/scl.lisp
+++ b/swank/scl.lisp
@@ -30,9 +30,8 @@
   :spawn)
 
 (defimplementation create-socket (host port &key backlog)
-  (let ((addr (resolve-hostname host)))
-    (ext:create-inet-listener port :stream :host addr :reuse-address t
-                              :backlog (or backlog 5))))
+  (assert (null port))
+  (ext:create-unix-listener port :stream :backlog (or backlog 5)))
 
 (defimplementation local-port (socket)
   (nth-value 1 (ext::get-socket-host-and-port (socket-fd socket))))


### PR DESCRIPTION
This adds support for UNIX domain sockets and makes them the only
option on platforms and Common Lisps that support them.

There are still bugs:

- The temporary files are not deleted when SLIME exits.  Note that
  these will be deleted in the event of a PID clash.
- TCP sockets are still completely insecure.