### PR TITLE
Do not perform arithmetic operations with NaN in SBCL

### DIFF
--- a/contrib/swank-fancy-inspector.lisp
+++ b/contrib/swank-fancy-inspector.lisp
@@ -936,12 +936,14 @@ SPECIAL-OPERATOR groups."
 
 (defmethod emacs-inspect ((f float))
   (cond
+    ((or #+sbcl
+         (sb-ext:float-nan-p f)
+         (not (= f f)))
+     (list "Not a Number."))
     ((> f most-positive-long-float)
      (list "Positive infinity."))
     ((< f most-negative-long-float)
      (list "Negative infinity."))
-    ((not (= f f))
-     (list "Not a Number."))
     (t
      (multiple-value-bind (significand exponent sign) (decode-float f)
        (append


### PR DESCRIPTION
Calling (= F F) or (> F ...) when F is NaN throws an arithmetic
exception in SBCL. Instead, we use the built-in predicate.