### PR TITLE
Revert "sldb-setup: don't assume there are more frames to show"

### DIFF
--- a/slime.el
+++ b/slime.el
@@ -5304,9 +5304,7 @@ CONTS is a list of pending Emacs continuations."
       (setq sldb-backtrace-start-marker (point-marker))
       (save-excursion
         (if frames
-            (let* ((initial-frames (sldb-prune-initial-frames frames))
-                   (more (slime-length> frames (length initial-frames))))
-              (sldb-insert-frames initial-frames more))
+            (sldb-insert-frames (sldb-prune-initial-frames frames) t)
           (insert "[No backtrace]")))
       (run-hooks 'sldb-hook)
       (set-syntax-table lisp-mode-syntax-table))


### PR DESCRIPTION
Reverts slime/slime#569

Unfortunately my proposed fix in #569 was a bit too simplisitic.  It didn't correctly handle the case where the total number of frames is larger than `swank::*sldb-initial-frames*` and none of the initial frames were pruned by `sldb-prune-initial-frames`.  With the old behavior it's possible for `--more--` to be shown when there aren't any more frames available, but with the new behavior it's possible for `--more--` to not be shown when there are more frames.

The old behavior is better than the new behavior.  A proper fix for the old behavior will be a little more involved than just the comparison I proposed.