### PR TITLE
Reference and compiler condition improvements

### DIFF
--- a/contrib/slime-references.el
+++ b/contrib/slime-references.el
@@ -21,16 +21,17 @@
 
 (defcustom slime-sbcl-manual-root "http://www.sbcl.org/manual/"
   "*The base URL of the SBCL manual, for documentation lookup."
-  :type 'string
+  :type '(choice (string :tag "HTML Documentation")
+                 (const :tag "Info Documentation" :info))
   :group 'slime-mode)
 
-(defface sldb-reference-face 
+(defface sldb-reference-face
   (list (list t '(:underline t)))
   "Face for references."
   :group 'slime-debugger)
 
 
-;;;;; SBCL-style references 
+;;;;; SBCL-style references
 
 (defvar slime-references-local-keymap
   (let ((map (make-sparse-keymap "local keymap for slime references")))
@@ -102,9 +103,13 @@ See SWANK-BACKEND:CONDITION-REFERENCES for the datatype."
              (t
               (hyperspec-lookup what))))
           (t
-           (let ((url (format "%s#%s" slime-sbcl-manual-root
-                              (subst-char-in-string ?\  ?\- what))))
-             (browse-url url))))))))
+           (case slime-sbcl-manual-root
+             (:info
+              (info (format "(sbcl)%s" what)))
+             (t
+              (browse-url
+               (format "%s#%s" slime-sbcl-manual-root
+                       (subst-char-in-string ?\  ?\- what)))))))))))
 
 (defun slime-lookup-reference-at-mouse (event)
   "Invoke the action pointed at by the mouse."
@@ -122,10 +127,10 @@ See SWANK-BACKEND:CONDITION-REFERENCES for the datatype."
 ;;; FIXME: `compilation-mode' will swallow the `mouse-face'
 ;;; etc. properties.
 (defadvice slime-note.message (after slime-note.message+references)
-  (setq ad-return-value 
+  (setq ad-return-value
         (concat ad-return-value
                 (with-temp-buffer
-                  (slime-insert-references 
+                  (slime-insert-references
                    (slime-note.references (ad-get-arg 0)))
                   (buffer-string)))))
 
@@ -137,9 +142,9 @@ See SWANK-BACKEND:CONDITION-REFERENCES for the datatype."
   (let ((note (plist-get (slime-tree.plist tree) 'note)))
     (when note
       (let ((references (slime-note.references note)))
-	(when references
-	  (terpri (current-buffer))
-	  (slime-insert-references references))))))
+        (when references
+          (terpri (current-buffer))
+          (slime-insert-references references))))))
 
 ;;;;; Hook into SLDB
 

--- a/contrib/slime-references.el
+++ b/contrib/slime-references.el
@@ -96,7 +96,9 @@ See SWANK-BACKEND:CONDITION-REFERENCES for the datatype."
              (:glossary
               (browse-url (funcall common-lisp-hyperspec-glossary-function what)))
              (:issue
-              (browse-url (funcall 'common-lisp-issuex what)))
+              (browse-url (common-lisp-issuex what)))
+             (:special-operator
+              (browse-url (common-lisp-special-operator (downcase name))))
              (t
               (hyperspec-lookup what))))
           (t

--- a/lib/hyperspec.el
+++ b/lib/hyperspec.el
@@ -2493,6 +2493,9 @@ incompatibly-more-like-defclass+emphasize-read-only" "iss102.htm")
 			common-lisp-hyperspec--issuex-symbols)))
     (concat common-lisp-hyperspec-root "Issues/" entry)))
 
+(defun common-lisp-special-operator (name)
+  (format "%sBody/s_%s.htm" common-lisp-hyperspec-root name))
+
 ;;; Added the following just to provide a common entry point according
 ;;; to the various 'hyperspec' implementations.
 ;;;

