### PR TITLE
Image buffers

### DIFF
--- a/contrib/slime-media.el
+++ b/contrib/slime-media.el
@@ -11,25 +11,35 @@
    (add-hook 'slime-event-hooks 'slime-dispatch-media-event)))
 
 (defun slime-media-decode-image (image)
-  (mapcar (lambda (image)
-	    (if (plist-get image :data)
-		(plist-put image :data (base64-decode-string (plist-get image :data)))
-	      image))
-	  image))
+  (typecase image
+    (string (list :file image :type nil))
+    (list
+     (if (plist-get image :data)
+         (plist-put image :data (base64-decode-string (plist-get image :data)))
+         image))))
 
 (defun slime-dispatch-media-event (event)
   (slime-dcase event
-    ((:write-image image string)
-     (let ((img (or (find-image (slime-media-decode-image image))
-                    (create-image image))))
-       (slime-media-insert-image img string))
-     t)
-    ((:popup-buffer bufname string mode)
+   ((:write-image image string)
+    (prog1 t
+      (let ((decoded (slime-media-decode-image image)))
+        (destructuring-bind (&key file type data) decoded
+          (let ((img
+                  (or (find-image decoded)
+                      (destructuring-bind (&key file type (data nil dp) props)
+                          decoded
+                        (apply 'create-image
+                               (or file data)
+                               type
+                               dp
+                               props)))))
+            (slime-media-insert-image img string))))))
+   ((:popup-buffer bufname string mode)
+    (prog1 t
      (slime-with-popup-buffer (bufname :connection t :package t)
        (when mode (funcall mode))
        (princ string)
-       (goto-char (point-min)))
-     t)
+       (goto-char (point-min)))))
     (t nil)))
 
 (defun slime-media-insert-image (image string &optional bol)

--- a/swank.lisp
+++ b/swank.lisp
@@ -1054,7 +1054,8 @@ The processing is done in the extent of the toplevel restart."
         ((:reader-error packet condition)
          (encode-message `(:reader-error ,packet
                                          ,(safe-condition-message condition))
-                         (current-socket-io))))))
+                         (current-socket-io)))
+        (t (encode-message event (current-socket-io))))))
 
 
 (defun send-event (thread event)


### PR DESCRIPTION
First patch allows custom message to pass through swank.lisp without error.
The second one allows to pass base64 strings as :data directly

```
(swank::send-to-emacs
          `(:write-image (:data ,(base64:usb8-array-to-base64-string
                                  (vecto:with-canvas (:width 64 :height 64)
                                    (vecto:set-rgb-stroke 100 100 100)
                                    (vecto:move-to 0 0)
                                    (vecto:line-to 64 64)
                                    (vecto:stroke)
                                    (flexi-streams:with-output-to-sequence (out)
                                      (vecto:save-png-stream out)))))
            " "))
```