### PR TITLE
Store copies of data at trace-time.

### DIFF
--- a/contrib/swank-fuzzy.lisp
+++ b/contrib/swank-fuzzy.lisp
@@ -74,7 +74,9 @@ designator's format. The cases are as follows:
                               (zerop time-limit-in-msec)))
          (time-limit (if no-time-limit-p nil time-limit-in-msec)))
     (multiple-value-bind (completion-set interrupted-p)
-        (fuzzy-completion-set string default-package-name :limit limit
+        ;; Deep down there's a type SIMPLE-STRING required...
+        (fuzzy-completion-set (coerce string 'simple-string)
+                              default-package-name :limit limit
                               :time-limit-in-msec time-limit)
       ;; We may send this as elisp [] arrays to spare a coerce here,
       ;; but then the network serialization were slower by handling arrays.

--- a/swank.lisp
+++ b/swank.lisp
@@ -721,11 +721,11 @@ If PACKAGE is not specified, the home package of SYMBOL is used."
 
 (defun start-server (port-file &key (style *communication-style*)
                                     (dont-close *dont-close*))
-  "Start the server and write the listen port number to PORT-FILE.
+  "Start the server and write the listen address and port number to PORT-FILE.
 This is the entry point for Emacs."
   (setup-server (or (ignore-errors (parse-integer (sb-posix:getenv "JS_SWANK_PORT")))
                     0)
-                (lambda (port) (announce-server-port port-file port))
+                (lambda (addr port) (announce-server-port port-file addr port))
                 style dont-close nil))
 
 (defun create-server (&key (port default-server-port)
@@ -766,10 +766,15 @@ e.g.: (restart-loop (http-request url) (use-value (new) (setq url new)))"
         (ignore-errors (list (parse-integer (read-line *query-io*)))))
       (setq port new-port))))
 
+(defun octets-to-ip-string (addr)
+  (ecase (length addr)
+    (4 (format nil "~{~d~^.~}" (coerce addr 'list)))
+    (16 (format nil "~{~2,'0x~2,'0x~^:~}" (coerce addr 'list)))))
+
 (defun setup-server (port announce-fn style dont-close backlog)
   (init-log-output)
   (let* ((socket (socket-quest port backlog))
-         (addr (local-addr socket))
+         (addr (octets-to-ip-string (local-addr socket)))
          (port (local-port socket)))
     (funcall announce-fn addr port)
     (labels ((serve () (accept-connections socket style dont-close))

--- a/swank.lisp
+++ b/swank.lisp
@@ -769,8 +769,9 @@ e.g.: (restart-loop (http-request url) (use-value (new) (setq url new)))"
 (defun setup-server (port announce-fn style dont-close backlog)
   (init-log-output)
   (let* ((socket (socket-quest port backlog))
+         (addr (local-addr socket))
          (port (local-port socket)))
-    (funcall announce-fn port)
+    (funcall announce-fn addr port)
     (labels ((serve () (accept-connections socket style dont-close))
              (note () (send-to-sentinel `(:add-server ,socket ,port
                                                       ,(current-thread))))
@@ -848,17 +849,17 @@ if the file doesn't exist; otherwise the first line of the file."
        (:sigio (deinstall-sigio-handler connection))
        (:fd-handler (deinstall-fd-handler connection))))))
 
-(defun announce-server-port (file port)
+(defun announce-server-port (file address port)
   (with-open-file (s file
                      :direction :output
                      :if-exists :error
                      :if-does-not-exist :create)
-    (format s "~S~%" port))
-  (simple-announce-function port))
+    (format s "~S ~S~%" address port))
+  (simple-announce-function address port))
 
-(defun simple-announce-function (port)
+(defun simple-announce-function (address port)
   (when *swank-debug-p*
-    (format *log-output* "~&;; Swank started at port: ~D.~%" port)
+    (format *log-output* "~&;; Swank started at ~a, port: ~D.~%" address port)
     (force-output *log-output*)))
 
 

--- a/swank.lisp
+++ b/swank.lisp
@@ -723,8 +723,7 @@ If PACKAGE is not specified, the home package of SYMBOL is used."
                                     (dont-close *dont-close*))
   "Start the server and write the listen address and port number to PORT-FILE.
 This is the entry point for Emacs."
-  (setup-server (or (ignore-errors (parse-integer (sb-posix:getenv "JS_SWANK_PORT")))
-                    0)
+  (setup-server 0
                 (lambda (addr port) (announce-server-port port-file addr port))
                 style dont-close nil))
 

--- a/swank.lisp
+++ b/swank.lisp
@@ -1103,7 +1103,7 @@ The processing is done in the extent of the toplevel restart."
 
 (defun wait-for-event (pattern &optional timeout)
   "Scan the event queue for PATTERN and return the event.
-If TIMEOUT is 'nil wait until a matching event is enqued.
+If TIMEOUT is 'nil wait until a matching event is enqueued.
 If TIMEOUT is 't only scan the queue without waiting.
 The second return value is t if the timeout expired before a matching
 event was found."
@@ -2101,7 +2101,7 @@ after Emacs causes a restart to be invoked."
   "The initial number of backtrace frames to send to Emacs.")
 
 (defvar *sldb-restarts* nil
-  "The list of currenlty active restarts.")
+  "The list of currently active restarts.")
 
 (defvar *sldb-stepping-p* nil
   "True during execution of a step command.")
@@ -2243,7 +2243,7 @@ where
   restart     ::= (name description)
   stack-frame ::= (number description [plist])
   extra       ::= (:references and other random things)
-  cont        ::= continutation
+  cont        ::= continuation
   plist       ::= (:restartable {nil | t | :unknown})
 
 condition---a pair of strings: message, and type.  If show-source is
@@ -2254,7 +2254,7 @@ restart---a pair of strings: restart name, and description.
 stack-frame---a number from zero (the top), and a printed
 representation of the frame's call.
 
-continutation---the id of a pending Emacs continuation.
+continuation---the id of a pending Emacs continuation.
 
 Below is an example return value. In this case the condition was a
 division by zero (multi-line description), and only one frame is being

--- a/swank/abcl.lisp
+++ b/swank/abcl.lisp
@@ -218,6 +218,9 @@
 (defimplementation create-socket (host port &key backlog)
   (ext:make-server-socket port))
 
+(defimplementation local-address (socket)
+  (jcall (jmethod "java.net.ServerSocket" "getLocalAddress") socket)) ;; ??
+
 (defimplementation local-port (socket)
   (jcall (jmethod "java.net.ServerSocket" "getLocalPort") socket))
 

--- a/swank/backend.lisp
+++ b/swank/backend.lisp
@@ -342,6 +342,9 @@ form suitable for testing with #+."
   "Create a listening TCP socket on interface HOST and port PORT.
 BACKLOG queue length for incoming connections.")
 
+(definterface local-addr (socket)
+  "Return the local address used by SOCKET.")
+
 (definterface local-port (socket)
   "Return the local port number of SOCKET.")
 

--- a/swank/clasp.lisp
+++ b/swank/clasp.lisp
@@ -67,6 +67,8 @@
     (sb-bsd-sockets:socket-listen socket (or backlog 5))
     socket))
 
+(defimplementation local-addr (socket)
+  (nth-value 0 (sb-bsd-sockets:socket-name socket)))
 (defimplementation local-port (socket)
   (nth-value 1 (sb-bsd-sockets:socket-name socket)))
 

--- a/swank/cmucl.lisp
+++ b/swank/cmucl.lisp
@@ -67,6 +67,8 @@
   (declare (ignore host))
   (ext:create-inet-listener port :stream :reuse-address t))
 
+(defimplementation local-addr (socket)
+  (nth-value 0 (ext::get-socket-host-and-port (socket-fd socket))))
 (defimplementation local-port (socket)
   (nth-value 1 (ext::get-socket-host-and-port (socket-fd socket))))
 

--- a/swank/ecl.lisp
+++ b/swank/ecl.lisp
@@ -84,6 +84,8 @@
     (sb-bsd-sockets:socket-listen socket (or backlog 5))
     socket))
 
+(defimplementation local-addr (socket)
+  (nth-value 0 (sb-bsd-sockets:socket-name socket)))
 (defimplementation local-port (socket)
   (nth-value 1 (sb-bsd-sockets:socket-name socket)))
 

--- a/swank/lispworks.lisp
+++ b/swank/lispworks.lisp
@@ -99,6 +99,8 @@
                                       (list #+unix (lw:get-unix-error errno))
                                       errno))))))
 
+(defimplementation local-addr (socket)
+  (nth-value 0 (comm:get-socket-address (socket-fd socket))))
 (defimplementation local-port (socket)
   (nth-value 1 (comm:get-socket-address (socket-fd socket))))
 

--- a/swank/mkcl.lisp
+++ b/swank/mkcl.lisp
@@ -63,6 +63,8 @@
     (sb-bsd-sockets:socket-listen socket (or backlog 5))
     socket))
 
+(defimplementation local-addr (socket)
+  (nth-value 0 (sb-bsd-sockets:socket-name socket)))
 (defimplementation local-port (socket)
   (nth-value 1 (sb-bsd-sockets:socket-name socket)))
 

--- a/swank/rpc.lisp
+++ b/swank/rpc.lisp
@@ -8,7 +8,7 @@
 ;;; are disclaimed.
 ;;;
 
-(in-package swank/rpc)
+(in-package :swank/rpc)
 
 
 ;;;;; Input

--- a/swank/rpc.lisp
+++ b/swank/rpc.lisp
@@ -106,7 +106,7 @@
     (write-sequence octets stream)
     (finish-output stream)))
 
-;; FIXME: for now just tell emacs that we and an encoding problem.
+;; FIXME: for now just tell emacs that we had an encoding problem.
 (defun encoding-error (condition string)
   (swank/backend:string-to-utf8
    (prin1-to-string-for-emacs

--- a/swank/sbcl.lisp
+++ b/swank/sbcl.lisp
@@ -131,6 +131,8 @@
     (sb-bsd-sockets:socket-listen socket (or backlog 5))
     socket))
 
+(defimplementation local-addr (socket)
+  (nth-value 0 (sb-bsd-sockets:socket-name socket)))
 (defimplementation local-port (socket)
   (nth-value 1 (sb-bsd-sockets:socket-name socket)))
 

--- a/swank/scl.lisp
+++ b/swank/scl.lisp
@@ -34,6 +34,8 @@
     (ext:create-inet-listener port :stream :host addr :reuse-address t
                               :backlog (or backlog 5))))
 
+(defimplementation local-addr (socket)
+  (nth-value 0 (ext::get-socket-host-and-port (socket-fd socket))))
 (defimplementation local-port (socket)
   (nth-value 1 (ext::get-socket-host-and-port (socket-fd socket))))
 


### PR DESCRIPTION
When passing structures or other identity-preserving items (arrays,
list heads) around,  tracing the call chain wouldn't show how these
items evolve.

At least for the simple well-known cases we can store a copy of the
arguments;  the time/space effort only occurs during tracing anyway
and is well spent, IMO.