### PR TITLE
Improve passwords handling

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2016-03-15  Tomas Zellerin  <tomas@zellerin.cz>
+
+	* swank.lisp (authenticate-client): Read password message in more secure way.
+
 2016-03-09  Tomas Zellerin  <tomas@zellerin.cz>
 
 	* swank/rpc.lisp (simple-read): We did not gain anything by custom string reader.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,9 @@
 2016-03-15  Tomas Zellerin  <tomas@zellerin.cz>
 
 	* swank.lisp (authenticate-client): Read password message in more secure way.
+	(authenticate-client): When password reading fails, return nil and
+	close socket instead of hanging.
+	(accept-connections): Dont close if authentication fails.
 
 2016-03-09  Tomas Zellerin  <tomas@zellerin.cz>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2016-03-15  Tomas Zellerin  <tomas@zellerin.cz>
 
+	* swank/sbcl.lisp (set-stream-timeout): Implement stream timeout.
+
 	* swank.lisp (authenticate-client): Read password message in more secure way.
 	(authenticate-client): When password reading fails, return nil and
 	close socket instead of hanging.

--- a/swank.lisp
+++ b/swank.lisp
@@ -781,7 +781,8 @@ first."
       (send-to-sentinel `(:stop-server :socket ,socket)))))
 
 (defun authenticate-client (stream)
-  (let ((secret (slime-secret)))
+  (let ((secret (slime-secret))
+        (swank/rpc::*validate-input* t))
     (when secret
       (set-stream-timeout stream 20)
       (let ((first-val (decode-message stream)))

--- a/swank.lisp
+++ b/swank.lisp
@@ -775,20 +775,29 @@ first."
                                                :buffering t)
                   (unless dont-close
                     (close-socket socket)))))
-    (authenticate-client client)
-    (serve-requests (make-connection socket client style))
-    (unless dont-close
-      (send-to-sentinel `(:stop-server :socket ,socket)))))
+    (when  (authenticate-client client)
+      (serve-requests (make-connection socket client style))
+      (unless dont-close
+        (send-to-sentinel `(:stop-server :socket ,socket))))))
 
 (defun authenticate-client (stream)
+  "NIL if secret password was expected but not provided correctly."
   (let ((secret (slime-secret))
         (swank/rpc::*validate-input* t))
-    (when secret
-      (set-stream-timeout stream 20)
-      (let ((first-val (decode-message stream)))
-        (unless (and (stringp first-val) (string= first-val secret))
-          (error "Incoming connection doesn't know the password.")))
-      (set-stream-timeout stream nil))))
+    (if secret
+        (handler-case
+            (progn
+              (set-stream-timeout stream 20)
+              (let ((first-val (decode-message stream)))
+                (unless (and (stringp first-val) (string= first-val secret))
+                  (error "Incoming connection doesn't know the password.")))
+              (set-stream-timeout stream nil)
+              t)
+          (error (e)
+            (close stream)
+            (warn "Swank password: ~a" e)
+            nil))
+        t)))
 
 (defun slime-secret ()
   "Finds the magic secret from the user's home directory.  Returns nil

--- a/swank/sbcl.lisp
+++ b/swank/sbcl.lisp
@@ -89,6 +89,13 @@
     ((member :win32 *features*) nil)
     (t :fd-handler)))
 
+(defimplementation set-stream-timeout (stream timeout)
+  "Set the 'stream 'timeout.  The timeout is either the real number
+  specifying the timeout in seconds or 'nil for no timeout."
+  (setf (sb-impl::fd-stream-timeout stream)
+        (when timeout
+          (coerce timeout 'single-float))))
+
 (defun resolve-hostname (name)
   (car (sb-bsd-sockets:host-ent-addresses
         (sb-bsd-sockets:get-host-by-name name))))


### PR DESCRIPTION
This is a set of simple fixes to increase security of password handling.

They probably do not conform to the best coding practices (in particular, use internal symbols of other packages), but show some problems with current situation. Feedback welcome. See also #302.

Was tested only on sbcl/Linux.

The goal is for the server to survive things like nmap -sV or random connection to the port, not sofisticated attacker going for DoS.