### PR TITLE
Added line, column kw args to swank-compile-string

### DIFF
--- a/swank.lisp
+++ b/swank.lisp
@@ -2496,9 +2496,9 @@ Record compiler notes signalled as `compiler-condition's."
   "Compile STRING (exerpted from BUFFER at POSITION).
 Record compiler notes signalled as `compiler-condition's."
   (let* ((offset (cadr (assoc :position position)))
-         (line-column (assoc :line position))
-         (line (cadr line-column))
-         (column (caddr line-column)))
+         (line-column (cdr (assoc :line position)))
+         (line (first line-column))
+         (column (second line-column)))
     (with-buffer-syntax ()
       (collect-notes
        (lambda () 

--- a/swank.lisp
+++ b/swank.lisp
@@ -2495,7 +2495,10 @@ Record compiler notes signalled as `compiler-condition's."
 (defslimefun compile-string-for-emacs (string buffer position filename policy)
   "Compile STRING (exerpted from BUFFER at POSITION).
 Record compiler notes signalled as `compiler-condition's."
-  (let ((offset (cadr (assoc :position position))))
+  (let* ((offset (cadr (assoc :position position)))
+         (line-column (assoc :line position))
+         (line (cadr line-column))
+         (column (caddr line-column)))
     (with-buffer-syntax ()
       (collect-notes
        (lambda () 
@@ -2504,6 +2507,8 @@ Record compiler notes signalled as `compiler-condition's."
                                  :buffer buffer
                                  :position offset 
                                  :filename filename
+                                 :line line
+                                 :column column
                                  :policy policy)))))))
 
 (defslimefun compile-multiple-strings-for-emacs (strings policy)

--- a/swank/abcl.lisp
+++ b/swank/abcl.lisp
@@ -498,8 +498,8 @@
                        (not (load fn)))))))))
 
 (defimplementation swank-compile-string (string &key buffer position filename
-                                                policy)
-  (declare (ignore filename policy))
+                                                line column policy)
+  (declare (ignore filename line column policy))
   (let ((jvm::*resignal-compiler-warnings* t)
         (*abcl-signaled-conditions* nil))
     (handler-bind ((warning #'handle-compiler-warning))

--- a/swank/allegro.lisp
+++ b/swank/allegro.lisp
@@ -567,8 +567,8 @@ to do this, this factors in the length of the inserted header itself."
        (not failure?)))))
 
 (defimplementation swank-compile-string (string &key buffer position filename
-                                         policy)
-  (declare (ignore policy))
+                                                line column policy)
+  (declare (ignore line column policy))
   (handler-case
       (with-compilation-hooks ()
         (let ((*buffer-name* buffer)

--- a/swank/backend.lisp
+++ b/swank/backend.lisp
@@ -510,7 +510,7 @@ such package."
   `(call-with-compilation-hooks (lambda () (progn ,@body))))
 
 (definterface swank-compile-string (string &key buffer position filename
-                                           policy)
+                                           line column policy)
   "Compile source from STRING.
 During compilation, compiler conditions must be trapped and
 resignalled as COMPILER-CONDITIONs.
@@ -527,6 +527,10 @@ source information.
 If POLICY is supplied, and non-NIL, it may be used by certain
 implementations to compile with optimization qualities of its
 value.
+
+If LINE and COLUMN are supplied, and non-NIL, they may be used
+by certain implementations as the line and column of the start of
+the string in FILENAME. Both LINE and COLUMN are 1-based.
 
 Should return T on successful compilation, NIL otherwise.
 ")

--- a/swank/ccl.lisp
+++ b/swank/ccl.lisp
@@ -203,8 +203,8 @@
 ;; Use a temp file rather than in-core compilation in order to handle
 ;; eval-when's as compile-time.
 (defimplementation swank-compile-string (string &key buffer position filename
-                                         policy)
-  (declare (ignore policy))
+                                                line column policy)
+  (declare (ignore line column policy))
   (with-compilation-hooks ()
     (let ((temp-file-name (ccl:temp-pathname))
           (ccl:*save-source-locations* t))

--- a/swank/clasp.lisp
+++ b/swank/clasp.lisp
@@ -285,8 +285,8 @@
 (defun tmpfile-to-buffer (tmp-file)
   (gethash tmp-file *tmpfile-map*))
 
-(defimplementation swank-compile-string (string &key buffer position filename policy)
-  (declare (ignore policy))
+(defimplementation swank-compile-string (string &key buffer position filename line column policy)
+  (declare (ignore line column policy)) ;; We will use line and column in the future
   (with-compilation-hooks ()
     (let ((*buffer-name* buffer)        ; for compilation hooks
           (*buffer-start-position* position))

--- a/swank/clisp.lisp
+++ b/swank/clisp.lisp
@@ -700,8 +700,8 @@ Execute BODY with NAME's function slot set to FUNCTION."
                          (not (load fasl-file)))))))))
 
 (defimplementation swank-compile-string (string &key buffer position filename
-                                         policy)
-  (declare (ignore filename policy))
+                                                line column policy)
+  (declare (ignore filename line column policy))
   (with-compilation-hooks ()
     (let ((*buffer-name* buffer)
           (*buffer-offset* position))

--- a/swank/cmucl.lisp
+++ b/swank/cmucl.lisp
@@ -291,8 +291,8 @@ NIL if we aren't compiling from a buffer.")
                       (not (load output-file)))))))))
 
 (defimplementation swank-compile-string (string &key buffer position filename
-                                         policy)
-  (declare (ignore filename policy))
+                                                line column policy)
+  (declare (ignore filename line column policy))
   (with-compilation-hooks ()
     (let ((*buffer-name* buffer)
           (*buffer-start-position* position)

--- a/swank/corman.lisp
+++ b/swank/corman.lisp
@@ -378,8 +378,8 @@
 		(or failure? (and load-p (load output-file))))))))
 
 (defimplementation swank-compile-string (string &key buffer position filename
-					 policy)
-  (declare (ignore filename policy))
+                                                line column policy)
+  (declare (ignore filename line column policy))
   (with-compilation-hooks ()
     (let ((*buffer-name* buffer)
           (*buffer-position* position)

--- a/swank/ecl.lisp
+++ b/swank/ecl.lisp
@@ -313,8 +313,8 @@
   (gethash tmp-file *tmpfile-map*))
 
 (defimplementation swank-compile-string
-    (string &key buffer position filename policy)
-  (declare (ignore policy))
+    (string &key buffer position filename line column policy)
+  (declare (ignore line column policy))
   (with-compilation-hooks ()
     (let ((*buffer-name* buffer)        ; for compilation hooks
           (*buffer-start-position* position))

--- a/swank/lispworks.lisp
+++ b/swank/lispworks.lisp
@@ -762,8 +762,8 @@ function names like \(SETF GET)."
 	   htab))
 
 (defimplementation swank-compile-string (string &key buffer position filename
-                                         policy)
-  (declare (ignore filename policy))
+                                                line column policy)
+  (declare (ignore filename line column policy))
   (assert buffer)
   (assert position)
   (let* ((location (list :emacs-buffer buffer position))

--- a/swank/mezzano.lisp
+++ b/swank/mezzano.lisp
@@ -93,8 +93,8 @@
     (funcall func)))
 
 (defimplementation swank-compile-string (string &key buffer position filename
-                                                policy)
-  (declare (ignore buffer policy))
+                                                line column policy)
+  (declare (ignore buffer line column policy))
   (let* ((*load-pathname* (ignore-errors (pathname filename)))
          (*load-truename* (when *load-pathname*
                             (ignore-errors (truename *load-pathname*))))

--- a/swank/mkcl.lisp
+++ b/swank/mkcl.lisp
@@ -265,8 +265,8 @@
                    (or failure-p
                        (and load-p (not (load output-truename))))))))))
 
