### PR TITLE
* mit-scheme: use correct function for file load

### DIFF
--- a/contrib/swank-mit-scheme.scm
+++ b/contrib/swank-mit-scheme.scm
@@ -348,7 +348,7 @@
   (apply
    (lambda (errors seconds)
      (list ':compilation-result errors 't seconds load? 
-	   (->namestring (pathname-new-type file))))
+	   (->namestring (pathname-name file))))
    (call-compiler
     (lambda () (with-output-to-repl socket (lambda () (compile-file file)))))))
 


### PR DESCRIPTION
The previous commit (c7726e03) failed to change `pathname-new-type` to
`pathname-name` when it removed the `com` extension. The function change
is necessary since we're not actually changing the filetype.

Sorry for not doing this properly in the previous commit.