### PR TITLE
slime-c-p-c: correctly insert the chosen completion candidate

### DIFF
--- a/contrib/slime-c-p-c.el
+++ b/contrib/slime-c-p-c.el
@@ -119,24 +119,23 @@ terminates a current completion."
        (equal (buffer-name (window-buffer slime-completions-window))
               slime-completions-buffer-name)))
 
-(defun slime-display-completion-list (completions base)
+(defun slime-display-completion-list (completions start end)
   (let ((savedp (slime-complete-maybe-save-window-configuration)))
     (with-output-to-temp-buffer slime-completions-buffer-name
       (display-completion-list completions)
-      (let ((offset (- (point) 1 (length base))))
-        (with-current-buffer standard-output
-          (setq completion-base-position offset)
-          (set-syntax-table lisp-mode-syntax-table))))
+      (with-current-buffer standard-output
+        (setq completion-base-position (list start end))
+        (set-syntax-table lisp-mode-syntax-table)))
     (when savedp
       (setq slime-completions-window
             (get-buffer-window slime-completions-buffer-name)))))
 
-(defun slime-display-or-scroll-completions (completions base)
+(defun slime-display-or-scroll-completions (completions start end)
   (cond ((and (eq last-command this-command)
               (slime-completion-window-active-p))
          (slime-scroll-completions))
         (t
-         (slime-display-completion-list completions base)))
+         (slime-display-completion-list completions start end)))
   (slime-complete-delay-restoration))
 
 (defun slime-scroll-completions ()
@@ -213,8 +212,9 @@ terminates a current completion."
 			       minimizing (or (cl-mismatch completed-prefix c)
                                               (length completed-prefix)))))
 		 (goto-char (+ beg unambiguous-completion-length))))
