### PR TITLE
fancy inspector improvements

### DIFF
--- a/slime.el
+++ b/slime.el
@@ -6236,6 +6236,11 @@ was called originally."
   "Face for labels in the inspector."
   :group 'slime-inspector)
 
+(defface slime-inspector-strong-face
+  '((t (:inherit slime-inspector-label-face)))
+  "Face for parts of values that are emphasized in the inspector."
+  :group 'slime-inspector)
+
 (defface slime-inspector-value-face
     '((t (:inherit font-lock-builtin-face)))
   "Face for things which can themselves be inspected."
@@ -6293,13 +6298,14 @@ KILL-BUFFER hooks for the inspector buffer."
     (let ((inhibit-read-only t))
       (erase-buffer)
       (pop-to-buffer (current-buffer))
+      (font-lock-mode -1)
       (cl-destructuring-bind (&key id title content) inspected-parts
         (cl-macrolet ((fontify (face string)
                                `(slime-inspector-fontify ,face ,string)))
           (slime-propertize-region
               (list 'slime-part-number id
                     'mouse-face 'highlight
-                    'face 'slime-inspector-value-face)
+                    'face 'slime-inspector-topline-face)
             (insert title))
           (while (eq (char-before) ?\n)
             (backward-delete-char 1))
@@ -6336,11 +6342,17 @@ If PREV resp. NEXT are true insert more-buttons as needed."
   (if (stringp ispec)
       (insert ispec)
     (slime-dcase ispec
-      ((:value string id)
+      ((:value string id )
        (slime-propertize-region
            (list 'slime-part-number id
                  'mouse-face 'highlight
                  'face 'slime-inspector-value-face)
+         (insert string)))
+      ((:strong-value string id )
+       (slime-propertize-region
+           (list 'slime-part-number id
+                 'mouse-face 'highlight
+                 'face 'slime-inspector-strong-face)
          (insert string)))
       ((:label string)
        (insert (slime-inspector-fontify label string)))

--- a/swank.lisp
+++ b/swank.lisp
@@ -3155,6 +3155,8 @@ DSPEC is a string and LOCATION a source location. NAME is a string."
               ((:newline) (list newline))
               ((:value obj &optional str) 
                (list (value-part obj str (istate.parts istate))))
+              ((:strong-value obj &optional str) 
+               (list (value-part obj str (istate.parts istate) t)))
               ((:label &rest strs)
                (list (list :label (apply #'cat (mapcar #'string strs)))))
               ((:action label lambda &key (refreshp t)) 
@@ -3165,10 +3167,10 @@ DSPEC is a string and LOCATION a source location. NAME is a string."
                      (value-part value nil (istate.parts istate))
                      newline)))))))
 
-(defun value-part (object string parts)
-  (list :value 
-        (or string (print-part-to-string object))
-        (assign-index object parts)))
+(defun value-part (object string parts &optional strong?)
+  (list (if strong? :strong-value  :value)
+            (or string (print-part-to-string object))
+            (assign-index object parts)))
 
 (defun action-part (label lambda refreshp actions)
   (list :action label (assign-index (list lambda refreshp) actions)))

--- a/swank/backend.lisp
+++ b/swank/backend.lisp
@@ -1225,7 +1225,7 @@ output of CL:DESCRIBE."
 (defun label-value-line (label value &key (newline t))
   "Create a control list which prints \"LABEL: VALUE\" in the inspector.
 If NEWLINE is non-NIL a `(:newline)' is added to the result."
-  (list* (princ-to-string label) ": " `(:value ,value)
+  (list* (list :label (princ-to-string label)) ": " `(:value ,value)
          (if newline '((:newline)) nil)))
 
 (defmacro label-value-line* (&rest label-values)


### PR DESCRIPTION
1) Adds some extra information for the symbol inspector - symbols with the same name in other packages
2) Labels, like "Function:" were plain text. Make them '(:label "Function") instead thereby telling the inspector to use the label face.
3) Add a :strong-view for elements in another style. I uses this in a java class inspector in abcl to highlight the function name in the longer string describing it. e.g.

"public abstract int java.io.InputStream.read() throws java.io.IOException" becomes
```elisp
`((:view ,method "public abstract int java.io.InputStream.") 
 (:strong-view ,method "read") 
 (:view ,method,  "() throws java.io.IOException"))
```