-(defimplementation swank-compile-string (string &key buffer position filename policy)
-  (declare (ignore filename policy))
+(defimplementation swank-compile-string (string &key buffer position filename line column policy)
+  (declare (ignore filename line column policy))
   (with-compilation-hooks ()
     (let ((*buffer-name* buffer)
           (*buffer-start-position* position)

--- a/swank/sbcl.lisp
+++ b/swank/sbcl.lisp
@@ -733,7 +733,8 @@ QUALITIES is an alist with (quality . value)"
 (defvar *trap-load-time-warnings* t)
 
 (defimplementation swank-compile-string (string &key buffer position filename
-                                         policy)
+                                                line column policy)
+  (declare (ignore line column))
   (let ((*buffer-name* buffer)
         (*buffer-offset* position)
         (*buffer-substring* string)

--- a/swank/scl.lisp
+++ b/swank/scl.lisp
@@ -157,8 +157,8 @@
                       (not (load output-file)))))))))
 
 (defimplementation swank-compile-string (string &key buffer position filename
-                                                policy)
-  (declare (ignore filename policy))
+                                                line column policy)
+  (declare (ignore filename line column policy))
   (with-compilation-hooks ()
     (let ((*buffer-name* buffer)
           (*buffer-start-position* position)


### PR DESCRIPTION
This will pass the 1-based line and column source position
info (or NIL) to swank-compile-string.
The line and column source position information is
where the string to be compiled starts in the file
with the given filename.