### PR TITLE
Fix race conditions in swank

### DIFF
--- a/swank.lisp
+++ b/swank.lisp
@@ -583,7 +583,7 @@ recently established one."
              (when (and thread 
                         (thread-alive-p thread)
                         (not (eq thread (current-thread))))
-               (kill-thread thread))))
+               (ignore-errors (kill-thread thread)))))
           (t
            (warn "No server for ~s: ~s" key value)))))
 
@@ -1177,7 +1177,7 @@ event was found."
       (when (and thread
                  (thread-alive-p thread)
                  (not (equal (current-thread) thread)))
-        (kill-thread thread)))))
+        (ignore-errors (kill-thread thread))))))
 
 ;;;;;; Signal driven IO
 


### PR DESCRIPTION
When swank kills threads, it checks whether they are alive before doing so. However, the threads can still die before kill-thread is actually called, leading to spurious errors like "Cannot interrupt the inactive process ...". The only reasonable way to prevent this is to ignore such errors. The issue is not only academic, with ECL I'm observing the behaviour regularly on slime startup.