### PR TITLE
Add SWANK:ED-RPC and SWANK:ED-RPC-NO-WAIT

### DIFF
--- a/packages.lisp
+++ b/packages.lisp
@@ -184,6 +184,8 @@
            #:quit-lisp
            #:eval-for-emacs
            #:eval-in-emacs
+           #:ed-rpc
+           #:ed-rpc-no-wait
            #:y-or-n-p-in-emacs
            #:*find-definitions-right-trim*
            #:*find-definitions-left-trim*


### PR DESCRIPTION
SWANK:ED-RPC and SWANK:ED-RPC-NO-WAIT implement RPC from SWANK to
Emacs, similarly to what `slime-eval' does in the Emacs => SWANK
direction.

Example usage:
```
  ;; elisp
  (defslimefun increment (n) (1+ n))

  ;; CL
  (swank:ed-rpc 'increment 41) ; => 42
```