### PR TITLE
Use the eldoc-highlight-function-argument face for consistency

### DIFF
--- a/contrib/slime-autodoc.el
+++ b/contrib/slime-autodoc.el
@@ -103,7 +103,7 @@
       (let ((highlight (match-string 1)))
         ;; Can't use (replace-match highlight) here -- broken in Emacs 21
         (delete-region (match-beginning 0) (match-end 0))
-	(slime-insert-propertized '(face highlight) highlight)))
+	(slime-insert-propertized '(face eldoc-highlight-function-argument) highlight)))
     (buffer-substring (point-min) (point-max))))
 
 (define-obsolete-function-alias 'slime-fontify-string


### PR DESCRIPTION
ElDoc mode has been using its own `eldoc-highlight-function-argument` face for the argument at point in a function's argument list.