### PR TITLE
Avoid trailing newlines in resend-form shortcut

### DIFF
--- a/contrib/slime-repl.el
+++ b/contrib/slime-repl.el
@@ -1415,8 +1415,7 @@ expansion will be added to the REPL's history.)"
   (:handler (lambda ()
               (interactive)
               (insert (car slime-repl-input-history))
-              (insert "\n")
-              (slime-repl-send-input)))
+              (slime-repl-send-input t)))
   (:one-liner "Resend the last form."))
 
 (defslime-repl-shortcut slime-repl-disconnect ("disconnect")


### PR DESCRIPTION
Hello,

Regarding the `resend-form` shortcut command, in `slime-repl.el`.

This PR uses the optional `new-line` argument in `slime-repl-send-input` instead of directly inserting the newline, in order to avoid trailing newlines on consecutive `resend-form` evaluation.

Current situation is like the image below (comments were added afterwards evaluation):
![slime-resend-form](https://user-images.githubusercontent.com/20625381/52320053-3e9f9580-2a10-11e9-8ac0-2aa0220f62cc.png)

