### PR TITLE
Enable goto source location to find definitions in jars

### DIFF
--- a/swank-abcl.lisp
+++ b/swank-abcl.lisp
@@ -492,12 +492,19 @@
 (defmethod source-location ((symbol symbol))
   (when (pathnamep (ext:source-pathname symbol))
     (let ((pos (ext:source-file-position symbol)))
-      `(:location
-        (:file ,(namestring (ext:source-pathname symbol)))
-        ,(if pos
-             (list :position (1+ pos))
-             (list :function-name (string symbol)))
-        (:align t)))))
+      (if (ext:pathname-jar-p (ext:source-pathname symbol))
+          `(:location
+            (:zip ,@(swank/abcl::split-string (subseq (namestring (ext:source-pathname symbol)) 9) "!/"))
+            ,(if nil;pos -- positions seem to be wrong. Just use function name
+                 (list :position (1+ pos))
+                 (list :function-name (string symbol)))
+            (:align t))
+          `(:location
+            (:file ,(namestring (ext:source-pathname symbol)))
+            ,(if pos
+                 (list :position (1+ pos))
+                 (list :function-name (string symbol)))
+            (:align t))))))
 
 (defmethod source-location ((frame sys::java-stack-frame))
   (destructuring-bind (&key class method file line) (sys:frame-to-list frame)


### PR DESCRIPTION
Some source locations in ABCL are recorded as being in jar files. This patch modifies swank-abcl to recognize this situation and use the form (:zip file entry) for the file portion of the location spec.  