### PR TITLE
fix errors by slime-export-symbol on slime-tramp environment

### DIFF
--- a/contrib/slime-package-fu.el
+++ b/contrib/slime-package-fu.el
@@ -62,11 +62,11 @@ use `slime-export-symbol-representation-function'.")
       (slime-eval `(swank:package= ,designator1 ,designator2))))
 
 (defun slime-export-symbol (symbol package)
-  "Unexport `symbol' from `package' in the Lisp image."
+  "Export `symbol' from `package' in the Lisp image."
   (slime-eval `(swank:export-symbol-for-emacs ,symbol ,package)))
 
 (defun slime-unexport-symbol (symbol package)
-  "Export `symbol' from `package' in the Lisp image."
+  "Unexport `symbol' from `package' in the Lisp image."
   (slime-eval `(swank:unexport-symbol-for-emacs ,symbol ,package)))
 
 

--- a/contrib/slime-package-fu.el
+++ b/contrib/slime-package-fu.el
@@ -72,13 +72,13 @@ use `slime-export-symbol-representation-function'.")
 
 (defun slime-find-possible-package-file (buffer-file-name)
   (cl-labels ((file-name-subdirectory (dirname)
-                                      (expand-file-name
-                                       (concat (file-name-as-directory (slime-to-lisp-filename dirname))
-                                               (file-name-as-directory ".."))))
+                                      (slime-from-lisp-filename
+                                       (expand-file-name
+                                        (concat (file-name-as-directory (slime-to-lisp-filename dirname))
+                                                (file-name-as-directory "..")))))
               (try (dirname)
                    (cl-dolist (package-file-name slime-package-file-candidates)
-                     (let ((f (slime-to-lisp-filename
-                               (concat dirname package-file-name))))
+                     (let ((f (concat dirname package-file-name)))
                        (when (file-readable-p f)
                          (cl-return f))))))
     (when buffer-file-name

--- a/contrib/slime-package-fu.el
+++ b/contrib/slime-package-fu.el
@@ -49,8 +49,9 @@ use `slime-export-symbol-representation-function'.")
         (while (re-search-forward slime-defpackage-regexp nil t)
           (when (slime-package-equal package (slime-sexp-at-point))
             (backward-sexp)
-            (cl-return (make-slime-file-location (buffer-file-name)
-                                                 (1- (point))))))))))
+            (cl-return (make-slime-file-location
+                        (slime-to-lisp-filename (buffer-file-name)) 
+                        (1- (point))))))))))
 
 (defun slime-package-equal (designator1 designator2)
   ;; First try to be lucky and compare the strings themselves (for the

--- a/contrib/slime-package-fu.el
+++ b/contrib/slime-package-fu.el
@@ -288,7 +288,7 @@ symbol in the Lisp image if possible."
     (unless symbol (error "No symbol at point."))
     (cond (current-prefix-arg
            (if (cl-plusp (slime-frob-defpackage-form package :unexport symbol))
-               (message "Symbol `%s' no longer exported form `%s'"
+               (message "Symbol `%s' no longer exported from `%s'"
                         symbol package)
              (message "Symbol `%s' is not exported from `%s'"
                       symbol package))


### PR DESCRIPTION
This pull request tries to fix errors by `slime-export-symbol` on slime-tramp environment.

- commit e09c504 fixes `tramp-error: Not a Tramp file name: ...` error.
- commit d0d9f0c fixes `down-list: Scan error: "Unbalanced parentheses", 1, 1` error.

other commits changes some words.

