### PR TITLE
Add ASDF build system

### DIFF
--- a/asdf-init.lisp
+++ b/asdf-init.lisp
@@ -1,0 +1,6 @@
+;;; -*- lisp -*-
+
+(setf swank-loader:*source-directory*
+      (asdf:system-source-directory :swank))
+
+(setf swank::*find-module* 'swank::find-module-asdf)

--- a/slime.el
+++ b/slime.el
@@ -180,8 +180,10 @@ This applies to the *inferior-lisp* buffer and the network connections."
   :group 'slime)
 
 (defcustom slime-backend "swank-loader.lisp"
-  "The name of the Lisp file that loads the Swank server.
-This name is interpreted relative to the directory containing
+  "\"ASDF\" or the path to a Lisp file that loads the Swank server.
+If it's ASDF (case-insensitive), the Lisp image is required to
+contain a working ASDF and Slime will load swank.asd.  If it's a
+file path it is interpreted relative to the directory containing
 slime.el, but could also be set to an absolute filename."
   :type 'string
   :group 'slime-lisp)
@@ -1206,9 +1208,11 @@ See `slime-start'."
     ;; Return a single form to avoid problems with buffered input.
     (format "%S\n\n"
             `(progn
-               (load ,(slime-to-lisp-filename (expand-file-name loader))
-                     :verbose t)
-               (funcall (read-from-string "swank-loader:init"))
+               ,@(if (equalp "ASDF" slime-backend)
+                     `((funcall (read-from-string "asdf:load-system") :swank))
+                   `((load ,(slime-to-lisp-filename (expand-file-name loader))
+                           :verbose t)
+                     (funcall (read-from-string "swank-loader:init"))))
                (funcall (read-from-string "swank:start-server")
                         ,(slime-to-lisp-filename port-filename))))))
 

