### PR TITLE
slime-dispatching-connection cleanups

### DIFF
--- a/slime.el
+++ b/slime.el
@@ -440,7 +440,6 @@ This is a hack so that we can reinitilize the real slime-mode-map
 more easily. See `slime-init-keymaps'.")
 
 (defvar slime-buffer-connection)
-(defvar slime-dispatching-connection)
 (defvar slime-current-thread)
 
 (defun slime--on ()
@@ -1113,9 +1112,7 @@ DIRECTORY change to this directory before starting the process.
              (y-or-n-p "Close old connections first? "))
     (slime-disconnect-all))
   (message "Connecting to Swank on port %S.." port)
-  (let* ((process (apply 'slime-net-connect host port parameters))
-         (slime-dispatching-connection process))
-    (slime-setup-connection process)))
+  (slime-setup-connection (apply 'slime-net-connect host port parameters)))
 
 ;; FIXME: seems redundant
 (defun slime-start-and-init (options fun)


### PR DESCRIPTION
This removes an unnecessary binding and (related) defvar.

`slime-connect` binds `slime-dispatching-connection` before calling `slime-setup-connection`, which in turn immediately binds this variable to the same value.  There were previously other functions called during the scope of this binding in `slime-connect`, but those calls have since been removed.

There has been a defvar for `slime-dispatching-connection` with an initial value and docstring that occurs after the definition of `slime-connect`.  The defvar being removed here was added later in commit 55ef9ac0 when enabling lexical binding for slime.el, and this defvar was presumably only for making the binding in `slime-connect` dynamic.  With the removal of this binding this defvar is unnecessary.

(This is just something I noticed while looking into something else.)