### PR TITLE
git autocrlf mismatch fix

### DIFF
--- a/swank-loader.lisp
+++ b/swank-loader.lisp
@@ -152,7 +152,8 @@ Return nil if nothing appropriate is available."
             for line = (read-line s nil :eof)
             until (eq line :eof)
             when (string-starts-with line prefix)
-              return (subseq line (length prefix))))))
+              return (string-right-trim '(#\return)
+                                        (subseq line (length prefix)))))))
 
 (defun default-fasl-dir ()
   (merge-pathnames


### PR DESCRIPTION
Discovered that slime errors when git core.autocrlf is turned on when running on windows with the error:
`;;
;; Error ???ing C:/Users/me/slime/packages.lisp:
\;   Can't create directory C:\Users\me\\.slime\fasl\2.23
;;
While evaluating the form starting at line 12, column 0
  of #P"C:/Users/me/slime/start-swank.lisp":

debugger invoked on a SB-INT:SIMPLE-FILE-ERROR in thread
#<THREAD "main thread" RUNNING {10012E0613}>:
\ Can't create directory C:\Users\me\\.slime\fasl\2.23`

This 2 line swank-loader.lisp patch simply removes the carriage return from the offending string, which is normally collected from slime.el. Should be safe as linux doesn't use \r?