### PR TITLE
Error while loading slime because of accent

### DIFF
--- a/contrib/swank-macrostep.lisp
+++ b/contrib/swank-macrostep.lisp
@@ -1,6 +1,6 @@
 ;;; swank-macrostep.lisp -- fancy macro-expansion via macrostep.el
 ;;
-;; Authors: Luís Oliveira <luismbo@gmail.com>
+;; Authors: Luis Oliveira <luismbo@gmail.com>
 ;;          Jon Oddie <j.j.oddie@gmail.com>
 ;;
 ;; License: Public Domain


### PR DESCRIPTION
The accentuated i in LUIS, in line 3 causes a forced break in ubuntu 16 (bash mode).

![image](https://user-images.githubusercontent.com/7820699/34333992-233a5eac-e910-11e7-8970-bdbbd5085106.png)

after fixing the i it becomes normal:

![image](https://user-images.githubusercontent.com/7820699/34334004-4a1aa950-e910-11e7-9332-0ffb89821d95.png)
