### PR TITLE
Improvements for abcl-1.5.0

### DIFF
--- a/packages.lisp
+++ b/packages.lisp
@@ -60,6 +60,15 @@
            profile-reset
            profile-package
 
+           with-struct*
+           lcons
+           lcons*
+           lcons-cdr
+           llist-range
+           llist-skip
+           llist-take
+           iline
+
            with-collected-macro-forms
            auto-flush-loop
            *auto-flush-interval*))

--- a/slime.el
+++ b/slime.el
@@ -3988,6 +3988,7 @@ WHAT can be:
   A filename (string),
   A list (:filename FILENAME &key LINE COLUMN POSITION),
   A function name (:function-name STRING)
+  A string (:string STRING)
   nil.
 
 This is for use in the implementation of COMMON-LISP:ED."
@@ -4006,7 +4007,13 @@ This is for use in the implementation of COMMON-LISP:ED."
                         (byte-to-position position)
                       position))))
       ((:function-name name)
-       (slime-edit-definition name)))))
+       (slime-edit-definition name))
+      ((:string string)
+       (with-output-to-temp-buffer "*edit-string*"
+         (switch-to-buffer "*edit-string*")
+         (princ string)
+         (fundamental-mode)
+         (setq buffer-read-only nil))))))
 
 (defun slime-goto-line (line-number)
   "Move to line LINE-NUMBER (1-based).

--- a/slime.el
+++ b/slime.el
@@ -6363,6 +6363,11 @@ was called originally."
   "Face for labels in the inspector."
   :group 'slime-inspector)
 
+(defface slime-inspector-strong-face
+  '((t (:inherit slime-inspector-label-face)))
+  "Face for parts of values that are emphasized in the inspector."
+  :group 'slime-inspector)
+
 (defface slime-inspector-value-face
     '((t (:inherit font-lock-builtin-face)))
   "Face for things which can themselves be inspected."
@@ -6420,13 +6425,14 @@ KILL-BUFFER hooks for the inspector buffer."
     (let ((inhibit-read-only t))
       (erase-buffer)
       (pop-to-buffer (current-buffer))
+      (font-lock-mode -1)
       (cl-destructuring-bind (&key id title content) inspected-parts
         (cl-macrolet ((fontify (face string)
                                `(slime-inspector-fontify ,face ,string)))
           (slime-propertize-region
               (list 'slime-part-number id
                     'mouse-face 'highlight
-                    'face 'slime-inspector-value-face)
+                    'face 'slime-inspector-topline-face)
             (insert title))
           (while (eq (char-before) ?\n)
             (backward-delete-char 1))
@@ -6463,11 +6469,17 @@ If PREV resp. NEXT are true insert more-buttons as needed."
   (if (stringp ispec)
       (insert ispec)
     (slime-dcase ispec
-      ((:value string id)
+      ((:value string id )
        (slime-propertize-region
            (list 'slime-part-number id
                  'mouse-face 'highlight
                  'face 'slime-inspector-value-face)
+         (insert string)))
+      ((:strong-value string id )
+       (slime-propertize-region
+           (list 'slime-part-number id
+                 'mouse-face 'highlight
+                 'face 'slime-inspector-strong-face)
          (insert string)))
       ((:label string)
        (insert (slime-inspector-fontify label string)))

--- a/swank-loader.lisp
+++ b/swank-loader.lisp
@@ -46,7 +46,7 @@
   #+lispworks '((swank lispworks) (swank gray))
   #+allegro '((swank allegro) (swank gray))
   #+clisp '(xref metering (swank clisp) (swank gray))
-  #+armedbear '((swank abcl))
+  #+armedbear '((swank abcl) xref)
   #+cormanlisp '((swank corman) (swank gray))
   #+ecl '((swank ecl) (swank gray))
   #+clasp '((swank clasp) (swank gray))

--- a/swank-loader.lisp
+++ b/swank-loader.lisp
@@ -247,7 +247,7 @@ If LOAD is true, load the fasl file."
 
 (defvar *swank-files*
   `(packages
-    (swank backend) ,@*sysdep-files* (swank match) (swank rpc)
+    (swank backend)  (swank match) (swank rpc) ,@*sysdep-files*
     swank))
 
 (defvar *contribs*

--- a/swank.lisp
+++ b/swank.lisp
@@ -3144,6 +3144,8 @@ DSPEC is a string and LOCATION a source location. NAME is a string."
               ((:newline) (list newline))
               ((:value obj &optional str) 
                (list (value-part obj str (istate.parts istate))))
+              ((:strong-value obj &optional str) 
+               (list (value-part obj str (istate.parts istate) t)))
               ((:label &rest strs)
                (list (list :label (apply #'cat (mapcar #'string strs)))))
               ((:action label lambda &key (refreshp t)) 
@@ -3154,10 +3156,10 @@ DSPEC is a string and LOCATION a source location. NAME is a string."
                      (value-part value nil (istate.parts istate))
                      newline)))))))
 
-(defun value-part (object string parts)
-  (list :value 
-        (or string (print-part-to-string object))
-        (assign-index object parts)))
+(defun value-part (object string parts &optional strong?)
+  (list (if strong? :strong-value  :value)
+            (or string (print-part-to-string object))
+            (assign-index object parts)))
 
 (defun action-part (label lambda refreshp actions)
   (list :action label (assign-index (list lambda refreshp) actions)))

--- a/swank.lisp
+++ b/swank.lisp
@@ -507,17 +507,6 @@ corresponding values in the CDR of VALUE."
   (check-type msg string)
   `(call-with-retry-restart ,msg (lambda () ,@body)))
 
-(defmacro with-struct* ((conc-name get obj) &body body)
-  (let ((var (gensym)))
-    `(let ((,var ,obj))
-       (macrolet ((,get (slot)
-                    (let ((getter (intern (concatenate 'string
-                                                       ',(string conc-name)
-                                                       (string slot))
-                                          (symbol-package ',conc-name))))
-                      `(,getter ,',var))))
-         ,@body))))
-
 (defmacro define-special (name doc)
   "Define a special variable NAME with doc string DOC.
 This is like defvar, but NAME will not be initialized."
@@ -3053,52 +3042,6 @@ DSPEC is a string and LOCATION a source location. NAME is a string."
 (defun xref>elisp (xref)
   (destructuring-bind (name loc) xref
     (list (to-string name) loc)))
-
-
-;;;;; Lazy lists
-
-(defstruct (lcons (:constructor %lcons (car %cdr))
-                  (:predicate lcons?))
-  car
-  (%cdr nil :type (or null lcons function))
-  (forced? nil))
-
-(defmacro lcons (car cdr)
-  `(%lcons ,car (lambda () ,cdr)))
-
-(defmacro lcons* (car cdr &rest more)
-  (cond ((null more) `(lcons ,car ,cdr))
-        (t `(lcons ,car (lcons* ,cdr ,@more)))))
-
-(defun lcons-cdr (lcons)
-  (with-struct* (lcons- @ lcons)
-    (cond ((@ forced?)
-           (@ %cdr))
-          (t
-           (let ((value (funcall (@ %cdr))))
-             (setf (@ forced?) t
-                   (@ %cdr) value))))))
-
-(defun llist-range (llist start end)
-  (llist-take (llist-skip llist start) (- end start)))
-
-(defun llist-skip (lcons index)
-  (do ((i 0 (1+ i))
-       (l lcons (lcons-cdr l)))
-      ((or (= i index) (null l))
-       l)))
-
-(defun llist-take (lcons count)
-  (let ((result '()))
-    (do ((i 0 (1+ i))
-         (l lcons (lcons-cdr l)))
-        ((or (= i count)
-             (null l)))
-      (push (lcons-car l) result))
-    (nreverse result)))
-
-(defun iline (label value)
-  `(:line ,label ,value))
 
 
 ;;;; Inspecting

--- a/swank.lisp
+++ b/swank.lisp
@@ -3044,7 +3044,7 @@ DSPEC is a string and LOCATION a source location. NAME is a string."
 
 (defun xref>elisp (xref)
   (destructuring-bind (name loc) xref
-    (list (to-string name) loc)))
+    (list (if (stringp name) name (to-string name) ) loc)))
 
 
 ;;;; Inspecting

--- a/swank.lisp
+++ b/swank.lisp
@@ -1958,14 +1958,17 @@ N.B. this is not an actual package name or nickname."
 
 WHAT can be:
   A pathname or a string,
+  A literal string (:string STRING)
   A list (PATHNAME-OR-STRING &key LINE COLUMN POSITION),
   A function name (symbol or cons),
   NIL. "
   (flet ((canonicalize-filename (filename)
            (pathname-to-filename (or (probe-file filename) filename))))
     (let ((target 
-           (etypecase what
-             (null nil)
+            (etypecase what
+              (null nil)
+              ((cons (eql :string) (cons string))
+               what)
              ((or string pathname) 
               `(:filename ,(canonicalize-filename what)))
              ((cons (or string pathname) *)
@@ -3135,6 +3138,8 @@ DSPEC is a string and LOCATION a source location. NAME is a string."
   (let ((newline '#.(string #\newline)))
     (etypecase part
       (string (list part))
+      ((cons (eql :multiple))
+       (mapcan (lambda(p) (prepare-part p istate)) (cdr part)))
       (cons (dcase part
               ((:newline) (list newline))
               ((:value obj &optional str) 
@@ -3145,7 +3150,7 @@ DSPEC is a string and LOCATION a source location. NAME is a string."
                (list (action-part label lambda refreshp
                                   (istate.actions istate))))
               ((:line label value)
-               (list (princ-to-string label) ": "
+               (list `(:label ,(princ-to-string label)) ": "
                      (value-part value nil (istate.parts istate))
                      newline)))))))
 
@@ -3377,7 +3382,7 @@ Return NIL if LIST is circular."
    (iline "Adjustable" (adjustable-array-p array))
    (iline "Fill pointer" (if (array-has-fill-pointer-p array)
                              (fill-pointer array)))
-   "Contents:" '(:newline)
+   `(:label "Contents:") '(:newline)
    (labels ((k (i max)
               (cond ((= i max) '())
                     (t (lcons (iline i (row-major-aref array i))

--- a/swank/backend.lisp
+++ b/swank/backend.lisp
@@ -1190,6 +1190,63 @@ SPEC can be:
 
 ;;;; Inspector
 
+(defmacro with-struct* ((conc-name get obj) &body body)
+  (let ((var (gensym)))
+    `(let ((,var ,obj))
+       (macrolet ((,get (slot)
+                    (let ((getter (intern (concatenate 'string
+                                                       ',(string conc-name)
+                                                       (string slot))
+                                          (symbol-package ',conc-name))))
+                      `(,getter ,',var))))
+         ,@body))))
+
+;;;;; Lazy lists (moved from swank.lisp)
+
+(defstruct (lcons (:constructor %lcons (car %cdr))
+                  (:predicate lcons?))
+  car
+  (%cdr nil :type (or null lcons function))
+  (forced? nil))
+
+(defmacro lcons (car cdr)
+  `(%lcons ,car (lambda () ,cdr)))
+
+(defmacro lcons* (car cdr &rest more)
+  (cond ((null more) `(lcons ,car ,cdr))
+        (t `(lcons ,car (lcons* ,cdr ,@more)))))
+
+(defun lcons-cdr (lcons)
+  (with-struct* (lcons- @ lcons)
+    (cond ((@ forced?)
+           (@ %cdr))
+          (t
+           (let ((value (funcall (@ %cdr))))
+             (setf (@ forced?) t
+                   (@ %cdr) value))))))
+
+(defun llist-range (llist start end)
+  (llist-take (llist-skip llist start) (- end start)))
+
+(defun llist-skip (lcons index)
+  (do ((i 0 (1+ i))
+       (l lcons (lcons-cdr l)))
+      ((or (= i index) (null l))
+       l)))
+
+(defun llist-take (lcons count)
+  (let ((result '()))
+    (do ((i 0 (1+ i))
+         (l lcons (lcons-cdr l)))
+        ((or (= i count)
+             (null l)))
+      (push (lcons-car l) result))
+    (nreverse result)))
+
+(defun iline (label value)
+  `(:line ,label ,value))
+
+
 (defgeneric emacs-inspect (object)
   (:documentation
    "Explain to Emacs how to inspect OBJECT.


### PR DESCRIPTION
Supersedes <https://github.com/slime/slime/pull/477> and <https://github.com/slime/slime/pull/376>.


Changes for abcl-1.5.0 that are forwards (1.6.0-dev) and backwards (1.4.0) compatible across versions of the ABCL implementation.  Requires the following:

## SLIME/SWANK Enhancements

1. Load swank matcher earlier so that it may be used by implementation-specific code (has architectural issues for SLIME loader vs. swank.lisp availablity to reuse between implementation specific code)

2. Refactor utilities used by implementation-specific inspector code into swank/backend.lisp

3. Add an inspector :strong-view for a view with a bolder face

4. Strings may edited in an emacs buffer from the inspector

Does not contain the fuzzy company mode DWIM symbol matching from <https://github.com/slime/slime/pull/477/commits/e15c4163cfca6cfdb042e6c8a9003e77f4527ca8>

