### PR TITLE
* contrib/swank-mit-scheme.scm: stop using `.com` extension explicitl…

### DIFF
--- a/contrib/ChangeLog
+++ b/contrib/ChangeLog
@@ -1,3 +1,9 @@
+2016-04-09  W. David Jarvis <venantius@gmail.com>
+
+	* contrib/swank-mit-scheme.scm: changed compilation result
+	filename to not explicitly look for `.com` extensions and instead
+	allow the compiler to do its own extension lookup.
+
 2016-02-11  Stas Boukarev  <stassats@gmail.com>
 
 	* swank-sbcl-exts.lisp (compute-enriched-decoded-arglist):

--- a/contrib/swank-mit-scheme.scm
+++ b/contrib/swank-mit-scheme.scm
@@ -348,7 +348,7 @@
   (apply
    (lambda (errors seconds)
      (list ':compilation-result errors 't seconds load? 
-	   (->namestring (pathname-new-type file "com"))))
+	   (->namestring (pathname-new-type file))))
    (call-compiler
     (lambda () (with-output-to-repl socket (lambda () (compile-file file)))))))
 


### PR DESCRIPTION
…y for load

Changes the compilation result filename to not explicitly use `.com` extensions
and instead allows the compiler to do its own extension lookup when calling
`load`. MIT scheme compiled for OS X will compile `.so` files but not `.com`
files.