### PR TITLE
Call swank:inspector-call-nth-action with a single colon, not ::

### DIFF
--- a/slime.el
+++ b/slime.el
@@ -6405,7 +6405,7 @@ that value.
         (slime-range-button
          (slime-inspector-fetch-more value))
         (slime-action-number
-         (slime-eval-async `(swank::inspector-call-nth-action ,value)
+         (slime-eval-async `(swank:inspector-call-nth-action ,value)
            opener))
         (t (error "No object at point"))))))
 


### PR DESCRIPTION
`inspector-call-nth-action` is a normal slime function, it can be called with a single colon.
I'm working on a swank for R7RS Schemes, and kawa can not read :: (that is used for type annotations).

This should not influence CL swank at all.