-             (slime-display-or-scroll-completions completion-set 
-                                                  completed-prefix))))))
+             (slime-display-or-scroll-completions completion-set
+                                                  beg
+                                                  (max (point) end)))))))
 
 (defun slime-complete-symbol*-fancy-bit ()
   "Do fancy tricks after completing a symbol.

--- a/contrib/test/slime-c-p-c-tests.el
+++ b/contrib/test/slime-c-p-c-tests.el
@@ -1,7 +1,7 @@
 (require 'slime-c-p-c)
 (require 'slime-tests)
 
-(def-slime-test complete-symbol*
+(def-slime-test completions
     (prefix expected-completions)
     "Find the completions of a symbol-name prefix."
     '(("cl:compile" (("cl:compile" "cl:compile-file" "cl:compile-file-pathname"
@@ -19,6 +19,82 @@
       ("common-lisp" (("common-lisp-user:" "common-lisp:") "common-lisp")))
   (let ((completions (slime-completions prefix)))
     (slime-test-expect "Completion set" expected-completions completions)))
+
+(def-slime-test complete-symbol*
+    (buffer-sexp wished-completion &optional chosen-completion fancy unambiguous)
+    "Ensure that completions are correctly inserted."
+    '(("cl:and" "cl:and")
+      ("(cl:and" "(cl:and")
+      ("(cl:and)" "(cl:and)")
+      ("(cl:and)" "(cl:and)" nil nil t)
+      ;; Fancy completion of a form that accepts arguments should
+      ;; insert a space after the completed form.
+      ("(cl:and)" "(cl:and )" nil t)
+      ;; ...but only for symbols in the funcall position.
+      ("cl:and" "cl:and" nil t)
+      ;; Fancy completion of a form without arguments should insert a
+      ;; closing paren.
+      ("(cl:get-internal-run-time" "(cl:get-internal-run-time)" nil t)
+      ;; ...but only for symbols in the funcall position.
+      ("cl:get-internal-run-time" "cl:get-internal-run-time" nil t)
+      ("cl:m-v-b" "cl:multiple-value-bind")
+      ("cl:m-v-l" "cl:multiple-value-list" "cl:multiple-value-list")
+      ;; Fancy completion is only done for unique completions. This is
+      ;; not a hard requirement, and might change in the future. This
+      ;; test is included merely to document the current behavior.
+      ("(cl:m-v-l)" "(cl:multiple-value-list)" "cl:multiple-value-list" t)
+      ("cl:mult" "cl:multiple-value-call" "cl:multiple-value-call")
+      ("cl:multiple-value" "cl:multiple-value-setq" "cl:multiple-value-setq")
+      ("cl:compile" "cl:compile" "cl:compile")
+      ("cl:compile" "cl:compile-file" "cl:compile-file")
+      ("cl:f-o" "cl:force-output" "cl:force-output")
+      ;; When `slime-c-p-c-unambiguous-prefix-p' is non nil,
+      ;; `slime-complete-symbol*' will move point back to the
+      ;; unambiguous portion of the prefix; however, the final result
+      ;; after choosing a completion candidate should be the same.
+      ("cl:f-o" "cl:force-output" "cl:force-output" nil t)
+      ("(cl:f-o)" "(cl:force-output)" "cl:force-output" nil t)
+      ;; Character completions
+      ("#\\N" "#\\Newline")
+      ("#\\R" "#\\Return" "#\\Return")
+      ("#\\R" "#\\Rubout" "#\\Rubout" nil t)
+      ;; Keyword completions
+      ("(cl:find 'x '() :)" "(cl:find 'x '() :START)" ":START")
+      ("(cl:find 'x '() :S)" "(cl:find 'x '() :START)")
+      ("(cl:find 'x '() :s)" "(cl:find 'x '() :start)")
+      ("(cl:find 'x '() :s)" "(cl:find 'x '() :start)" nil t)
+      ("(cl:find 'x '() :t)" "(cl:find 'x '() :test)" ":test")
+      ("(cl:find 'x '() :t)" "(cl:find 'x '() :test-not)" ":test-not" nil t))
+  (slime-check-top-level)
+  (save-window-excursion
+    (with-temp-buffer
+      (lisp-mode)
+      (setq slime-buffer-package "SWANK")
+      (insert buffer-sexp)
+      (when (eq (char-before) ?\))
+        (backward-char))
+      (let ((slime-c-p-c-unambiguous-prefix-p unambiguous)
+            (slime-complete-symbol*-fancy fancy))
+        (if (not fancy)
+            (slime-complete-symbol*)
+          ;; `slime-complete-symbol*-fancy-bit' may call
+          ;; `execute-kbd-macro', which ultimately operates on the
+          ;; buffer associated with the selected window, not
+          ;; necessarily the current buffer. Call `pop-to-buffer' to
+          ;; ensure that the current buffer is in the selected window
+          ;; before calling `slime-complete-symbol*'. Fancy completion
+          ;; might also kick off a `slime-eval-async' in
+          ;; `slime-echo-arglist', so ensure the output is consumed
+          ;; with `slime-sync-to-top-level' before continuing.
+          (pop-to-buffer (current-buffer))
+          (slime-complete-symbol*)
+          (slime-sync-to-top-level 1)))
+      (when chosen-completion
+        (with-selected-window slime-completions-window
+          (goto-char (point-min))
+          (search-forward chosen-completion)
+          (choose-completion)))
+      (slime-check-completed-form buffer-sexp wished-completion))))
 
 (def-slime-test complete-form
     (buffer-sexpr wished-completion &optional skip-trailing-test-p)


### PR DESCRIPTION
Fix `slime-complete-symbol*` in `slime-c-p-c.el` to correctly insert the chosen completion candidate.

See the included commit messages for more info.

**slime-version**: 2.22

I've run the full test suite (`make check`, `make test`, and `make check-all`) using the following combinations of emacs and inferior-lisp versions.

| emacs | lisp                 |
|-------|----------------------|
|  23.3 | sbcl 1.0.55.0.debian |
|  24.5 | sbcl 1.4.5.debian    |
|  25.3 | sbcl 1.4.5.debian    |
|  26.1 | sbcl 1.4.5.debian    |
|  26.1 | sbcl 1.4.11          |
|  26.1 | ccl 1.10-r16196      |

Note that different emacs and lisp version combos usually produce a small handful of unexpected test results (failures or "passed unexpectedly"), but the changes in this pull request never affect the set of failing tests.

## Steps to reproduce

This pull request contains new test cases in `slime-c-p-c-tests.el` to demonstrate the bug and corresponding fix. To reproduce the bug, you can merge only the new tests without the fix and then run `make check-c-p-c`.

Alternatively, here is a minimal `init.el` to reproduce the bug.

``` emacs-lisp
(require 'package)
(add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/") t)
(package-initialize)
(package-refresh-contents)
(package-install 'slime)
(setq inferior-lisp-program "sbcl")
(setq slime-contribs '(slime-c-p-c)) ; also reproduces with slime-fancy
(slime)
```

1. Start emacs with `emacs -Q -l minimal-init.el`
2. Enable slime-mode (by visiting a lisp file in a new buffer, say).
3. In the new buffer, insert the text "(map"
4. Call `slime-complete-symbol*`, either invoking it directly via `M-:` or by using the default `C-c C-i` keybinding.
5. Choose "mapcar" as the desired completion in the resulting \*Completions\* buffer.
6. Observe that the completed text is "mapmapcar", rather than the desired "mapcar".