### PR TITLE
Make fuzzy completion up/down navigation wrap around the edges

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Quick setup instructions
      ```el
      ;; Set your lisp system and, optionally, some contribs
      (setq inferior-lisp-program "/opt/sbcl/bin/sbcl")
-     (slime-setup '(slime-fancy))
+     (setq slime-contribs '(slime-fancy))
      ```
 
   3. Use `M-x slime` to fire up and connect to an inferior Lisp. SLIME will
@@ -40,7 +40,7 @@ Contribs
 --------
 
 SLIME comes with additional contributed packages or "contribs".
-Contribs can be loaded with the `slime-setup` function.
+Contribs can be selected via the `slime-contribs` list.
 
 The most-often used contrib is `slime-fancy`, which primarily installs a
 popular set of other contributed packages. It includes a better REPL, and

--- a/contrib/slime-fancy.el
+++ b/contrib/slime-fancy.el
@@ -13,7 +13,7 @@
                        slime-fancy-trace
                        slime-fuzzy
                        slime-mdot-fu
-                       ;;slime-macrostep
+                       slime-macrostep
                        slime-presentations
                        slime-scratch
                        slime-references

--- a/contrib/slime-fuzzy.el
+++ b/contrib/slime-fuzzy.el
@@ -467,23 +467,24 @@ the completion that point is on in the completions buffer."
 
 (defun slime-fuzzy-next ()
   "Moves point directly to the next completion in the completions
-buffer."
+buffer. Wraps around the end."
   (interactive)
   (with-current-buffer (slime-get-fuzzy-buffer)
-    (let ((point (next-single-char-property-change
-                  (point) 'completion nil slime-fuzzy-last)))
+    (let* ((next-point (next-single-char-property-change
+                        (point) 'completion nil slime-fuzzy-last))
+           (point (if (= next-point (point)) slime-fuzzy-first next-point)))
       (set-window-point (get-buffer-window (current-buffer)) point)
       (goto-char point))
     (slime-fuzzy-highlight-current-completion)))
 
 (defun slime-fuzzy-prev ()
   "Moves point directly to the previous completion in the
-completions buffer."
+completions buffer. Wraps around the beginning."
   (interactive)
   (with-current-buffer (slime-get-fuzzy-buffer)
-    (let ((point (previous-single-char-property-change
-                  (point)
-                  'completion nil slime-fuzzy-first)))
+    (let* ((prev-point (previous-single-char-property-change
+                        (point) 'completion nil slime-fuzzy-first))
+           (point (if (= prev-point (point)) slime-fuzzy-last prev-point)))
       (set-window-point (get-buffer-window (current-buffer)) point)
       (goto-char point))
     (slime-fuzzy-highlight-current-completion)))

--- a/slime.el
+++ b/slime.el
@@ -943,6 +943,7 @@ See `slime-lisp-implementations'")
 (defun slime (&optional command coding-system)
   "Start an inferior^_superior Lisp and connect to its Swank server."
   (interactive)
+  (slime-setup)
   (let ((inferior-lisp-program (or command inferior-lisp-program))
         (slime-net-coding-system (or coding-system slime-net-coding-system)))
     (slime-start* (cond ((and command (symbolp command))
@@ -1061,6 +1062,7 @@ DIRECTORY change to this directory before starting the process.
                        "Port: " (cl-first slime-connect-port-history)
                        nil nil '(slime-connect-port-history . 1)))
                      nil t))
+  (slime-setup)
   (when (and interactive-p
              slime-net-processes
              (y-or-n-p "Close old connections first? "))
@@ -7491,8 +7493,6 @@ The returned bounds are either nil or non-empty."
 
 (run-hooks 'slime-load-hook)
 (provide 'slime)
-
-(slime-setup)
 
 ;; Local Variables:
 ;; outline-regexp: ";;;;+"

--- a/swank/sbcl.lisp
+++ b/swank/sbcl.lisp
@@ -723,8 +723,9 @@ QUALITIES is an alist with (quality . value)"
                  (with-compilation-unit
                      (:source-plist (list :emacs-buffer buffer
                                           :emacs-filename filename
-                                          :emacs-string string
-                                          :emacs-position position)
+                                          :emacs-package (package-name *package*)
+                                          :emacs-position position
+                                          :emacs-string string)
                       :source-namestring filename
                       :allow-other-keys t)
                    (compile-file *buffer-tmpfile* :external-format :utf-8)))))
@@ -1250,7 +1251,11 @@ stack."
 
 (defun code-location-source-location (code-location)
   (let* ((dsource (sb-di:code-location-debug-source code-location))
-         (plist (sb-c::debug-source-plist dsource)))
+         (plist (sb-c::debug-source-plist dsource))
+         (package (getf plist :emacs-package))
+         (*package* (or (and package
+                             (find-package package))
+                        *package*)))
     (if (getf plist :emacs-buffer)
         (emacs-buffer-source-location code-location plist)
         #+#.(swank/backend:with-symbol 'debug-source-from 'sb-di)


### PR DESCRIPTION
When using fuzzy completion I am frequently facing a fairly long completion list. I thought that not being able to wrap around the edges (i.e. scroll up from the beginning and arrive at the end and vice versa) was a bit counter-intuitive. So I modified the `slime-fuzzy-next` and `slime-fuzzy-prev` functions.
