### PR TITLE
Alan Ruttenberg 201703a

### DIFF
--- a/contrib/swank-fancy-inspector.lisp
+++ b/contrib/swank-fancy-inspector.lisp
@@ -9,6 +9,15 @@
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (swank-require :swank-util))
 
+(defun symbol-info (symbol)
+  (list (and (constantp symbol) (symbol-value symbol))
+	  (and (fboundp symbol) (symbol-function symbol))
+	  (and (boundp symbol) (symbol-value symbol))
+	  (and (find-class symbol nil) (find-class symbol))
+	  (find-package symbol)
+	  #+armedbear (get symbol 'sys::structure-definition)))
+
+    
 (defmethod emacs-inspect ((symbol symbol))
   (let ((package (symbol-package symbol)))
     (multiple-value-bind (_symbol status)
@@ -89,7 +98,43 @@
         ;; More package
         (if (find-package symbol)
             (label-value-line "It names the package" (find-package symbol)))
+
+	;; Same string
+	(lines-for-symbol-in-other-packages symbol)
+       
         (inspect-type-specifier symbol)))))
+
+(defun lines-for-symbol-in-other-packages (symbol)
+  (let ((others
+         (loop for p in (list-all-packages) 
+            for candidate = (find-symbol (string symbol) p) 
+            for found = (and (not (null candidate)) 
+                             (eq (symbol-package candidate) p)
+                             (not (eq (symbol-package symbol) (symbol-package candidate)))
+                             candidate)
+            for (constant function value class package structure) = (and found (symbol-info found))
+            for specs  = (and found
+                              (append (when value
+                                        `((:value ,value
+                                                  ,(if constant "constant" "bound") ", ")))
+                                      (when function
+                                        `((:value ,function "fbound" ", ")))
+                                      (when package
+                                        `((:value ,package "package" ", ")))
+                                      (when class
+                                        `((:value ,class "class") ", "))
+                                      (when structure
+                                        `((:value ,structure "structure") ", "))))
+            when found
+            collect
+              (let ((specs (butlast specs)))
+                (list* (list :value found (let ((*package* (find-package :keyword))) (format nil "~s" found)))
+                       (if specs ": " "")
+                       (append specs '((:newline))))))))
+    (if others
+        `("In other packages: " 
+          (:newline)  
+          ,@(apply 'append others)))))
 
 #-sbcl
 (defun inspect-type-specifier (symbol)

--- a/contrib/swank-fancy-inspector.lisp
+++ b/contrib/swank-fancy-inspector.lisp
@@ -48,9 +48,9 @@
         ;; Function
         (if (fboundp symbol)
             (append (if (macro-function symbol)
-                        `("It a macro with macro-function: "
+                        `((:label "It a macro with macro-function: ")
                           (:value ,(macro-function symbol)))
-                        `("It is a function: "
+                        `((:label "It is a function: ")
                           (:value ,(symbol-function symbol))))
                     `(" " (:action "[unbind]"
                                    ,(lambda () (fmakunbound symbol))))
@@ -70,8 +70,8 @@
         ;;
         ;; Package
         (if package
-            `("It is " ,(string-downcase (string status))
-                       " to the package: "
+            `((:label "It is ") (:label ,(string-downcase (string status)))
+	      (:label " to the package: ")
                        (:value ,package ,(package-name package))
                        ,@(if (eq :internal status)
                              `(" "
@@ -184,9 +184,9 @@
     (cond ((not docstring) nil)
           ((< (+ (length label) (length docstring))
               75)
-           (list label ": " docstring '(:newline)))
+           (list `(:label ,label) ": " docstring '(:newline)))
           (t
-           (list label ":" '(:newline) "  " docstring '(:newline))))))
+           (list `(:label ,label) ":" '(:newline) "  " docstring '(:newline))))))
 
 (unless (find-method #'emacs-inspect '() (list (find-class 'function)) nil)
   (defmethod emacs-inspect ((f function))
@@ -194,13 +194,13 @@
 
 (defun inspect-function (f)
   (append
-   (label-value-line "Name" (function-name f))
-   `("Its argument list is: "
+   (list '(:label "Name:") (function-name f) '(:newline))
+   `((:label "Argument list: ")
      ,(inspector-princ (arglist f)) (:newline))
    (docstring-ispec "Documentation" f t)
    (if (function-lambda-expression f)
        (label-value-line "Lambda Expression"
-                         (function-lambda-expression f)))))
+			 (function-lambda-expression f)))))
 
 (defun method-specializers-for-inspect (method)
   "Return a \"pretty\" list of the method's specializers. Normal
@@ -386,7 +386,7 @@ See `methods-by-applicability'.")
       ,@ (case (ref grouping-kind)
            (:all
             `((:newline)
-              "All Slots:"
+              (:label "All Slots:")
               (:newline)
               ,@(make-slot-listing checklist object class
                                    effective-slots direct-slots
@@ -496,7 +496,7 @@ See `methods-by-applicability'.")
 
 
 (defmethod emacs-inspect ((gf standard-generic-function))
-  (flet ((lv (label value) (label-value-line label value)))
+  (flet ((lv (label value) `((:label ,label)": " (:value  ,value ,(princ-to-string value)) (:newline))))
     (append
       (lv "Name" (swank-mop:generic-function-name gf))
       (lv "Arguments" (swank-mop:generic-function-lambda-list gf))
@@ -504,7 +504,7 @@ See `methods-by-applicability'.")
       (lv "Method class" (swank-mop:generic-function-method-class gf))
       (lv "Method combination"
           (swank-mop:generic-function-method-combination gf))
-      `("Methods: " (:newline))
+      `((:label "Methods: ") (:newline))
       (loop for method in (funcall *gf-method-getter* gf) append
             `((:value ,method ,(inspector-princ
                                ;; drop the name of the GF
@@ -520,7 +520,7 @@ See `methods-by-applicability'.")
 
 (defmethod emacs-inspect ((method standard-method))
   `(,@(if (swank-mop:method-generic-function method)
-          `("Method defined on the generic function "
+          `((:label "Method defined on the generic function ")
             (:value ,(swank-mop:method-generic-function method)
                     ,(inspector-princ
                       (swank-mop:generic-function-name
@@ -528,15 +528,15 @@ See `methods-by-applicability'.")
           '("Method without a generic function"))
       (:newline)
       ,@(docstring-ispec "Documentation" method t)
-      "Lambda List: " (:value ,(swank-mop:method-lambda-list method))
+      (:label "Lambda List: ") (:value ,(swank-mop:method-lambda-list method))
       (:newline)
-      "Specializers: " (:value ,(swank-mop:method-specializers method)
+      (:label "Specializers: ") (:value ,(swank-mop:method-specializers method)
                                ,(inspector-princ
                                  (method-specializers-for-inspect method)))
       (:newline)
-      "Qualifiers: " (:value ,(swank-mop:method-qualifiers method))
+      (:label "Qualifiers: ") (:value ,(swank-mop:method-qualifiers method))
       (:newline)
-      "Method function: " (:value ,(swank-mop:method-function method))
+      (:label "Method function: ") (:value ,(swank-mop:method-function method))
       (:newline)
       ,@(all-slots-for-inspector method)))
 
@@ -553,22 +553,22 @@ See `methods-by-applicability'.")
                  (second name)))))))
 
 (defmethod emacs-inspect ((class standard-class))
-  `("Name: "
+  `((:label "Name: ")
     (:value ,(class-name class))
     (:newline)
-    "Super classes: "
-    ,@(common-seperated-spec (swank-mop:class-direct-superclasses class))
+    (:label "Super classes: ")
+    ,@(common-separated-spec (swank-mop:class-direct-superclasses class))
     (:newline)
-    "Direct Slots: "
-    ,@(common-seperated-spec
+    (:label "Direct Slots: ")
+    ,@(common-separated-spec
        (swank-mop:class-direct-slots class)
        (lambda (slot)
          `(:value ,slot ,(inspector-princ
                           (swank-mop:slot-definition-name slot)))))
     (:newline)
-    "Effective Slots: "
+    (:label "Effective Slots: ")
     ,@(if (swank-mop:class-finalized-p class)
-          (common-seperated-spec
+          (common-separated-spec
            (swank-mop:class-slots class)
            (lambda (slot)
              `(:value ,slot ,(inspector-princ
@@ -579,16 +579,16 @@ See `methods-by-applicability'.")
     (:newline)
     ,@(let ((doc (documentation class t)))
         (when doc
-          `("Documentation:" (:newline) ,(inspector-princ doc) (:newline))))
+          `((:label "Documentation:") (:newline) ,(inspector-princ doc) (:newline))))
     "Sub classes: "
-    ,@(common-seperated-spec (swank-mop:class-direct-subclasses class)
+    ,@(common-separated-spec (swank-mop:class-direct-subclasses class)
                              (lambda (sub)
                                `(:value ,sub
                                         ,(inspector-princ (class-name sub)))))
     (:newline)
-    "Precedence List: "
+    (:label "Precedence List: ")
     ,@(if (swank-mop:class-finalized-p class)
-          (common-seperated-spec
+          (common-separated-spec
            (swank-mop:class-precedence-list class)
            (lambda (class)
              `(:value ,class ,(inspector-princ (class-name class)))))
@@ -599,16 +599,16 @@ See `methods-by-applicability'.")
           (:newline)
           ,@(loop
               for method in (specializer-direct-methods class)
+	      for method-spec = (method-for-inspect-value method)
               collect "  "
-              collect `(:value ,method
-                               ,(inspector-princ
-                                 (method-for-inspect-value method)))
+	      collect `(:value ,method ,(inspector-princ (car method-spec)))
+              collect `(:value ,method ,(format nil " (~{~a~^ ~})" (cdr method-spec)))
               collect '(:newline)
               if (documentation method t)
               collect "    Documentation: " and
               collect (abbrev-doc (documentation method t)) and
               collect '(:newline))))
-    "Prototype: " ,(if (swank-mop:class-finalized-p class)
+    (:label "Prototype: ") ,(if (swank-mop:class-finalized-p class)
                        `(:value ,(swank-mop:class-prototype class))
                        '"#<N/A (class not finalized)>")
     (:newline)
@@ -619,19 +619,19 @@ See `methods-by-applicability'.")
     (:value ,(swank-mop:slot-definition-name slot))
     (:newline)
     ,@(when (swank-mop:slot-definition-documentation slot)
-        `("Documentation:" (:newline)
+        `((:label "Documentation:") (:newline)
                            (:value ,(swank-mop:slot-definition-documentation
                                      slot))
                            (:newline)))
-    "Init args: "
+    (:label "Init args: ")
     (:value ,(swank-mop:slot-definition-initargs slot))
     (:newline)
-    "Init form: "
+    (:label "Init form: ")
     ,(if (swank-mop:slot-definition-initfunction slot)
          `(:value ,(swank-mop:slot-definition-initform slot))
          "#<unspecified>")
     (:newline)
-    "Init function: "
+    (:label "Init function: ")
     (:value ,(swank-mop:slot-definition-initfunction slot))
     (:newline)
     ,@(all-slots-for-inspector slot)))
@@ -806,21 +806,21 @@ SPECIAL-OPERATOR groups."
           external-symbols     (sort external-symbols #'string<)
           inherited-symbols    (sort inherited-symbols #'string<))
     `("" ;; dummy to preserve indentation.
-      "Name: " (:value ,package-name) (:newline)
+      (:label "Name: ") (:value ,package-name) (:newline)
 
-      "Nick names: " ,@(common-seperated-spec package-nicknames) (:newline)
+      (:label "Nick names: ") ,@(common-separated-spec package-nicknames) (:newline)
 
       ,@(when (documentation package t)
-          `("Documentation:" (:newline)
+          `((:label "Documentation:") (:newline)
                              ,(documentation package t) (:newline)))
 
-      "Use list: " ,@(common-seperated-spec
+      "Uses packages: " ,@(common-separated-spec
                       package-use-list
                       (lambda (package)
                         `(:value ,package ,(package-name package))))
       (:newline)
 
-      "Used by list: " ,@(common-seperated-spec
+      (:label "Used by packages: ") ,@(common-separated-spec
                           package-used-by-list
                           (lambda (package)
                             `(:value ,package ,(package-name package))))
@@ -1031,7 +1031,7 @@ SPECIAL-OPERATOR groups."
                 (make-file-stream-ispec stream))
               content))))
 
-(defun common-seperated-spec (list &optional (callback (lambda (v)
+(defun common-separated-spec (list &optional (callback (lambda (v)
                                                          `(:value ,v))))
   (butlast
    (loop

--- a/packages.lisp
+++ b/packages.lisp
@@ -60,6 +60,15 @@
            profile-reset
            profile-package
 
+	   with-struct*
+	   lcons
+	   lcons*
+	   lcons-cdr
+	   llist-range
+	   llist-skip
+	   llist-take
+	   iline
+
            with-collected-macro-forms))
 
 (defpackage swank/rpc

--- a/slime.el
+++ b/slime.el
@@ -3176,6 +3176,8 @@ you should check twice before modifying.")
        (set-buffer buffer)
        (goto-char (point-min))))))
 
+(defvar optional-package-regex "\\([[:word:]]+:\\{1,2\\}\\)\\{0,1\\}")
+
 (defun slime-goto-location-position (position)
   (slime-dcase position
     ((:position pos)
@@ -3195,10 +3197,10 @@ you should check twice before modifying.")
        (goto-char (point-min))
        (when (or
               (re-search-forward
-               (format "\\s *(def\\(\\s_\\|\\sw\\)*\\s +(*%s\\S_"
-                       (regexp-quote name)) nil t)
+               (format "\\s *(%sdef\\(\\s_\\|\\sw\\)*\\s +(*%s%s\\S_"
+                       optional-package-regex optional-package-regex (regexp-quote name)) nil t)
               (re-search-forward
-               (format "[( \t]%s\\>\\(\\s \\|$\\)" name) nil t))
+               (format "[( \t]%s%s\\>\\(\\s \\|$\\)" optional-package-regex name) nil t))
          (goto-char (match-beginning 0)))))
     ((:method name specializers &rest qualifiers)
      (slime-search-method-location name specializers qualifiers))
@@ -3230,27 +3232,33 @@ you should check twice before modifying.")
   ;; qualifers specializers don't look for "T" since it isn't requires
   ;; (arg without t) as class is taken as such.
   (let* ((case-fold-search t)
-         (name (regexp-quote name))
+         (name  (regexp-quote name))
          (qualifiers (mapconcat (lambda (el) (concat ".+?\\<" el "\\>"))
                                 qualifiers ""))
-         (specializers (mapconcat
-                        (lambda (el)
-                          (if (eql (aref el 0) ?\()
-                              (let ((spec (read el)))
-                                (if (eq (car spec) 'EQL)
-                                    (concat
-                                     ".*?\\n\\{0,1\\}.*?(EQL.*?'\\{0,1\\}"
-                                     (format "%s" (cl-second spec)) ")")
-                                  (error "don't understand specializer: %s,%s"
-                                         el (car spec))))
-                            (concat ".+?\n\\{0,1\\}.+?\\<" el "\\>")))
-                        (remove "T" specializers) ""))
-         (regexp (format "\\s *(def\\(\\s_\\|\\sw\\)*\\s +%s\\s +%s%s" name
-                         qualifiers specializers)))
-    (or (and (re-search-forward regexp  nil t)
-             (goto-char (match-beginning 0)))
-        ;;	(slime-goto-location-position `(:function-name ,name))
-        )))
+	 (specializers (mapconcat
+			(lambda (el)
+			  (if (eql (aref el 0) ?\()
+			      (let ((spec (read el)))
+				(if (eq (car spec) 'EQL)
+				    (concat
+				     ".*?\\n\\{0,1\\}.*?(EQL.*?'\\{0,1\\}"
+				     (format "%s" (cl-second spec)) ")")
+				    (error "don't understand specializer: %s,%s"
+					   el (car spec))))
+			      (concat ".*?\\n\\{0,1\\}.*?\\<" el "\\>")))
+			(subst "[[:word:]]+" "t" specializers :test 'equalp) ""))
+	 (regexp (format "\\s *(%sdef\\(\\s_\\|\\sw\\)*\\s +%s%s\\s +%s%s" 
+			 optional-package-regex 
+			 optional-package-regex name
+			 qualifiers specializers)))
+    (or (and 
+	 (re-search-forward regexp  nil t)
+	 (goto-char (match-beginning 0)))
+	(and 
+	 (re-search-backward regexp  nil t)
+	 (goto-char (match-beginning 0)))
+	;;	(slime-goto-location-position `(:function-name ,name))
+	)))
 
 (defun slime-search-call-site (fname)
   "Move to the place where FNAME called.

--- a/slime.el
+++ b/slime.el
@@ -6236,6 +6236,11 @@ was called originally."
   "Face for labels in the inspector."
   :group 'slime-inspector)
 
+(defface slime-inspector-strong-face
+  '((t (:inherit slime-inspector-label-face)))
+  "Face for parts of values that are emphasized in the inspector."
+  :group 'slime-inspector)
+
 (defface slime-inspector-value-face
     '((t (:inherit font-lock-builtin-face)))
   "Face for things which can themselves be inspected."
@@ -6293,13 +6298,14 @@ KILL-BUFFER hooks for the inspector buffer."
     (let ((inhibit-read-only t))
       (erase-buffer)
       (pop-to-buffer (current-buffer))
+      (font-lock-mode -1)
       (cl-destructuring-bind (&key id title content) inspected-parts
         (cl-macrolet ((fontify (face string)
                                `(slime-inspector-fontify ,face ,string)))
           (slime-propertize-region
               (list 'slime-part-number id
                     'mouse-face 'highlight
-                    'face 'slime-inspector-value-face)
+                    'face 'slime-inspector-topline-face)
             (insert title))
           (while (eq (char-before) ?\n)
             (backward-delete-char 1))
@@ -6336,11 +6342,17 @@ If PREV resp. NEXT are true insert more-buttons as needed."
   (if (stringp ispec)
       (insert ispec)
     (slime-dcase ispec
-      ((:value string id)
+      ((:value string id )
        (slime-propertize-region
            (list 'slime-part-number id
                  'mouse-face 'highlight
                  'face 'slime-inspector-value-face)
+         (insert string)))
+      ((:strong-value string id )
+       (slime-propertize-region
+           (list 'slime-part-number id
+                 'mouse-face 'highlight
+                 'face 'slime-inspector-strong-face)
          (insert string)))
       ((:label string)
        (insert (slime-inspector-fontify label string)))

--- a/slime.el
+++ b/slime.el
@@ -3890,6 +3890,7 @@ WHAT can be:
   A filename (string),
   A list (:filename FILENAME &key LINE COLUMN POSITION),
   A function name (:function-name STRING)
+  A string (:string STRING)
   nil.
 
 This is for use in the implementation of COMMON-LISP:ED."
@@ -3908,7 +3909,13 @@ This is for use in the implementation of COMMON-LISP:ED."
                         (byte-to-position position)
                       position))))
       ((:function-name name)
-       (slime-edit-definition name)))))
+       (slime-edit-definition name))
+      ((:string string)
+       (with-output-to-temp-buffer "*edit-string*"
+         (switch-to-buffer "*edit-string*")
+         (princ string)
+         (fundamental-mode)
+         (setq buffer-read-only nil))))))
 
 (defun slime-goto-line (line-number)
   "Move to line LINE-NUMBER (1-based).

--- a/swank-loader.lisp
+++ b/swank-loader.lisp
@@ -240,7 +240,7 @@ If LOAD is true, load the fasl file."
 
 (defvar *swank-files*
   `(packages
-    (swank backend) ,@*sysdep-files* (swank match) (swank rpc)
+    (swank backend)  (swank match) (swank rpc) ,@*sysdep-files*
     swank))
 
 (defvar *contribs*

--- a/swank.lisp
+++ b/swank.lisp
@@ -501,17 +501,6 @@ corresponding values in the CDR of VALUE."
   (check-type msg string)
   `(call-with-retry-restart ,msg (lambda () ,@body)))
 
-(defmacro with-struct* ((conc-name get obj) &body body)
-  (let ((var (gensym)))
-    `(let ((,var ,obj))
-       (macrolet ((,get (slot)
-                    (let ((getter (intern (concatenate 'string
-                                                       ',(string conc-name)
-                                                       (string slot))
-                                          (symbol-package ',conc-name))))
-                      `(,getter ,',var))))
-         ,@body))))
-
 (defmacro define-special (name doc)
   "Define a special variable NAME with doc string DOC.
 This is like defvar, but NAME will not be initialized."
@@ -3026,52 +3015,6 @@ DSPEC is a string and LOCATION a source location. NAME is a string."
 (defun xref>elisp (xref)
   (destructuring-bind (name loc) xref
     (list (to-string name) loc)))
-
-
-;;;;; Lazy lists
-
-(defstruct (lcons (:constructor %lcons (car %cdr))
-                  (:predicate lcons?))
-  car
-  (%cdr nil :type (or null lcons function))
-  (forced? nil))
-
-(defmacro lcons (car cdr)
-  `(%lcons ,car (lambda () ,cdr)))
-
-(defmacro lcons* (car cdr &rest more)
-  (cond ((null more) `(lcons ,car ,cdr))
-        (t `(lcons ,car (lcons* ,cdr ,@more)))))
-
-(defun lcons-cdr (lcons)
-  (with-struct* (lcons- @ lcons)
-    (cond ((@ forced?)
-           (@ %cdr))
-          (t
-           (let ((value (funcall (@ %cdr))))
-             (setf (@ forced?) t
-                   (@ %cdr) value))))))
-
-(defun llist-range (llist start end)
-  (llist-take (llist-skip llist start) (- end start)))
-
-(defun llist-skip (lcons index)
-  (do ((i 0 (1+ i))
-       (l lcons (lcons-cdr l)))
-      ((or (= i index) (null l))
-       l)))
-
-(defun llist-take (lcons count)
-  (let ((result '()))
-    (do ((i 0 (1+ i))
-         (l lcons (lcons-cdr l)))
-        ((or (= i count)
-             (null l)))
-      (push (lcons-car l) result))
-    (nreverse result)))
-
-(defun iline (label value)
-  `(:line ,label ,value))
 
 
 ;;;; Inspecting

--- a/swank.lisp
+++ b/swank.lisp
@@ -1948,14 +1948,17 @@ N.B. this is not an actual package name or nickname."
 
 WHAT can be:
   A pathname or a string,
+  A literal string (:string STRING)
   A list (PATHNAME-OR-STRING &key LINE COLUMN POSITION),
   A function name (symbol or cons),
   NIL. "
   (flet ((canonicalize-filename (filename)
            (pathname-to-filename (or (probe-file filename) filename))))
     (let ((target 
-           (etypecase what
-             (null nil)
+            (etypecase what
+              (null nil)
+              ((cons (eql :string) (cons string))
+               what)
              ((or string pathname) 
               `(:filename ,(canonicalize-filename what)))
              ((cons (or string pathname) *)
@@ -3162,6 +3165,8 @@ DSPEC is a string and LOCATION a source location. NAME is a string."
   (let ((newline '#.(string #\newline)))
     (etypecase part
       (string (list part))
+      ((cons (eql :multiple))
+       (mapcan (lambda(p) (prepare-part p istate)) (cdr part)))
       (cons (dcase part
               ((:newline) (list newline))
               ((:value obj &optional str) 
@@ -3174,7 +3179,7 @@ DSPEC is a string and LOCATION a source location. NAME is a string."
                (list (action-part label lambda refreshp
                                   (istate.actions istate))))
               ((:line label value)
-               (list (princ-to-string label) ": "
+               (list `(:label ,(princ-to-string label)) ": "
                      (value-part value nil (istate.parts istate))
                      newline)))))))
 
@@ -3406,7 +3411,7 @@ Return NIL if LIST is circular."
    (iline "Adjustable" (adjustable-array-p array))
    (iline "Fill pointer" (if (array-has-fill-pointer-p array)
                              (fill-pointer array)))
-   "Contents:" '(:newline)
+   `(:label "Contents:") '(:newline)
    (labels ((k (i max)
               (cond ((= i max) '())
                     (t (lcons (iline i (row-major-aref array i))

--- a/swank.lisp
+++ b/swank.lisp
@@ -3166,6 +3166,8 @@ DSPEC is a string and LOCATION a source location. NAME is a string."
               ((:newline) (list newline))
               ((:value obj &optional str) 
                (list (value-part obj str (istate.parts istate))))
+              ((:strong-value obj &optional str) 
+               (list (value-part obj str (istate.parts istate) t)))
               ((:label &rest strs)
                (list (list :label (apply #'cat (mapcar #'string strs)))))
               ((:action label lambda &key (refreshp t)) 
@@ -3176,10 +3178,10 @@ DSPEC is a string and LOCATION a source location. NAME is a string."
                      (value-part value nil (istate.parts istate))
                      newline)))))))
 
-(defun value-part (object string parts)
-  (list :value 
-        (or string (print-part-to-string object))
-        (assign-index object parts)))
+(defun value-part (object string parts &optional strong?)
+  (list (if strong? :strong-value  :value)
+            (or string (print-part-to-string object))
+            (assign-index object parts)))
 
 (defun action-part (label lambda refreshp actions)
   (list :action label (assign-index (list lambda refreshp) actions)))

--- a/swank.lisp
+++ b/swank.lisp
@@ -120,6 +120,9 @@ Backend code should treat the connection structure as opaque.")
 (defvar *after-init-hook* '()
   "Hook run after user init files are loaded.")
 
+(defvar *find-definitions-all-packages* nil
+  "If t then find-definitions will be called even if there is no symbol in the current package")
+
 
 ;;;; Connections
 ;;;
@@ -2974,8 +2977,10 @@ If non-nil, called with two arguments SPEC and TRACED-P." )
 DSPEC is a string and LOCATION a source location. NAME is a string."
   (multiple-value-bind (symbol found)
       (find-definitions-find-symbol-or-package name)
-    (when found
-      (mapcar #'xref>elisp (find-definitions symbol)))))
+    (if *find-definitions-all-packages*
+        (mapcar #'xref>elisp (find-definitions (or symbol name)))
+        (when found 
+          (mapcar #'xref>elisp (find-definitions (or symbol name)))))))
 
 ;;; Generic function so contribs can extend it.
 (defgeneric xref-doit (type thing)

--- a/swank/backend.lisp
+++ b/swank/backend.lisp
@@ -1183,6 +1183,63 @@ SPEC can be:
 
 ;;;; Inspector
 
+(defmacro with-struct* ((conc-name get obj) &body body)
+  (let ((var (gensym)))
+    `(let ((,var ,obj))
+       (macrolet ((,get (slot)
+                    (let ((getter (intern (concatenate 'string
+                                                       ',(string conc-name)
+                                                       (string slot))
+                                          (symbol-package ',conc-name))))
+                      `(,getter ,',var))))
+         ,@body))))
+
+;;;;; Lazy lists (moved from swank.lisp)
+
+(defstruct (lcons (:constructor %lcons (car %cdr))
+                  (:predicate lcons?))
+  car
+  (%cdr nil :type (or null lcons function))
+  (forced? nil))
+
+(defmacro lcons (car cdr)
+  `(%lcons ,car (lambda () ,cdr)))
+
+(defmacro lcons* (car cdr &rest more)
+  (cond ((null more) `(lcons ,car ,cdr))
+        (t `(lcons ,car (lcons* ,cdr ,@more)))))
+
+(defun lcons-cdr (lcons)
+  (with-struct* (lcons- @ lcons)
+    (cond ((@ forced?)
+           (@ %cdr))
+          (t
+           (let ((value (funcall (@ %cdr))))
+             (setf (@ forced?) t
+                   (@ %cdr) value))))))
+
+(defun llist-range (llist start end)
+  (llist-take (llist-skip llist start) (- end start)))
+
+(defun llist-skip (lcons index)
+  (do ((i 0 (1+ i))
+       (l lcons (lcons-cdr l)))
+      ((or (= i index) (null l))
+       l)))
+
+(defun llist-take (lcons count)
+  (let ((result '()))
+    (do ((i 0 (1+ i))
+         (l lcons (lcons-cdr l)))
+        ((or (= i count)
+             (null l)))
+      (push (lcons-car l) result))
+    (nreverse result)))
+
+(defun iline (label value)
+  `(:line ,label ,value))
+
+
 (defgeneric emacs-inspect (object)
   (:documentation
    "Explain to Emacs how to inspect OBJECT.

--- a/swank/backend.lisp
+++ b/swank/backend.lisp
@@ -1225,7 +1225,7 @@ output of CL:DESCRIBE."
 (defun label-value-line (label value &key (newline t))
   "Create a control list which prints \"LABEL: VALUE\" in the inspector.
 If NEWLINE is non-NIL a `(:newline)' is added to the result."
-  (list* (princ-to-string label) ": " `(:value ,value)
+  (list* (list :label (princ-to-string label)) ": " `(:value ,value)
          (if newline '((:newline)) nil)))
 
 (defmacro label-value-line* (&rest label-values)


### PR DESCRIPTION
This merge consolidates Alan Ruttenberg's work on non-abcl specific portions of SLIME.
@easye vouches that these changes work well with ABCL, (and other popular open CL implementations SBCL, CCL, ECL) when rebased against https://github.com/slime/slime/tree/master

These patches include:


FIXES
------

1. Fixes for searching for functions and methods


ENHANCEMENTS
------------------

1. Load swank matcher earlier so that it may be used by implementation-specific code (has architectural issues for SLIME loader vs. swank.lisp availablity to reuse between implementation specific code)

2. Refactor utilties used by implementation-specific inspector code into swank/backend.lisp

3. Add an inspector :strong-view for a view with a bolder face

4. Strings may edited in an emacs buffer from the inspector 

5. Return information for definitions even if the symbol isn't found in the current package if the ```*find-definitions-all-packages*``` special  is set to non-nil.  By default it is set to nil, but currently the SLIME inspector still offers a visualization (TODO: verify)

