### PR TITLE
Move target manipulation out of repl contrib

### DIFF
--- a/contrib/slime-media.el
+++ b/contrib/slime-media.el
@@ -34,7 +34,7 @@
 
 (defun slime-media-insert-image (image string &optional bol)
   (with-current-buffer (slime-output-buffer)
-    (let ((marker (slime-output-target-marker :repl-result)))
+    (let ((marker (slime-repl-output-target-marker :repl-result)))
       (goto-char marker)
       (slime-propertize-region `(face slime-repl-result-face
                                       rear-nonsticky (face))

--- a/contrib/slime-presentations.el
+++ b/contrib/slime-presentations.el
@@ -68,7 +68,7 @@ TARGET can be nil (regular process output) or :repl-result."
   (setf (gethash id slime-presentation-start-to-point)
         ;; We use markers because text can also be inserted before this presentation.
         ;; (Output arrives while we are writing presentations within REPL results.)
-        (copy-marker (slime-output-target-marker target) nil)))
+        (copy-marker (slime-repl-output-target-marker target) nil)))
 
 (defun slime-mark-presentation-start-handler (process string)
   (if (and string (string-match "<\\([-0-9]+\\)" string))
@@ -82,7 +82,7 @@ TARGET can be nil (regular process output) or :repl-result."
   (let ((start (gethash id slime-presentation-start-to-point)))
     (remhash id slime-presentation-start-to-point)
     (when start
-      (let* ((marker (slime-output-target-marker target))
+      (let* ((marker (slime-repl-output-target-marker target))
              (buffer (and marker (marker-buffer marker))))
         (with-current-buffer buffer
           (let ((end (marker-position marker)))
@@ -777,7 +777,7 @@ output; otherwise the new input is appended."
 
 (defun slime-presentation-write-result (string)
   (with-current-buffer (slime-output-buffer)
-    (let ((marker (slime-output-target-marker :repl-result))
+    (let ((marker (slime-repl-output-target-marker :repl-result))
           (saved-point (point-marker)))
       (goto-char marker)
       (slime-propertize-region `(face slime-repl-result-face
@@ -799,7 +799,7 @@ output; otherwise the new input is appended."
      (slime-repl-emit string))
     (:repl-result
      (slime-presentation-write-result string))
-    (t (slime-emit-to-target string target))))
+    (t (slime-repl-emit-to-target string target))))
 
 (defun slime-presentation-current-input (&optional until-point-p)
   "Return the current input as string.

--- a/contrib/slime-repl.el
+++ b/contrib/slime-repl.el
@@ -240,7 +240,7 @@ hashtable `slime-output-target-to-marker'; output is inserted at this marker."
   (case target
     ((nil) (slime-repl-emit string))
     (:repl-result (slime-repl-emit-result string t))
-    (t (slime-emit-to-target string target))))
+    (t (slime-repl-emit-to-target string target))))
 
 (defvar slime-repl-popup-on-output nil
   "Display the output buffer when some output is written.
@@ -293,27 +293,10 @@ This is set to nil after displaying the buffer.")
 (defvar slime-last-output-target-id 0
   "The last integer we used as a TARGET id.")
 
-(defvar slime-output-target-to-marker
-  (make-hash-table)
-  "Map from TARGET ids to Emacs markers.
-The markers indicate where output should be inserted.")
-
-(defun slime-output-target-marker (target)
-  "Return the marker where output for TARGET should be inserted."
-  (case target
-    ((nil)
-     (with-current-buffer (slime-output-buffer)
-       slime-output-end))
-    (:repl-result
-     (with-current-buffer (slime-output-buffer)
-       slime-repl-input-start-mark))
-    (t
-     (gethash target slime-output-target-to-marker))))
-
-(defun slime-emit-to-target (string target)
+(defun slime-repl-emit-to-target (string target)
   "Insert STRING at target TARGET.
 See `slime-output-target-to-marker'."
-  (let* ((marker (slime-output-target-marker target))
+  (let* ((marker (slime-repl-output-target-marker target))
          (buffer (and marker (marker-buffer marker))))
     (when buffer
       (with-current-buffer buffer
@@ -323,6 +306,18 @@ See `slime-output-target-to-marker'."
           (goto-char marker)
           (insert-before-markers string)
           (set-marker marker (point)))))))
+
+(defun slime-repl-output-target-marker (target)
+  (case target
+    ((nil)
+     (with-current-buffer (slime-output-buffer)
+       slime-output-end))
+    (:repl-result
+     (with-current-buffer (slime-output-buffer)
+       slime-repl-input-start-mark))
+    (t
+     (slime-output-target-marker target))))
+
 
 (defun slime-switch-to-output-buffer ()
   "Select the output buffer, when possible in an existing window.

--- a/contrib/swank-repl.lisp
+++ b/contrib/swank-repl.lisp
@@ -110,8 +110,8 @@ DEDICATED-OUTPUT INPUT OUTPUT IO REPL-RESULTS"
          (out (or dedicated-output
                   (make-output-stream (make-output-function connection))))
          (io (make-two-way-stream in out))
-         (repl-results (make-output-stream-for-target connection
-                                                      :repl-result)))
+         (repl-results (swank:make-output-stream-for-target connection
+                                                            :repl-result)))
     (typecase connection
       (multithreaded-connection
        (setf (mconn.auto-flush-thread connection)
@@ -123,18 +123,6 @@ DEDICATED-OUTPUT INPUT OUTPUT IO REPL-RESULTS"
   (lambda (string)
     (with-connection (connection)
       (send-to-emacs `(:write-string ,string)))))
-
-(defun make-output-function-for-target (connection target)
-  "Create a function to send user output to a specific TARGET in Emacs."
-  (lambda (string)
-    (with-connection (connection)
-      (with-simple-restart
-          (abort "Abort sending output to Emacs.")
-        (send-to-emacs `(:write-string ,string ,target))))))
-
-(defun make-output-stream-for-target (connection target)
-  "Create a stream that sends output to a specific TARGET in Emacs."
-  (make-output-stream (make-output-function-for-target connection target)))
 
 (defun open-dedicated-output-stream (connection coding-system)
   "Open a dedicated output connection to the Emacs on SOCKET-IO.
@@ -301,7 +289,7 @@ LISTENER-EVAL directly, so that spacial variables *, etc are set."
 
 (defslimefun redirect-trace-output (target)
   (setf (connection.trace-output *emacs-connection*)
-        (make-output-stream-for-target *emacs-connection* target))
+        (swank:make-output-stream-for-target *emacs-connection* target))
   nil)
 
 

--- a/packages.lisp
+++ b/packages.lisp
@@ -195,4 +195,6 @@
            #:from-string
            #:to-string
            #:*swank-debugger-condition*
-           #:run-hook-with-args-until-success))
+           #:run-hook-with-args-until-success
+           #:make-output-function-for-target
+           #:make-output-stream-for-target))

--- a/slime.el
+++ b/slime.el
@@ -7548,6 +7548,33 @@ The returned bounds are either nil or non-empty."
              `((,regexp (1 font-lock-keyword-face)
                         (2 font-lock-variable-name-face)))))
 
+;;;; target manipulation (used by slime-presentations, slime-media,
+;;;;                      slime-repl and slime-buffer-streams, at
+;;;;                      least)
+
+(defvar slime-output-target-to-marker
+  (make-hash-table)
+  "Map from TARGET ids to Emacs markers.
+The markers indicate where output should be inserted.")
+
+(defun slime-output-target-marker (target)
+  "Return the marker where output for TARGET should be inserted."
+  (gethash target slime-output-target-to-marker))
+
+(defun slime-emit-to-target (string target)
+  "Insert STRING at target TARGET.
+See `slime-output-target-to-marker'."
+  (let* ((marker (slime-output-target-marker target))
+         (buffer (and marker (marker-buffer marker))))
+    (when buffer
+      (with-current-buffer buffer
+        (save-excursion
+          ;; Insert STRING at MARKER, then move MARKER behind
+          ;; the insertion.
+          (goto-char marker)
+          (insert-before-markers string)
+          (set-marker marker (point)))))))
+
 ;;;; Finishing up
 
 (eval-when-compile

--- a/swank.lisp
+++ b/swank.lisp
@@ -3711,6 +3711,22 @@ Collisions are caused because package information is ignored."
 #-clasp
 (add-hook *pre-reply-hook* 'sync-indentation-to-emacs)
 
+(defun make-output-function-for-target (connection target)
+  "Create a function to send user output to a specific TARGET in Emacs."
+  (format t "~&connection is: ~s~%" connection)
+  (lambda (string)
+    (declare (optimize (debug 3)))
+    (format t "~&connection is: ~s~%" connection)
+    (break)
+    (swank::with-connection (connection)
+      (with-simple-restart
+          (abort "Abort sending output to Emacs.")
+        (swank::send-to-emacs `(:write-string ,string ,target))))))
+
+(defun make-output-stream-for-target (connection target)
+  "Create a stream that sends output to a specific TARGET in Emacs."
+  (make-output-stream (make-output-function-for-target connection target)))
+
 
 ;;;; Testing 
 


### PR DESCRIPTION
I'm not sure if this is exactly the right way to do this, but it moves the manipulation of targets entirely out of the repl contrib, without breaking the parts of slime and swank that depend on it already.