### PR TITLE
allow passing parameters to open-network-stream

### DIFF
--- a/slime.el
+++ b/slime.el
@@ -1097,7 +1097,7 @@ DIRECTORY change to this directory before starting the process.
 (defun slime-start* (options)
   (apply #'slime-start options))
 
-(defun slime-connect (host port &optional _coding-system interactive-p)
+(defun slime-connect (host port &optional _coding-system interactive-p &rest parameters)
   "Connect to a running Swank server. Return the connection."
   (interactive (list (read-from-minibuffer
                       "Host: " (cl-first slime-connect-host-history)
@@ -1113,7 +1113,7 @@ DIRECTORY change to this directory before starting the process.
              (y-or-n-p "Close old connections first? "))
     (slime-disconnect-all))
   (message "Connecting to Swank on port %S.." port)
-  (let* ((process (slime-net-connect host port))
+  (let* ((process (apply 'slime-net-connect host port parameters))
          (slime-dispatching-connection process))
     (slime-setup-connection process)))
 
@@ -1418,10 +1418,10 @@ first line of the file."
                              payload)))
         (process-send-string proc string)))))
 
-(defun slime-net-connect (host port)
+(defun slime-net-connect (host port &rest parameters)
   "Establish a connection with a CL."
   (let* ((inhibit-quit nil)
-         (proc (open-network-stream "SLIME Lisp" nil host port))
+         (proc (apply 'open-network-stream "SLIME Lisp" nil host port parameters))
          (buffer (slime-make-net-buffer " *cl-connection*")))
     (push proc slime-net-processes)
     (set-process-buffer proc buffer)


### PR DESCRIPTION
This allows for passing arguments to the `open-network-stream` function. 

In my use case, it allows me to perform x509 client certificate authentication when Swank is behind a reverse proxy providing SSL termination by connecting like

```lisp
(slime-connect "k-master" "30006" nil nil
               :tls-parameters (cons 'gnutls-x509pki
                                     (gnutls-boot-parameters
                                      :type 'gnutls-x509pki
                                      :hostname "*.dacodastrack.com"
                                      :keylist '(("/home/dacoda/.kube/dacoda@kubernetes-cluster.linode.key" 
                                                  "/home/dacoda/.kube/dacoda@kubernetes-cluster.linode.crt"))
                                      :trustfiles '("/home/dacoda/quicklisp/local-projects/orihime/orihime-secrets/tls/ca/ca.crt")
                                      :verify-error t)))
```

Perhaps the above could be worked into something like

```lisp
(defun slime-connect-over-tls (host port keylist trustfiles &optional server-certificate-name)
  "Connect to a swank server sitting behind an SSL-terminating reverse
  proxy.

KEYLIST is the keylist specified in `gnutls-boot-parameters` e.g.
'((\"/path/to/my/private.key\" \"/path/to/my/public.crt\")). This will
server as the source of your client certificate and thus your
authentication.

TRUSTFILES is a list of CA certificates that you would like to trust.

SERVER-CERTIFICATE-NAME is the common name of the server public
certificate, in case it is different than the host you are specifying
"
  (slime-connect host port nil nil
                 :tls-parameters (cons 'gnutls-x509pki
                                       (gnutls-boot-parameters
                                        :type 'gnutls-x509pki
                                        :hostname (or server-certificate-name host)
                                        :keylist keylist 
                                        :trustfiles trustfiles
                                        :verify-error t))))

(slime-connect-over-tls "k-master" "30006"
                        '(("/home/dacoda/.kube/dacoda@kubernetes-cluster.linode.key" 
                           "/home/dacoda/.kube/dacoda@kubernetes-cluster.linode.crt"))
                        '("/home/dacoda/quicklisp/local-projects/orihime/orihime-secrets/tls/ca/ca.crt")
                        "*.dacodastrack.com")
```