### PR TITLE
Specify nix path for install-nix-action in CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,13 @@ jobs:
       matrix:
         lisp: [ccl, sbcl]
         os: [ubuntu-latest]
-        emacs_version: [24-5, 25-3, 26-3, snapshot]
+        emacs_version: [24-5, 25-3, 26-3, 27-1, snapshot]
       fail-fast: false
     steps:
 
     - uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
     - uses: purcell/setup-emacs@master
       with:
         version: ${{ matrix.emacs_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,5 @@ jobs:
       with:
         version: ${{ matrix.emacs_version }}
     - uses: actions/checkout@v2
-    - run: nix-env -i ${{ matrix.lisp }}
+    - run: nix-env -i ${{ matrix.lisp }} -f '<nixpkgs>'
     - run: make LISP="${{ matrix.lisp }}" check


### PR DESCRIPTION
Should resolve recent build issues which were due to `install-nix-action` being slimmed down by default to not include any package sources.