### PR TITLE
Remove call to ASDF::OPERATION-FORCED.

### DIFF
--- a/swank.asd
+++ b/swank.asd
@@ -31,8 +31,8 @@
 (defmethod asdf:perform ((o asdf:load-op) (f swank-loader-file))
   (load (asdf::component-pathname f))
   (funcall (read-from-string "swank-loader::init")
-           :reload (asdf::operation-forced o)
-           :delete (asdf::operation-forced o)))
+           :reload nil
+           :delete nil))
 
 (asdf:defsystem :swank
   :default-component-class swank-loader-file


### PR DESCRIPTION
Please try to merge this directly.

The function `OPERATION-FORCED` is being removed from ASDF, and at any rate was never an API function.

Previously, this function always returned `NIL`, but that behavior breaks reloading swank.  Rather than "fixing" it by changing the function to always return `T`, we are going to simply remove it.