### PR TITLE
Update slime-make-tramp-file-name for emacs 26.

### DIFF
--- a/contrib/slime-tramp.el
+++ b/contrib/slime-tramp.el
@@ -55,16 +55,30 @@ See also `slime-create-filename-translator'."
         (t (list #'identity #'identity))))
 
 (defun slime-make-tramp-file-name (username remote-host lisp-filename)
-  "Old (with multi-hops) tramp compatability function"
-  (if (boundp 'tramp-multi-methods)
-      (tramp-make-tramp-file-name nil nil
-                                  username
-                                  remote-host
-                                  lisp-filename)
-      (tramp-make-tramp-file-name nil
-                                  username
-                                  remote-host
-                                  lisp-filename)))
+  "Tramp compatability function.
+
+Handles the signature of `tramp-make-tramp-file-name' changing
+over time."
+  (cond
+   ((>= emacs-major-version 26)
+    ;; Emacs 26 requires the method to be provided and the signature of
+    ;; `tramp-make-tramp-file-name' has changed.
+    (tramp-make-tramp-file-name (tramp-find-method nil username remote-host)
+                                username
+                                nil
+                                remote-host
+                                nil
+                                lisp-filename))
+   ((boundp 'tramp-multi-methods)
+    (tramp-make-tramp-file-name nil nil
+                                username
+                                remote-host
+                                lisp-filename))
+   (t
+    (tramp-make-tramp-file-name nil
+                                username
+                                remote-host
+                                lisp-filename))))
 
 (cl-defun slime-create-filename-translator (&key machine-instance
                                                  remote-host


### PR DESCRIPTION
Emacs 26 added two new required arguments to `tramp-make-tramp-file-name`. Additionally, the method part of remote file names is mandatory.