### PR TITLE
Fix 'set-default-directory' function

### DIFF
--- a/swank/clasp.lisp
+++ b/swank/clasp.lisp
@@ -162,7 +162,7 @@
   (si:getpid))
 
 (defimplementation set-default-directory (directory)
-  (ext:chdir (namestring directory))  ; adapts *DEFAULT-PATHNAME-DEFAULTS*.
+  (ext:chdir (pathname directory))  ; adapts *DEFAULT-PATHNAME-DEFAULTS*.
   (default-directory))
 
 (defimplementation default-directory ()


### PR DESCRIPTION
Change 'namestring' to 'pathname' in 'set-default-directory' function because 'ext:chdir' accepts a filepath object, not a string