### PR TITLE
Make slime repl output read-only

### DIFF
--- a/contrib/slime-repl.el
+++ b/contrib/slime-repl.el
@@ -280,13 +280,14 @@ This is set to nil after displaying the buffer.")
       (slime-save-marker slime-output-start
         (slime-propertize-region '(face slime-repl-output-face
                                         slime-repl-output t
-                                        rear-nonsticky (face))
+                                        read-only t
+                                        rear-nonsticky t)
           (let ((inhibit-read-only t))
-	    (insert-before-markers string)
-	    (when (and (= (point) slime-repl-prompt-start-mark)
-		       (not (bolp)))
-	      (insert-before-markers "\n")
-	      (set-marker slime-output-end (1- (point))))))))
+	          (insert-before-markers string)
+	          (when (and (= (point) slime-repl-prompt-start-mark)
+		                   (not (bolp)))
+	            (insert-before-markers "\n")
+	            (set-marker slime-output-end (1- (point))))))))
     (when slime-repl-popup-on-output
       (setq slime-repl-popup-on-output nil)
       (display-buffer (current-buffer)))


### PR DESCRIPTION
I found it a bit jarring that it was possible to edit past output in the slime repl, so I messed around a bit & made the output read-only.

I should note that I don't know *why* `rear-nonsticky` was set as `face`, and therefore the new value of `t` is suspect: it doesn't *seem* to have changed anything visible & the tests all pass (except for one which fails even on the current `master`). However, I found that unless I changed the value for `rear-nonsticky`, formatting with `read-only t` would complain about some sort of "timer error" and never display the input prompt or cursor after any output had been written to the repl.

I was also hoping to do the same for the results returned by functions instead of just printed output: after trying to make analogous changes to `slime-repl.el/slime-repl-emit-result`, I figured out that this function wasn't actually involved in emitting results. The function actually responsible is `slime-presentations.el/slime-presentation-write-result`. Unfortunately trying the same trick makes the repl very slow to display evaluation results & seems to reset the font color.

Anyways. I thought I'd submit what I had. Perhaps who knows what they're doing could finish the job for evaluation results?