### PR TITLE
 Add `slime-quicklisp' contrib.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2016-02-03  Matthew Kennedy  <burnsidemk@gmail.com>
+
+	* contrib: Add `slime-quicklisp' contrib.
+
+	* swank-loader.lisp (*contribs*): Add `swank-quicklisp`.
+
 2016-02-02  Jon Oddie  <j.j.oddie@gmail.com>
 
 	Add `slime-macrostep' contrib.

--- a/contrib/slime-quicklisp.el
+++ b/contrib/slime-quicklisp.el
@@ -1,0 +1,51 @@
+(require 'slime)
+(require 'cl-lib)
+
+;;; bits of the following taken from slime-asdf.el
+
+(define-slime-contrib slime-quicklisp
+  "Quicklisp support."
+  (:authors "Matthew Kennedy <burnsidemk@gmail.com>")
+  (:license "GPL")
+  (:slime-dependencies slime-repl)
+  (:swank-dependencies swank-quicklisp))
+
+;;; Utilities
+
+(defgroup slime-quicklisp nil
+  "Quicklisp support for Slime."
+  :prefix "slime-quicklisp-"
+  :group 'slime)
+
+(defvar slime-quicklisp-system-history nil
+  "History list for Quicklisp system names.")
+
+
+
+(defun slime-read-quicklisp-system-name (&optional prompt default-value)
+  "Read a Quick system name from the minibuffer, prompting with PROMPT."
+  (let* ((completion-ignore-case nil)
+         (prompt (or prompt "Quicklisp system"))
+         (quicklisp-system-names (slime-eval `(swank:list-quicklisp-systems)))
+         (prompt (concat prompt (if default-value
+                                    (format " (default `%s'): " default-value)
+                                  ": "))))
+    (completing-read prompt (slime-bogus-completion-alist quicklisp-system-names)
+                     nil nil nil
+                     'slime-quicklisp-system-history default-value)))
+
+(defun slime-quicklisp-quickload (system)
+  "Load a Quicklisp system."
+  (slime-save-some-lisp-buffers)
+  (slime-display-output-buffer)
+  (slime-repl-shortcut-eval-async `(ql:quickload ,system)))
+
+;;; REPL shortcuts
+
+(defslime-repl-shortcut slime-repl-quicklisp-quickload ("quicklisp-quickload" "ql")
+  (:handler (lambda ()
+              (interactive)
+              (slime-quicklisp-quickload (slime-read-quicklisp-system-name))))
+  (:one-liner "Load a system known to Quicklisp."))
+
+(provide 'slime-quicklisp)

--- a/contrib/swank-quicklisp.lisp
+++ b/contrib/swank-quicklisp.lisp
@@ -1,0 +1,17 @@
+;;; swank-quicklisp.lisp -- Quicklisp support
+;;
+;; Authors: Matthew Kennedy <burnsidemk@gmail.com>
+;; License: Public Domain
+;;
+
+(in-package :swank)
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (unless (member :quicklisp *features*)
+    (error "Could not find Quicklisp already loaded.")))
+
+(defslimefun list-quicklisp-systems ()
+  "Returns the Quicklisp systems list."
+  (mapcar #'ql-dist:name (ql:system-list)))
+
+(provide :swank-quicklisp)

--- a/contrib/swank-quicklisp.lisp
+++ b/contrib/swank-quicklisp.lisp
@@ -6,12 +6,12 @@
 
 (in-package :swank)
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (unless (member :quicklisp *features*)
-    (error "Could not find Quicklisp already loaded.")))
-
 (defslimefun list-quicklisp-systems ()
   "Returns the Quicklisp systems list."
-  (mapcar #'ql-dist:name (ql:system-list)))
+  (if (member :quicklisp *features*)
+      (let ((ql-dist-name (find-symbol "NAME" "QL-DIST"))
+            (ql-system-list (find-symbol "SYSTEM-LIST" "QL")))
+        (mapcar ql-dist-name (funcall ql-system-list)))
+      (error "Could not find Quicklisp already loaded.")))
 
 (provide :swank-quicklisp)

--- a/doc/contributors.texi
+++ b/doc/contributors.texi
@@ -51,5 +51,4 @@
 @item Brandon Bergren @tab Bozhidar Batsov @tab Bob Halley
 @item Barry Fishman @tab B.Scott Michel @tab Andrew Myers
 @item Aleksandar Bakic @tab Alain Picard @tab Adam Bozanich
-@item Matthew Kennedy
 @end multitable

--- a/doc/contributors.texi
+++ b/doc/contributors.texi
@@ -51,4 +51,5 @@
 @item Brandon Bergren @tab Bozhidar Batsov @tab Bob Halley
 @item Barry Fishman @tab B.Scott Michel @tab Andrew Myers
 @item Aleksandar Bakic @tab Alain Picard @tab Adam Bozanich
+@item Matthew Kennedy
 @end multitable

--- a/doc/slime.texi
+++ b/doc/slime.texi
@@ -233,6 +233,7 @@ Contributed Packages
 * SLIME Trace Dialog::
 * slime-sprof::
 * slime-fancy::
+* Quicklisp::
 
 REPL: the ``top level''
 
@@ -2159,6 +2160,7 @@ particular packages do.
 * slime-sprof::
 * SLIME Enhanced M-.::
 * slime-fancy::
+* Quicklisp::
 @end menu
 
 @node Loading Contribs
@@ -3192,6 +3194,21 @@ declared with @code{flet} and @code{labels}, via
 
 @code{slime-fancy} is a meta package which loads a combination of the
 most popular packages.
+
+@node Quicklisp
+@section Quicklisp
+The package @code{slime-quicklisp} adds support for loading Quicklisp
+systems in the REPL buffer.  In order for this to work, Quicklisp
+should have already been loaded in the Lisp implementation.  Refer
+to @url{https://www.quicklisp.org/} for Quicklisp installation
+details.
+
+The package installs the following REPL shortcuts (@pxref{Shortcuts}):
+
+@table @kbd
+@item quicklisp-quickload (aka ql)
+Load a Quicklisp system.
+@end table
 
 @c -----------------------
 @node Credits

--- a/swank-loader.lisp
+++ b/swank-loader.lisp
@@ -247,7 +247,8 @@ If LOAD is true, load the fasl file."
     #+sbcl swank-sbcl-exts
     swank-mrepl
     swank-trace-dialog
-    swank-macrostep)
+    swank-macrostep
+    swank-quicklisp)
   "List of names for contrib modules.")
 
 (defun append-dir (absolute name)


### PR DESCRIPTION
Hi, This adds a new command "quicklisp-quickload" with an alias "ql" for working with quicklisp via the slime repl.