### PR TITLE
ecl improvements

### DIFF
--- a/slime.el
+++ b/slime.el
@@ -1316,6 +1316,7 @@ The default condition handler for timer functions (see
     "May the source be with you!"
     "Take this REPL, brother, and may it serve you well."
     "Lemonodor-fame is but a hack away!"
+    "Are we consing yet?"
     ,(format "%s, this could be the start of a beautiful program."
              (slime-user-first-name)))
   "Scientifically-proven optimal words of hackerish encouragement.")

--- a/swank/ecl.lisp
+++ b/swank/ecl.lisp
@@ -253,16 +253,9 @@
 
 ;;;; Packages
 
-;;; Returns an alist of (local-nickname . actual-package) describing the
-;;; nicknames local to the designated package.
-;;;
-;;;   package-local-nicknames (package)
-
-;;; Return the package whose local nickname in BASE-PACKAGE matches NAME.
-;;; Return NIL if local nicknames are not implemented or if there is no
-;;; such package.
-;;;
-;;;  find-locally-nicknamed-package (name base-package)
+#+package-local-nicknames
+(defimplementation package-local-nicknames (package)
+  (ext:package-local-nicknames package))
 
 
 ;;;; Compilation

--- a/swank/ecl.lisp
+++ b/swank/ecl.lisp
@@ -129,9 +129,10 @@
 ;;;   remove-fd-handlers (socket)
 
 (defimplementation preferred-communication-style ()
-  #.(if (>= ext:+ecl-version-number+ 160104)
-        :spawn
-        nil))
+  (cond
+    ((member :threads *features*) :spawn)
+    ((member :windows *features*) nil)
+    (t #|:fd-handler|# nil)))
 
 ;;; Set the 'stream 'timeout.  The timeout is either the real number
 ;;; specifying the timeout in seconds or 'nil for no timeout.
@@ -978,9 +979,7 @@
                (setf (mailbox.queue mbox) (nconc (ldiff q tail) (cdr tail)))
                (return (car tail))))
            (when (eq timeout t) (return (values nil t)))
-           (mp:condition-variable-timedwait (mailbox.cvar mbox)
-                                            mutex
-                                            0.2)))))
+           (mp:condition-variable-wait (mailbox.cvar mbox) mutex)))))
 
   ;; Trigger a call to CHECK-SLIME-INTERRUPTS in THREAD without using
   ;; asynchronous interrupts.

--- a/swank/ecl.lisp
+++ b/swank/ecl.lisp
@@ -861,3 +861,17 @@
   (declare (type function function))
   (mp:with-lock (lock) (funcall function)))
 
+
+;;; Weak datastructures
+
+#+ecl-weak-hash
+(progn
+  (defimplementation make-weak-key-hash-table (&rest args)
+    (apply #'make-hash-table :weakness :key args))
+
+  (defimplementation make-weak-value-hash-table (&rest args)
+    (apply #'make-hash-table :weakness :value args))
+
+  (defimplementation hash-table-weakness (hashtable)
+    (ext:hash-table-weakness hashtable)))
+

--- a/swank/ecl.lisp
+++ b/swank/ecl.lisp
@@ -996,6 +996,25 @@
   ;;
   ;;   wake-thread (thread)
 
+  ;; Copied from sbcl.lisp and adjusted to ECL.
+  (let ((alist '())
+        (mutex (mp:make-lock :name "register-thread")))
+
+    (defimplementation register-thread (name thread)
+      (declare (type symbol name))
+      (mp:with-lock (mutex)
+        (etypecase thread
+          (null
+           (setf alist (delete name alist :key #'car)))
+          (mp:process
+           (let ((probe (assoc name alist)))
+             (cond (probe (setf (cdr probe) thread))
+                   (t (setf alist (acons name thread alist))))))))
+      nil)
+
+    (defimplementation find-registered (name)
+      (mp:with-lock (mutex)
+        (cdr (assoc name alist)))))
 
   ;; Not needed in ECL (?).
   ;;

--- a/swank/ecl.lisp
+++ b/swank/ecl.lisp
@@ -118,6 +118,8 @@
 
 ;;;; Unix Integration
 
+(defimplementation getpid ()
+  (si:getpid))
 ;;; If ECL is built with thread support, it'll spawn a helper thread
 ;;; executing the SIGINT handler. We do not want to BREAK into that
 ;;; helper but into the main thread, though. This is coupled with the

--- a/swank/ecl.lisp
+++ b/swank/ecl.lisp
@@ -411,10 +411,9 @@
 ;;; 
 ;;; valid-function-name-p (form)
 
-;;; Recursively expand all macros in FORM.
-;;; Return the resulting form.
-;;;
-;;;   macroexpand-all (form &optional env)
+#+walker
+(defimplementation macroexpand-all (form &optional env)
+  (walker:macroexpand-all form env))
 
 ;;; Default implementation is fine.
 ;;;


### PR DESCRIPTION
General cleanup of ecl.lisp backend file.

Most notable changes:
- spawn is preferred communication style for threaded environment (nil otherwise)
- sentinel thread should work (register/find-thread are implemented)
- swank functions aren't shown in the backtrace
- order of interface implementation matches backend.lisp file
- implementation for `macroexpand-all` has been added
- added package local nicknames implementation