### PR TITLE
ecl: non-threaded build doesn't have mp:make-lock interface

### DIFF
--- a/swank/ecl.lisp
+++ b/swank/ecl.lisp
@@ -1046,6 +1046,7 @@
 
 ;;;; Locks
 
+#+threads
 (defimplementation make-lock (&key name)
   (mp:make-lock :name name :recursive t))
 


### PR DESCRIPTION
Add feature check for non-threaded builds.