### PR TITLE
sbcl: Filter out invalid definition sources in find-definitions

### DIFF
--- a/swank/sbcl.lisp
+++ b/swank/sbcl.lisp
@@ -804,9 +804,22 @@ QUALITIES is an alist with (quality . value)"
          name
          (sb-introspect::definition-source-description source-location)))
 
+(defun categorize-definition-source (definition-source)
+  (with-definition-source (pathname form-path character-offset plist)
+    definition-source
+    (let ((file-p (and pathname (probe-file pathname)
+                       (or form-path character-offset))))
+      (cond ((and (getf plist :emacs-buffer) file-p) :buffer-and-file)
+            ((getf plist :emacs-buffer) :buffer)
+            (file-p :file)
+            (pathname :file-without-position)
+            (t :invalid)))))
+
 (defimplementation find-definitions (name)
   (loop for type in *definition-types* by #'cddr
-        for defsrcs = (sb-introspect:find-definition-sources-by-name name type)
+        for defsrcs = (remove :invalid
+                              (sb-introspect:find-definition-sources-by-name name type)
+                              :key #'categorize-definition-source)
         append (loop for defsrc in defsrcs collect
                      (list (make-dspec type name defsrc)
                            (converting-errors-to-error-location
@@ -859,17 +872,6 @@ QUALITIES is an alist with (quality . value)"
                        (cons `(,(first name) (,(reader (second name)) ,tmp)))
                        (t (error "Malformed syntax in WITH-STRUCT: ~A" name))))
             ,@body)))))
-
-(defun categorize-definition-source (definition-source)
-  (with-definition-source (pathname form-path character-offset plist)
-    definition-source
-    (let ((file-p (and pathname (probe-file pathname)
-                       (or form-path character-offset))))
-      (cond ((and (getf plist :emacs-buffer) file-p) :buffer-and-file)
-            ((getf plist :emacs-buffer) :buffer)
-            (file-p :file)
-            (pathname :file-without-position)
-            (t :invalid)))))
 
 #+#.(swank/backend:with-symbol 'definition-source-form-number 'sb-introspect)
 (defun form-number-position (definition-source stream)


### PR DESCRIPTION
They can't be visited, so filtering them eliminates this error:

    Error: DEFINITION-SOURCE of blah did not contain meaningful
    information

This commonly arises when a method is defined without a corresponding
defgeneric.