### PR TITLE
fix spurious detection of allegro modern-mode

### DIFF
--- a/swank-loader.lisp
+++ b/swank-loader.lisp
@@ -97,7 +97,7 @@
   #+lispworks (lisp-implementation-version)
   #+allegro   (format nil "~@{~a~}"
                       excl::*common-lisp-version-number*
-                      (if (string= (symbol-name 'lisp) "LISP") "A" "M")     ; ANSI vs MoDeRn
+                      (if (string= 'lisp "LISP") "A" "M")     ; ANSI vs MoDeRn
                       (if (member :smp *features*) "s" "")
                       (if (member :64bit *features*) "-64bit" "")
                       (excl:ics-target-case

--- a/swank-loader.lisp
+++ b/swank-loader.lisp
@@ -97,7 +97,7 @@
   #+lispworks (lisp-implementation-version)
   #+allegro   (format nil "~@{~a~}"
                       excl::*common-lisp-version-number*
-                      (if (eq 'h 'H) "A" "M")     ; ANSI vs MoDeRn
+                      (if (string= (symbol-name 'lisp) "LISP") "A" "M")     ; ANSI vs MoDeRn
                       (if (member :smp *features*) "s" "")
                       (if (member :64bit *features*) "-64bit" "")
                       (excl:ics-target-case


### PR DESCRIPTION

Hi,

The `(eql 'h 'H)` test for Allegro MoDeRn-mode was incorrectly detecting modern-mode when evaluated in an ANSI mode image with `(readtable-case *readtable*)` set to `:invert`. 

This changes the test to check directly for whether a built-in CL symbol is in uppercase or not, which should be more reliable, because modern-mode images differ from ANSI mode images in precisely this regard. 

Thanks,

 Dave