--- a/swank-loader-asdf.lisp
+++ b/swank-loader-asdf.lisp
@@ -1,0 +1,17 @@
+;;;; -*- lisp -*-
+;;;
+;;; swank-loader.lisp --- Compat to allow the Elisp code to load SWANK
+;;; via ASDF transparently.
+;;;
+
+(defpackage #:swank-loader
+  (:use #:common-lisp)
+  (:export #:init #:*source-directory*))
+
+(in-package #:swank-loader)
+
+(defun init (&key reload)
+  (asdf:load-system :swank :force reload))
+
+;; Gets initialized at the end of swank.asd
+(defvar *source-directory*)

--- a/swank.asd
+++ b/swank.asd
@@ -19,19 +19,91 @@
 ;; This code has been placed in the Public Domain.  All warranties
 ;; are disclaimed.
 
-(defpackage :swank-loader
-  (:use :cl))
+(defpackage #:swank-loader
+  (:use #:common-lisp #:asdf)
+  (:export #:init #:*source-directory*))
+(in-package #:swank-loader)
 
-(in-package :swank-loader)
+(defun init (&key delete)
+  (asdf:load-system :swank :force reload))
 
-(defclass swank-loader-file (asdf:cl-source-file) ())
+;; Gets initialized in asdf-init.lisp
+(defvar *source-directory*)
 
-;;;; after loading run init
+(defun load-user-init-file ()
+  "Load the user init file, return NIL if it does not exist."
+  (load (uiop:subpathname (user-homedir-pathname) ".swank.lisp")
+        :if-does-not-exist nil))
 
-(defmethod asdf:perform ((o asdf:load-op) (f swank-loader-file))
-  (load (asdf::component-pathname f))
-  (funcall (read-from-string "swank-loader::init") :reload t))
+(defvar *source-directory*)
 
-(asdf:defsystem :swank
-  :default-component-class swank-loader-file
-  :components ((:file "swank-loader")))
+(defclass no-load-file (cl-source-file) ())
+
+(defmethod perform ((op load-op) (c no-load-file)) nil)
+
+(defmacro define-swank-system ((sysdep-files impl-files))
+  `(defsystem :swank
+     :description "Swank is the Common Lisp back-end to SLIME"
+     :serial t
+     :components ((:file "packages")
+                  (:file "swank-backend" :pathname "swank/backend")
+                  (:file "nregex")
+                  ,@(mapcar (lambda (component)
+                              `(:file ,component :pathname ,(concatenate 'string "swank/" component)))
+                            sysdep-files)
+                  (:file "swank-match" :pathname "swank/match")
+                  (:file "swank-rpc" :pathname "swank/rpc")
+                  (:file "swank")
+                  ,@(mapcar (lambda (component)
+                              `(:file ,component :pathname ,(concatenate 'string "swank/" component)))
+                            impl-files)
+                  (:file "asdf-init")
+                  (:module "contrib"
+                   :components ((:no-load-file "swank-util")
+                                (:no-load-file "swank-c-p-c"
+                                 :depends-on ("swank-util"))
+                                (:no-load-file "swank-arglists"
+                                 :depends-on ("swank-c-p-c"))
+                                (:no-load-file "swank-asdf")
+                                (:no-load-file "swank-clipboard")
+                                (:no-load-file "swank-fancy-inspector"
+                                 :depends-on ("swank-util"))
+                                (:no-load-file "swank-fuzzy"
+                                 :depends-on ("swank-util" "swank-c-p-c"))
+                                (:no-load-file "swank-hyperdoc")
+                                (:no-load-file "swank-indentation")
+                                (:no-load-file "swank-repl")
+                                (:no-load-file "swank-macrostep")
+                                (:no-load-file "swank-mrepl")
+                                (:no-load-file "swank-listener-hooks"
+                                 :depends-on ("swank-repl"))
+                                (:no-load-file "swank-media")
+                                (:no-load-file "swank-package-fu")
+                                (:no-load-file "swank-presentations"
+                                 :depends-on ("swank-repl"))
+                                (:no-load-file "swank-quicklisp")
+                                (:no-load-file "swank-presentation-streams"
+                                 :depends-on ("swank-presentations"))
+                                (:no-load-file "swank-sbcl-exts"
+                                 :depends-on ("swank-arglists"))
+                                (:no-load-file "swank-snapshot")
+                                (:no-load-file "swank-sprof"))))
+     :depends-on (#+sbcl #:sb-bsd-sockets)
+     :perform (load-op :after (op swank)
+                (load-user-init-file))))
+
+#+(or allegro armedbear clozurecl openmcl clisp cmu cormanlisp ecl lispworks sbcl scl)
+(define-swank-system
+  #+allegro (() ("allegro" "gray"))
+  #+armedbear (() ("abcl"))
+  #+(or clozurecl openmcl) (("metering" ) ("ccl" "gray"))
+  #+clisp (("xref" "metering") ("clisp" "gray"))
+  #+cmu (("source-path-parser" "source-file-cache") ("cmucl" "gray"))
+  #+cormanlisp (() ("corman" "gray"))
+  #+ecl (("source-path-parser" "source-file-cache") ("ecl" "gray"))
+  #+lispworks (() ("lispworks" "gray"))
+  #+sbcl (("source-path-parser" "source-file-cache") ("sbcl" "gray"))
+  #+scl (("source-path-parser" "source-file-cache") ("scl" "gray")))
+
+#-(or allegro armedbear clozurecl openmcl clisp cmu cormanlisp ecl lispworks sbcl scl)
+(error "Your CL implementation is not supported !")

--- a/swank.lisp
+++ b/swank.lisp
@@ -2556,6 +2556,17 @@ the filename of the module (or nil if the file doesn't exist).")
     (some (lambda (dir) (some #'probe-file (module-candidates name dir)))
           *load-path*)))
 
+#+asdf
+(defun find-module-asdf (module)
+  (flet ((swank-fasl-pathname ()
+           (uiop:pathname-directory-pathname
+            (asdf:apply-output-translations
+             (asdf:system-definition-pathname :swank)))))
+    (or (let ((*load-path*
+                (list (uiop:subpathname (swank-fasl-pathname) "contrib/")
+                      (uiop:subpathname swank-loader:*source-directory* "contrib/"))))
+          (find-module module))
+        (find-module module))))
 
 ;;;; Macroexpansion
 


### PR DESCRIPTION
The ASDF build system is entirely separate from the one in
swank-loader.lisp. That ensures that those who do not wish to load
Swank via ASDF can continue as before. Trying to use ASDF internals to
replace the implemention of swank-loader.lisp gives little benefit and
would IMO be error prone.

The compilation of contrib modules is done via a custom ASDF source
class that only compiles the files (eagerly) but does not load
them. The loading is done through a custom *find-module* hook.

The ASDF system also loads ${HOME}/.swank.lisp if such a file exists.

ASDF compilation on M-x slime is enabled by setting the Emacs
custom var "slime-backend" thusly:

(setq slime-backend "swank-loader-asdf.lisp")

The file swank-loader-asdf merely defines the function
swank-loader:init, for compatibility with the custom build system, so
that the new build system is entirely transparent for Slime.