### PR TITLE
Fix swank.asd for implementations which don't allow package modificat…

### DIFF
--- a/swank.asd
+++ b/swank.asd
@@ -19,10 +19,10 @@
 ;; This code has been placed in the Public Domain.  All warranties
 ;; are disclaimed.
 
-(defpackage :swank-loader
+(defpackage :swank-loader-asdf
   (:use :cl))
 
-(in-package :swank-loader)
+(in-package :swank-loader-asdf)
 
 (defclass swank-loader-file (asdf:cl-source-file) ())
 


### PR DESCRIPTION
…ions

It is unfortunately implementation dependent as to whether evaluating
DEFPACKAGE forms refering to an existing package modify the existing
package or not.  The overloading of the SWANK-LOADER package to
contain both ASDF definitions as well as exporting external symbols
breaks the use of swank.asd under implementations such as ABCL.