### PR TITLE
Fix bug where packages where parsed as symbols.

### DIFF
--- a/swank.lisp
+++ b/swank.lisp
@@ -2779,8 +2779,13 @@ that symbols accessible in the current package go first."
       (describe object))))
 
 (defslimefun describe-symbol (symbol-name)
-  (with-buffer-syntax ()
-    (describe-to-string (parse-symbol-or-lose symbol-name))))
+  "Return description of a `symbol'. If SYMBOL-NAME
+   contains #\: then describe as a package."
+  (if (find #\: symbol-name)
+      (with-buffer-syntax ()
+        (describe-to-string (parse-package (string-right-trim ":" symbol-name))))
+      (with-buffer-syntax ()
+        (describe-to-string (parse-symbol-or-lose symbol-name)))))
 
 (defslimefun describe-function (name)
   (with-buffer-syntax ()


### PR DESCRIPTION
On trying to describe symbols ending with `#\:` using auto-completion tooltip the function `parse-symbol-or-loose` signals an error as it is not proper symbol. The calling function is `describe-symbol` has been modified to redirect to `parse-package`. See #337 