### PR TITLE
contrib/slime-c-p-c.el: completion bugfix

### DIFF
--- a/contrib/slime-c-p-c.el
+++ b/contrib/slime-c-p-c.el
@@ -274,7 +274,7 @@ current buffer."
     (let ((result (slime-eval `(swank:completions-for-character
                                 ,(cl-subseq prefix 2)))))
       (when (car result)
-        (list (mapcar 'append-char-syntax (car result))
+        (list (mapcar #'append-char-syntax (car result))
               (append-char-syntax (cadr result)))))))
 
 


### PR DESCRIPTION
+ Fixes "mapcar: Symbol's function definition is void:
  append-char-syntax" error when trying to complete #\

  This bug was introduced by Joao Tavora in:
  3467ebc9ead3408c21cd1d2ae119ac05e2a7e2d9