### PR TITLE
Fix some warnings in Emacs 25.1.

### DIFF
--- a/slime.el
+++ b/slime.el
@@ -281,7 +281,10 @@ argument."
   "List of functions to perform completion.
 Works like `completion-at-point-functions'.
 `slime--completion-at-point' uses this variable."
-  :group 'slime-mode)
+  :group 'slime-mode
+  :type 'hook
+  :options '(slime-filename-completion
+             slime-simple-completion-at-point))
 
 ;;;;; slime-mode-faces
 
@@ -2402,7 +2405,7 @@ Debugged requests are ignored."
         (slime-pprint-event event (current-buffer)))
       (when (and (boundp 'outline-minor-mode)
                  outline-minor-mode)
-        (hide-entry))
+        (outline-hide-entry))
       (goto-char (point-max)))))
 
 (defun slime-pprint-event (event buffer)
@@ -3075,7 +3078,7 @@ first element of the source-path redundant."
                         (when more (down-list 1))))
           ;; Align at beginning
           (slime-forward-sexp)
-          (beginning-of-sexp))
+          (thing-at-point--beginning-of-sexp))
       (error (goto-char origin)))))
 
 
@@ -3383,7 +3386,7 @@ are supported:
       (when call-site (slime-search-call-site call-site))
       (when align
         (slime-forward-sexp)
-        (beginning-of-sexp)))
+        (thing-at-point--beginning-of-sexp)))
     (point)))
 
 
@@ -3670,12 +3673,12 @@ alist but ignores CDRs."
 (defun slime-push-definition-stack ()
   "Add point to find-tag-marker-ring."
   (require 'etags)
-  (ring-insert find-tag-marker-ring (point-marker)))
+  (xref-push-marker-stack))
 
 (defun slime-pop-find-definition-stack ()
   "Pop the edit-definition stack and goto the location."
   (interactive)
-  (pop-tag-mark))
+  (xref-pop-marker-stack))
 
 (cl-defstruct (slime-xref (:conc-name slime-xref.) (:type list))
   dspec location)
@@ -4880,7 +4883,7 @@ This variable specifies both what was expanded and how.")
     (erase-buffer)
     (insert expansion)
     (goto-char (point-min))
-    (font-lock-fontify-buffer)))
+    (font-lock-flush)))
 
 (defun slime-create-macroexpansion-buffer ()
   (let ((name (slime-buffer-name :macroexpansion)))


### PR DESCRIPTION
Not sure how backwards compatible this is, but it fixes some compilation warnings on Emacs 25.1.

The font lock one should be the flush function I think? The rest are simply replacing deprecated aliases; the `DEFCUSTOM` call makes for a nicer menu.