### PR TITLE
Ignore spawn errors when warming up cache

### DIFF
--- a/contrib/swank-asdf.lisp
+++ b/contrib/swank-asdf.lisp
@@ -510,9 +510,12 @@ already knows."
 ;; since it accesses a file-system, so run it once at the background
 ;; to initialize caches.
 (when (eql *communication-style* :spawn)
-  (spawn (lambda ()
-           (ignore-errors (list-all-systems-in-central-registry)))
-         :name "init-asdf-fs-caches"))
+  ;; in LispWorks, multiprocessing might not be ready at the time
+  ;; swank is loading, so we just ignore any errors with spawning.
+  (ignore-errors
+   (spawn (lambda ()
+            (ignore-errors (list-all-systems-in-central-registry)))
+          :name "init-asdf-fs-caches")))
 
 ;;; Hook for compile-file-for-emacs
 


### PR DESCRIPTION
In LispWorks when running a build script with `-build`, multiprocessing is not available by default. This makes it very convoluted to load swank (something like `(mp:initialize-multiprocessing :swank-loader nil (intern "INIT" "SWANK-LOADER") :load-contribs t)`).

That's unnecessary, and this pull request should fix it. (In particular, I had a weird situation where I *couldn't* launch multiprocessing during the build process.)