### PR TITLE
Added load path to autoloads.

### DIFF
--- a/slime-autoloads.el
+++ b/slime-autoloads.el
@@ -14,6 +14,9 @@
 
 ;;; Code:
 
+(add-to-list 'load-path (directory-file-name
+                         (or (file-name-directory #$) (car load-path))))
+
 (autoload 'slime "slime"
   "Start a Lisp subprocess and connect to its Swank server." t)
 


### PR DESCRIPTION
This is needed in order to make slime work in emacs 27. Because the new package-quickstart.el that is generated automatically needs to know where to search for slime. 

Otherwise we need to set the slime directory by hand which is not consistent with use-packages.