### PR TITLE
Document * variable in inspector.

### DIFF
--- a/doc/slime.texi
+++ b/doc/slime.texi
@@ -1220,7 +1220,7 @@ Describe the slot at point.
 
 @kbditem{e, slime-inspector-eval}
 Evaluate an expression in the context of the inspected object.  The
-variable @t{*} will be bound to the inspected object.
+variable @code{*} will be bound to the inspected object.
 
 @kbditem{v, slime-inspector-toggle-verbose}
 Toggle between verbose and terse mode. Default is determined by

--- a/doc/slime.texi
+++ b/doc/slime.texi
@@ -1219,7 +1219,8 @@ value. If point is on an action then call that action.
 Describe the slot at point.
 
 @kbditem{e, slime-inspector-eval}
-Evaluate an expression in the context of the inspected object.
+Evaluate an expression in the context of the inspected object.  The
+variable @t{*} will be bound to the inspected object.
 
 @kbditem{v, slime-inspector-toggle-verbose}
 Toggle between verbose and terse mode. Default is determined by

--- a/slime.el
+++ b/slime.el
@@ -6518,7 +6518,8 @@ If ARG is negative, move forwards."
   (slime-eval-describe `(swank:pprint-inspector-part ,part)))
 
 (defun slime-inspector-eval (string)
-  "Eval an expression in the context of the inspected object."
+  "Eval an expression in the context of the inspected object.
+The \"*\" variable will be bound to the inspected object."
   (interactive (list (slime-read-from-minibuffer "Inspector eval: ")))
   (slime-eval-with-transcript `(swank:inspector-eval ,string)))
 

--- a/slime.el
+++ b/slime.el
@@ -6519,7 +6519,7 @@ If ARG is negative, move forwards."
 
 (defun slime-inspector-eval (string)
   "Eval an expression in the context of the inspected object.
-The \"*\" variable will be bound to the inspected object."
+The `*' variable will be bound to the inspected object."
   (interactive (list (slime-read-from-minibuffer "Inspector eval: ")))
   (slime-eval-with-transcript `(swank:inspector-eval ,string)))
 


### PR DESCRIPTION
Explain how the `*` variable is used when evaluating expressions in the slime inspector.  Trivial documentation patch.