### PR TITLE
Test that the object passed to VALID-OPERATOR-SYMBOL-P is a symbol.

### DIFF
--- a/contrib/swank-arglists.lisp
+++ b/contrib/swank-arglists.lisp
@@ -46,10 +46,11 @@ Otherwise NIL is returned."
 
 (defun valid-operator-symbol-p (symbol)
   "Is SYMBOL the name of a function, a macro, or a special-operator?"
-  (or (fboundp symbol)
-      (macro-function symbol)
-      (special-operator-p symbol)
-      (member symbol '(declare declaim))))
+  (and (symbolp symbol)
+       (or (fboundp symbol)
+           (macro-function symbol)
+           (special-operator-p symbol)
+           (member symbol '(declare declaim)))))
 
 (defun function-exists-p (form)
   (and (valid-function-name-p form)
@@ -1001,7 +1002,7 @@ If the arglist is not available, return :NOT-AVAILABLE."))
 (defgeneric arglist-dispatch (operator arguments)
   ;; Default method
   (:method (operator arguments)
-    (unless (and (symbolp operator) (valid-operator-symbol-p operator))
+    (unless (valid-operator-symbol-p operator)
       (return-from arglist-dispatch :not-available))
 
     (multiple-value-bind (decoded-arglist determining-args)
@@ -1254,7 +1255,7 @@ to the context provided by RAW-FORM."
        (yield-failure ()
          (values nil :not-available))
        (operator-p (operator local-ops)
-         (or (and (symbolp operator) (valid-operator-symbol-p operator))
+         (or (valid-operator-symbol-p operator)
              (assoc operator local-ops :test #'op=)))
        (op= (op1 op2)
          (cond ((and (symbolp op1) (symbolp op2))


### PR DESCRIPTION
It is sometimes passed a nonsymbol, and we don't want it to signal an
error.

To reproduce the issue, type this in the REPL: (apply (function foo)