### PR TITLE
sldb-setup: don't assume there are more frames to show

### DIFF
--- a/slime.el
+++ b/slime.el
@@ -5307,7 +5307,9 @@ CONTS is a list of pending Emacs continuations."
       (setq sldb-backtrace-start-marker (point-marker))
       (save-excursion
         (if frames
-            (sldb-insert-frames (sldb-prune-initial-frames frames) t)
+            (let* ((initial-frames (sldb-prune-initial-frames frames))
+                   (more (slime-length> frames (length initial-frames))))
+              (sldb-insert-frames initial-frames more))
           (insert "[No backtrace]")))
       (run-hooks 'sldb-hook)
       (set-syntax-table lisp-mode-syntax-table))


### PR DESCRIPTION
Check to see if there are actually more frames to show before calling `sldb-insert-frames` (instead of always passing `t` as the second argument to `sldb-insert-frames`).  The number of frames given to `sldb-setup` could be the same as the number of frames returned by `sldb-prune-initial-frames`.

This prevents `--more--` from being shown when there aren't actually any more frames.

(I stumbled across this by invoking the debugger from the `*inferior-lisp*` buffer.)