### PR TITLE
Add `slime-inspect-last-expression'.

### DIFF
--- a/slime.el
+++ b/slime.el
@@ -4010,6 +4010,11 @@ inserted in the current buffer."
   (interactive)
   (slime-interactive-eval (slime-last-expression)))
 
+(defun slime-inspect-last-expression ()
+  "Inspect the result of evaluating the expression preceding point."
+  (interactive)
+  (slime-inspect (slime-last-expression)))
+
 (defun slime-eval-defun ()
   "Evaluate the current toplevel form.
 Use `slime-re-evaluate-defvar' if the from starts with '(defvar'"


### PR DESCRIPTION
When interested in a way to get a handle of the result of the evaluation, eval-last-expression is not enough.  Not sure if there's a better way to do it, but just in case, here goes my solution.

Cheers