### PR TITLE
Prevent creating a letftover buffer when loading the symbol table

### DIFF
--- a/lib/hyperspec.el
+++ b/lib/hyperspec.el
@@ -138,7 +138,7 @@ If you copy the HyperSpec to another location, customize the variable
 
 (defun common-lisp-hyperspec--parse-map-file (file)
   (with-temp-buffer
-    (insert-file-contents-literally file)
+    (insert-file-contents file)
     (goto-char (point-min))
     (let ((result '()))
       (while (< (point) (point-max))

--- a/lib/hyperspec.el
+++ b/lib/hyperspec.el
@@ -137,7 +137,8 @@ If you copy the HyperSpec to another location, customize the variable
     (forward-line)))
 
 (defun common-lisp-hyperspec--parse-map-file (file)
-  (with-current-buffer (find-file-noselect file)
+  (with-temp-buffer
+    (insert-file-contents-literally file)
     (goto-char (point-min))
     (let ((result '()))
       (while (< (point) (point-max))


### PR DESCRIPTION
When `common-lisp-hyperspec--parse-map-file` is run, it leaves open a buffer with the Map_Sym.txt file from the Hyperspec. By using `with-temp-buffer`, this patch prevents it.