### PR TITLE
Define an interface for detecting float NaN and Infinity

### DIFF
--- a/contrib/swank-fancy-inspector.lisp
+++ b/contrib/swank-fancy-inspector.lisp
@@ -936,15 +936,11 @@ SPECIAL-OPERATOR groups."
 
 (defmethod emacs-inspect ((f float))
   (cond
-    ((or #+sbcl
-         (sb-ext:float-nan-p f)
-         (not (= f f)))
+    ((float-nan-p f)
+     ;; try NaN first because the next tests may perform operations
+     ;; that are undefined for NaNs.
      (list "Not a Number."))
-    ((> f most-positive-long-float)
-     (list "Positive infinity."))
-    ((< f most-negative-long-float)
-     (list "Negative infinity."))
-    (t
+    ((not (float-infinity-p f))
      (multiple-value-bind (significand exponent sign) (decode-float f)
        (append
 	`("Scientific: " ,(format nil "~E" f) (:newline)
@@ -954,7 +950,11 @@ SPECIAL-OPERATOR groups."
 			 (:value ,(float-radix f)) "^"
 			 (:value ,exponent) (:newline))
 	(label-value-line "Digits" (float-digits f))
-	(label-value-line "Precision" (float-precision f)))))))
+	(label-value-line "Precision" (float-precision f)))))
+    ((> f 0)
+     (list "Positive infinity."))
+    ((< f 0)
+     (list "Negative infinity."))))
 
 (defun make-pathname-ispec (pathname position)
   `("Pathname: "

--- a/swank/backend.lisp
+++ b/swank/backend.lisp
@@ -1403,6 +1403,22 @@ but that thread may hold it more than once."
   nil)
 
 
+;;;; Floating point
+
+(definterface float-nan-p (float)
+  "Return true if FLOAT is a NaN value (Not a Number)."
+  ;; When the float type implements IEEE-754 floats, two NaN values
+  ;; are never equal; when the implementation does not support NaN,
+  ;; the predicate should return false.
+  (not (= float float)))
+
+(definterface float-infinity-p (float)
+  "Return true if FLOAT is positive or negative infinity."
+  (not (< most-negative-long-float
+          float
+          most-positive-long-float)))
+
+
 ;;;; Character names
 
 (definterface character-completion-set (prefix matchp)

--- a/swank/sbcl.lisp
+++ b/swank/sbcl.lisp
@@ -1889,6 +1889,14 @@ stack."
   #+#.(swank/sbcl::sbcl-with-weak-hash-tables)
   (sb-ext:hash-table-weakness hashtable))
 
+;;; Floating point
+
+(defimplementation float-nan-p (float)
+  (sb-ext:float-nan-p float))
+
+(defimplementation float-infinity-p (float)
+  (sb-ext:float-infinity-p float))
+
 #-win32
 (defimplementation save-image (filename &optional restart-function)
   (flet ((restart-sbcl ()


### PR DESCRIPTION
Let implementation provide specialized functions for detecting special floating point values.

Maybe the portability layer could be implemented in IEEE-FLOATS[1], in which case Slime would have to  depend on that library. I don't know which way is the best.

[1] See issue https://github.com/marijnh/ieee-floats/issues/5