### PR TITLE
Correct spelling: unredable to unreadable.

### DIFF
--- a/packages.lisp
+++ b/packages.lisp
@@ -188,9 +188,9 @@
            #:*find-definitions-right-trim*
            #:*find-definitions-left-trim*
            #:*after-toggle-trace-hook*
-           #:unredable-result
-           #:unredable-result-p
-           #:unredable-result-string
+           #:unreadable-result
+           #:unreadable-result-p
+           #:unreadable-result-string
            #:parse-string
            #:from-string
            #:to-string

--- a/swank.lisp
+++ b/swank.lisp
@@ -1367,13 +1367,13 @@ entered nothing, returns NIL when user pressed C-g."
                                            ,prompt ,initial-value))
     (third (wait-for-event `(:emacs-return ,tag result)))))
 
-(defstruct (unredable-result
-            (:constructor make-unredable-result (string))
+(defstruct (unreadable-result
+            (:constructor make-unreadable-result (string))
             (:copier nil)
             (:print-object
              (lambda (object stream)
                (print-unreadable-object (object stream :type t)
-                 (princ (unredable-result-string object) stream)))))
+                 (princ (unreadable-result-string object) stream)))))
   string)
 
 (defun process-form-for-emacs (form)
@@ -1410,7 +1410,7 @@ converted to lower case."
 				  ,(process-form-for-emacs form)))
 	   (let ((value (caddr (wait-for-event `(:emacs-return ,tag result)))))
 	     (dcase value
-               ((:unreadable value) (make-unredable-result value))
+               ((:unreadable value) (make-unreadable-result value))
 	       ((:ok value) value)
                ((:error kind . data) (error "~a: ~{~a~}" kind data))
 	       ((:abort) (abort))))))))


### PR DESCRIPTION
Correct the spelling of the following symbols to "unreadable":

unredable-result
unredable-result-p
unredable-result-string
make-unredable-result