--- a/slime.el
+++ b/slime.el
@@ -326,6 +326,54 @@ Works like `completion-at-point-functions'.
   "Face for notes from the compiler."
   :group 'slime-mode-faces)
 
+(defface slime-early-deprecation-warning-face
+  `((((type graphic) (class color) (background light))
+     (:strike-through "brown"))
+    (((type graphic) (class color) (background dark))
+     (:strike-through "gold"))
+    (((type graphic))
+     (:strike-through t))
+    (((class color) (background light))
+     (:underline "brown"))
+    (((class color) (background dark))
+     (:underline "gold"))
+    (t
+     (:underline t)))
+  "Face for early deprecation warnings from the compiler."
+  :group 'slime-mode-faces)
+
+(defface slime-late-deprecation-warning-face
+  `((((type graphic) (class color) (background light))
+     (:strike-through "orange"))
+    (((type graphic) (class color) (background dark))
+     (:strike-through "coral"))
+    (((type graphic))
+     (:strike-through t))
+    (((class color) (background light))
+     (:underline "orange"))
+    (((class color) (background dark))
+     (:underline "coral"))
+    (t
+     (:underline t)))
+  "Face for late deprecation warnings from the compiler."
+  :group 'slime-mode-faces)
+
+(defface slime-final-deprecation-warning-face
+  `((((type graphic) (class color) (background light))
+     (:strike-through "red"))
+    (((type graphic) (class color) (background dark))
+     (:strike-through "red"))
+    (((type graphic))
+     (:strike-through t))
+    (((class color) (background light))
+     (:underline "red"))
+    (((class color) (background dark))
+     (:underline "red"))
+    (t
+     (:strike-through t)))
+  "Face for final deprecation warnings from the compiler."
+  :group 'slime-mode-faces)
+
 (defface slime-highlight-face
     '((t (:inherit highlight :underline nil)))
   "Face for compiler notes while selected."
@@ -496,8 +544,8 @@ information."
     ("\M-,"      slime-pop-find-definition-stack)
     ("\M-_"      slime-edit-uses)    ; for German layout
     ("\M-?"      slime-edit-uses)    ; for USian layout
-    ("\C-x4." 	 slime-edit-definition-other-window)
-    ("\C-x5." 	 slime-edit-definition-other-frame)
+    ("\C-x4."    slime-edit-definition-other-window)
+    ("\C-x5."    slime-edit-definition-other-frame)
     ("\C-x\C-e"  slime-eval-last-expression)
     ("\C-\M-x"   slime-eval-defun)
     ;; Include PREFIX keys...
@@ -2969,12 +3017,15 @@ Return nil if there's no useful source location."
                   (<= (max pos1 pos2) (line-end-position))))
 
 (defvar slime-severity-face-plist
-  '(:error         slime-error-face
-                   :read-error    slime-error-face
-                   :warning       slime-warning-face
-                   :redefinition  slime-style-warning-face
-                   :style-warning slime-style-warning-face
-                   :note          slime-note-face))
+  '(:error                     slime-error-face
+    :read-error                slime-error-face
+    :warning                   slime-warning-face
+    :redefinition              slime-style-warning-face
+    :style-warning             slime-style-warning-face
+    :early-deprecation-warning slime-early-deprecation-warning-face
+    :late-deprecation-warning  slime-late-deprecation-warning-face
+    :final-deprecation-warning slime-final-deprecation-warning-face
+    :note                      slime-note-face))
 
 (defun slime-severity-face (severity)
   "Return the name of the font-lock face representing SEVERITY."
@@ -2982,7 +3033,10 @@ Return nil if there's no useful source location."
       (error "No face for: %S" severity)))
 
 (defvar slime-severity-order
-  '(:note :style-warning :redefinition :warning :error :read-error))
+  '(:note
+    :early-deprecation-warning :style-warning :redefinition
+    :late-deprecation-warning :final-deprecation-warning
+    :warning :error :read-error))
 
 (defun slime-severity< (sev1 sev2)
   "Return true if SEV1 is less severe than SEV2."
@@ -7195,7 +7249,7 @@ keys."
   (let ((start (cl-position-if-not (lambda (x)
                                      (memq x '(?\t ?\n ?\s ?\r)))
                                    str))
-        
+
         (end (cl-position-if-not (lambda (x)
                                    (memq x '(?\t ?\n ?\s ?\r)))
                                  str

--- a/swank/sbcl.lisp
+++ b/swank/sbcl.lisp
@@ -519,6 +519,12 @@ information."
                       (sb-c:compiler-error  :error)
                       (reader-error         :read-error)
                       (error                :error)
+                      #+#.(swank/backend:with-symbol early-deprecation-warning sb-ext)
+                      (sb-ext:early-deprecation-warning :early-deprecation-warning)
+                      #+#.(swank/backend:with-symbol late-deprecation-warning sb-ext)
+                      (sb-ext:late-deprecation-warning :late-deprecation-warning)
+                      #+#.(swank/backend:with-symbol final-deprecation-warning sb-ext)
+                      (sb-ext:final-deprecation-warning :final-deprecation-warning)
                       #+#.(swank/backend:with-symbol redefinition-warning
                             sb-kernel)
                       (sb-kernel:redefinition-warning


### PR DESCRIPTION
* Support references to HyperSpec special operator pages
* Allow referencing SBCL's info documentation as an alternative to the online version of the manual
* Use distinct faces for SBCL's deprecation-related warnings 