### PR TITLE
include name of history file in "Continue?" prompt

### DIFF
--- a/contrib/slime-repl.el
+++ b/contrib/slime-repl.el
@@ -1173,12 +1173,12 @@ truncated.  That part is untested, though!"
 (defun slime-repl-safe-save-merged-history ()
   (slime-repl-call-with-handler
    #'slime-repl-save-merged-history
-   "%S while saving the history. Continue? "))
+   (format "%%S while saving the history %S. Continue? " slime-repl-history-file)))
 
 (defun slime-repl-safe-load-history ()
   (slime-repl-call-with-handler
    #'slime-repl-load-history
-   "%S while loading the history. Continue? "))
+   (format "%%S while loading the history %S. Continue? "  slime-repl-history-file)))
 
 (defun slime-repl-call-with-handler (fun query)
   "Call FUN in the context of an error handler.


### PR DESCRIPTION
If there is an error loading the "history" file, emacs/slime gives me a prompt saying "some error" 
while loading history. Continue?"  But it fails to tell me which file it is talking about.

This PR simply updates the prompt to let me know what file it is talking about so I can take a
look at the file fix the problem.