### PR TITLE
Fix SWANK-SNAPSHOT contrib

### DIFF
--- a/contrib/swank-snapshot.lisp
+++ b/contrib/swank-snapshot.lisp
@@ -52,7 +52,7 @@
 	 (stream (make-fd-stream fd nil))
 	 (connection (make-connection nil stream style)))
     (let ((*emacs-connection* connection))
-      (when repl (swank::create-repl nil))
+      (when repl (swank-repl:create-repl nil))
       (background-message "~A" "Lisp image restored"))
     (serve-requests connection)
     (simple-repl)))


### PR DESCRIPTION
The function CREATE-REPL was moved to the SWANK-REPL package.