### PR TITLE
ABCL introspect 201703a

### DIFF
--- a/swank-loader.lisp
+++ b/swank-loader.lisp
@@ -43,7 +43,7 @@
   #+lispworks '((swank lispworks) (swank gray))
   #+allegro '((swank allegro) (swank gray))
   #+clisp '(xref metering (swank clisp) (swank gray))
-  #+armedbear '((swank abcl))
+  #+armedbear '((swank abcl) xref)
   #+cormanlisp '((swank corman) (swank gray))
   #+ecl '((swank ecl) (swank gray))
   #+clasp '((swank clasp) (swank gray))

--- a/swank.lisp
+++ b/swank.lisp
@@ -3022,7 +3022,7 @@ DSPEC is a string and LOCATION a source location. NAME is a string."
 
 (defun xref>elisp (xref)
   (destructuring-bind (name loc) xref
-    (list (to-string name) loc)))
+    (list (if (stringp name) name (to-string name) ) loc)))
 
 
 ;;;;; Lazy lists


### PR DESCRIPTION
This pull request consolidates Alan Ruttenberg's Winter 2016 changes that drastically improve the inspection of code with the abcl implementation.

I have tested that this code works with both abcl-1.4.0 and abcl-1.5.0-dev (aka "abcl trunk").  

The code works independently of a bunch of SLIME additions from Alan Ruttenberg which will be issues a separate pull request (c.f. <https://github.com/slime/slime/pull/376>)
