### PR TITLE
Add support for slime-eval-print-last-expression for Kawa scheme

### DIFF
--- a/contrib/swank-kawa.scm
+++ b/contrib/swank-kawa.scm
@@ -809,6 +809,12 @@
          (l (values-to-list (eval form env))))
     (apply cat (map pprint-to-string l))))
 
+(defslimefun eval-and-grab-output (env string)
+  (let ((form (read (open-input-string string))))
+    (let-values ((values (eval form env)))
+      (list ""
+	    (format #f "~{~S~^~%~}" values)))))
+
 (df call-with-abort (f)
   (try-catch (f) (ex <throwable> (exception-message ex))))
 


### PR DESCRIPTION
This PR implements eval-and-grab-output in contrib/swank-kawa.scm, allowing for slime-eval-print-last-expression to work when using slime with Kawa scheme.

Note that this implementation does not capture values printed to
standard output. It is not clear that dynamically rebinding the
standard output port is possible in Kawa.