### PR TITLE
no point looking before the input mark (and occasionally ugly if you do)

### DIFF
--- a/contrib/slime-parse.el
+++ b/contrib/slime-parse.el
@@ -79,7 +79,12 @@ that the character is not escaped."
     ;; Don't parse more than 500 lines before point, so we don't spend
     ;; too much time. NB. Make sure to go to beginning of line, and
     ;; not possibly anywhere inside comments or strings.
-    (narrow-to-region (line-beginning-position -500) (point-max))
+    
+    (narrow-to-region 
+     (if (and (eq major-mode 'slime-repl-mode) ;; no point looking before the input start
+	      (boundp 'slime-repl-input-start-mark))
+	 (max (line-beginning-position -500) (marker-position slime-repl-input-start-mark))
+        (point-max)))
     (save-excursion
       (let ((suffix (list slime-cursor-marker)))
         (cond ((slime-compare-char-syntax #'char-after "(" t)


### PR DESCRIPTION
Autodoc uses this. Default is to try to parse up to 500 lines prior to point to find the containing function, in order to show the arglist. However if you are in the repl, there's no point in looking earlier than the input mark. Not doing so reduces slime traffic and gets rid of spurious errors.