### PR TITLE
Comment full abort message to avoid syntax hilighting issues

### DIFF
--- a/contrib/slime-repl.el
+++ b/contrib/slime-repl.el
@@ -580,8 +580,10 @@ joined together."))
       (slime-save-marker slime-output-start
         (slime-save-marker slime-output-end
           (goto-char slime-output-end)
-          (insert-before-markers (format "; Evaluation aborted on %s.\n"
-                                         condition))
+          (let ((here (point)))
+            (insert-before-markers (format "%s\n"
+                                           condition))
+            (comment-region here (point)))
           (slime-repl-insert-prompt))))
     (slime-repl-show-maximum-output)))
 


### PR DESCRIPTION
The first line of error messages are printed with a leading semi-colon. The remaining lines, however, are not and as such syntax highlighting can be messed up by a quote. See the screenshot:

<img width="388" alt="Screen Shot 2020-04-27 at 8 49 29 PM" src="https://user-images.githubusercontent.com/16821631/80445287-b9302b80-88c8-11ea-8cb5-4472a1d457c2.png">

After this change:
<img width="218" alt="Screen Shot 2020-04-27 at 8 53 16 PM" src="https://user-images.githubusercontent.com/16821631/80445445-2643c100-88c9-11ea-9bbf-32191c6e4d2e.png">

