### PR TITLE
Make sure ASDF-SYSTEM-DIRECTORY returns physical pathname.

### DIFF
--- a/contrib/swank-asdf.lisp
+++ b/contrib/swank-asdf.lisp
@@ -452,7 +452,7 @@ already knows."
   (component-loaded-p name))
 
 (defslimefun asdf-system-directory (name)
-  (namestring (asdf:system-source-directory name)))
+  (namestring (translate-logical-pathname (asdf:system-source-directory name))))
 
 (defun pathname-system (pathname)
   (let ((component (pathname-component pathname)))


### PR DESCRIPTION
I fixed this to translate any logical pathnames in the ASDF system directory.  I found that if you don't do that, and this returns a logical pathname, `slime-browse-system` will try to merge the logical pathname with a physical pathname, and hilarity will ensue.
