### PR TITLE
Correct the customization type of lisp-loop-body-forms-indentation

### DIFF
--- a/contrib/slime-cl-indent.el
+++ b/contrib/slime-cl-indent.el
@@ -103,7 +103,7 @@ form, instead of the keyword position."
 
 (defcustom lisp-loop-body-forms-indentation 3
   "Indentation of loop body clauses."
-  :type 'boolean
+  :type 'integer
   :group 'lisp-indent)
 
 (defcustom lisp-loop-indent-forms-like-keywords nil


### PR DESCRIPTION
The `lisp-loop-body-forms-indentation` customization variable is of type `integer` but was wrongly specified as `boolean`.