### PR TITLE
Fix simple read

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2016-03-09  Tomas Zellerin  <tomas@zellerin.cz>
+
+	* swank/rpc.lisp (simple-read): Fix handling of symbols.
+
 2016-03-04  Stas Boukarev  <stassats@gmail.com>
 
 	* swank.lisp (xref-doit): translate :sets to who-sets.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 2016-03-09  Tomas Zellerin  <tomas@zellerin.cz>
 
+	* swank/rpc.lisp (simple-read): We did not gain anything by custom string reader.
 	* swank/rpc.lisp (simple-read): Fix handling of symbols.
 
 2016-03-04  Stas Boukarev  <stassats@gmail.com>

--- a/swank/rpc.lisp
+++ b/swank/rpc.lisp
@@ -57,9 +57,8 @@
           (t
            (error "Short read: length=~D  count=~D" length count)))))
 
-;; FIXME: no one ever tested this and will probably not work.
 (defparameter *validate-input* nil
-  "Set to true to require input that strictly conforms to the protocol")
+  "Set to true to require input that more strictly conforms to the protocol")
 
 (defun read-form (string package)
   (with-standard-io-syntax
@@ -87,15 +86,20 @@
                           (#\) nil)
                           (#\space t))))
        (#\' `(quote ,(simple-read)))
-       (t (let ((string (with-output-to-string (*standard-output*)
-                          (loop for ch = c then (read-char nil nil) do
-                                (case ch
-                                  ((nil) (return))
-                                  (#\\ (write-char (read-char)))
-                                  ((#\space #\)) (unread-char ch)(return))
-                                  (t (write-char ch)))))))
-            (cond ((digit-char-p c) (parse-integer string))
-                  ((intern string))))))))
+       (t
+        (cond
+          ((digit-char-p c)
+           (parse-integer
+            (map 'simple-string #'identity
+                 (loop
+                    for ch = c then (read-char nil nil)
+                    while (and ch (digit-char-p ch))
+                    collect ch
+                    finally (unread-char ch)))))
+          ((or (eql c #\:) (alpha-char-p c))
+           (unread-char c)
+           (read-preserving-whitespace))
+          (t (error "Invalid character ~:c" c)))))))
 
 
 ;;;;; Output

--- a/swank/rpc.lisp
+++ b/swank/rpc.lisp
@@ -75,12 +75,6 @@
    "Read a form that conforms to the protocol, otherwise signal an error."
    (let ((c (read-char)))
      (case c
-       (#\" (with-output-to-string (*standard-output*)
-              (loop for c = (read-char) do
-                    (case c
-                      (#\" (return))
-                      (#\\ (write-char (read-char)))
-                      (t (write-char c))))))
        (#\( (loop collect (simple-read)
                   while (ecase (read-char)
                           (#\) nil)
@@ -96,7 +90,7 @@
                     while (and ch (digit-char-p ch))
                     collect ch
                     finally (unread-char ch)))))
-          ((or (eql c #\:) (alpha-char-p c))
+          ((or (member c '(#\: #\")) (alpha-char-p c))
            (unread-char c)
            (read-preserving-whitespace))
           (t (error "Invalid character ~:c" c)))))))


### PR DESCRIPTION
Make `simple-read` (and `*validate-input*`) really work.

I have it on for some time and no issue. There may be later interactions, still.