### PR TITLE
Properly handle number specializers in eldoc help

### DIFF
--- a/contrib/swank-arglists.lisp
+++ b/contrib/swank-arglists.lisp
@@ -412,6 +412,7 @@ Otherwise NIL is returned."
   "ARG can be a symbol or a destructuring pattern."
   (etypecase arg
     (symbol        arg)
+    (number        arg)
     (arglist-dummy arg)
     (list          (decode-arglist arg))))
 


### PR DESCRIPTION
I found that when I have a method with an `eql` specializer that happens to be a number, I (and some of my colleagues) notice an error similar to: `error in process filter: Wrong number of arguments: nil, 111`. One simple example triggering the error would be this:
```
(defmethod test ((a (eql 2)))
                      a)
```
The change in this push request solves the problem for number specializers.