### PR TITLE
Issue#379 Remove bindings on SPC

### DIFF
--- a/contrib/slime-autodoc.el
+++ b/contrib/slime-autodoc.el
@@ -172,8 +172,7 @@ If it's not in the cache, the cache will be updated asynchronously."
   "Toggle echo area display of Lisp objects at point."
   :keymap (let ((prefix (slime-autodoc--doc-map-prefix)))
 	    `((,(concat prefix "A") . slime-autodoc-manually)
-	      (,(concat prefix (kbd "C-A")) . slime-autodoc-manually)
-	      (,(kbd "SPC") . slime-autodoc-space)))
+	      (,(concat prefix (kbd "C-A")) . slime-autodoc-manually)))
   (set (make-local-variable 'eldoc-documentation-function) 'slime-autodoc)
   (set (make-local-variable 'eldoc-minor-mode-string) " adoc")
   (setq slime-autodoc-mode (eldoc-mode arg))

--- a/slime.el
+++ b/slime.el
@@ -533,9 +533,7 @@ information."
 edit s-exprs, e.g. for source buffers and the REPL.")
 
 (defvar slime-editing-keys
-  `(;; Arglist display & completion
-    (" "          slime-space)
-    ;; Evaluating
+  `(;; Evaluating
     ;;("\C-x\M-e" slime-eval-last-expression-display-output :inferior t)
     ("\C-c\C-p"   slime-pprint-eval-last-expression)
     ;; Macroexpand


### PR DESCRIPTION
The explicit bindings on SPC are not strictly necessary in order to
display the arglist in the echo area thanks to the hook registered
with eldoc. Furthermore, these bindings may conflict with other modes
like parinfer, which relies on SPC being a self-insert-command to work
properly, and so these bindings are dropped.

## Notes
* I didn't succeed in my first attempt to run the tests with `make check`, so I haven't yet verified that I'm not breaking anything.
* I'm not sure if the slime-space could also be dropped because it's referenced in a line like this:
```(put 'slime-space 'delete-selection t) ; for delete-section-mode & CUA```