### PR TITLE
Fix loader for implementations which don't modify packages

### DIFF
--- a/swank.asd
+++ b/swank.asd
@@ -19,17 +19,16 @@
 ;; This code has been placed in the Public Domain.  All warranties
 ;; are disclaimed.
 
-(defpackage :swank-loader
-  (:use :cl))
-
-(in-package :swank-loader)
-
 (defclass swank-loader-file (asdf:cl-source-file) ())
 
 ;;;; after loading run init
 
 (defmethod asdf:perform ((o asdf:load-op) (f swank-loader-file))
+  ;; swank-loader computes its own source/fasl relation based on the
+  ;; TRUENAME of the loader file, so we need a "manual" CL:LOAD
+  ;; invocation here.
   (load (asdf::component-pathname f))
+  ;; After loading, run the swank-loader init routines.
   (funcall (read-from-string "swank-loader::init") :reload t))
 
 (asdf:defsystem :swank


### PR DESCRIPTION
It is unfortunately implementation dependent as to whether evaluating
DEFPACKAGE forms refering to an existing package modify the existing
package or not. The overloading of the SWANK-LOADER package to contain
both ASDF definitions as well as exporting external symbols breaks the
use of swank.asd under implementations such as ABCL.  We fix this by
delegating the necessary packages to the ASDF DEFSYSTEM loading
mechanism.

Supercedes <https://github.com/slime/slime/pull/537>.