### PR TITLE
abcl: guard against repeated invocation to SWANK/BACKEND:WRAP

### DIFF
--- a/swank/abcl.lisp
+++ b/swank/abcl.lisp
@@ -95,7 +95,10 @@
   (format stream ">")
   nil)
 
-(wrap 'sys::%print-unreadable-object :more-informative :replace '%print-unreadable-object-java-too)
+;;; TODO: move such invocations out of toplevel?  
+(eval-when (:load-toplevel)
+  (unless (get 'sys::%print-unreadable-object 'swank/backend::slime-wrap) 
+    (wrap 'sys::%print-unreadable-object :more-informative :replace '%print-unreadable-object-java-too)))
 
 (defimplementation call-with-compilation-hooks (function)
   (funcall function))


### PR DESCRIPTION
Bug triggered by loading McCLIM.

TODO: investigate the "right way" to initialize```swank-backend:wrap``` hooks.