### PR TITLE
Small fix to common-lisp-hyperspec--read-format-character

### DIFF
--- a/lib/hyperspec.el
+++ b/lib/hyperspec.el
@@ -1237,8 +1237,8 @@ If you copy the HyperSpec to another location, customize the variable
 	char-at-point
       (completing-read
        "Look up format control character in Common Lisp HyperSpec: "
-       common-lisp-hyperspec--format-characters nil #'boundp
-       nil nil 'common-lisp-hyperspec-format-history))))
+       common-lisp-hyperspec--format-characters nil t nil
+       'common-lisp-hyperspec-format-history))))
 
 (defun common-lisp-hyperspec-format (character-name)
   (interactive (list (common-lisp-hyperspec--read-format-character)))


### PR DESCRIPTION
The call to `completing-read` in this function appears to have the arguments in the wrong order:
The require-match argument given is `#'boundp`(which defaults to `t`), history is given as `nil` and default is the history variable. This actually has little effect on the default completing-read function which still works fine. When `completing-read-function` is different (eg. in helm or ivy), however, it may misbehave. I am unsure of the effects on helm users but this is useless with ivy.