### PR TITLE
fix error in slime-parse.el and slime-fontifying-fu.el when use the GCC Emacs

### DIFF
--- a/contrib/slime-fontifying-fu.el
+++ b/contrib/slime-fontifying-fu.el
@@ -150,7 +150,7 @@ position, or nil."
 (defun slime-extend-region-for-font-lock ()
   (when slime-highlight-suppressed-forms
     (condition-case c
-        (progn
+        (let (changedp)
           (cl-multiple-value-setq (changedp font-lock-beg font-lock-end)
             (slime-compute-region-for-font-lock font-lock-beg font-lock-end))
           changedp)
@@ -182,7 +182,7 @@ position, or nil."
                            (point)))))
     (cl-values (or (/= beg orig-beg) (/= end orig-end)) beg end)))
 
-
+
 (defun slime-activate-font-lock-magic ()
   (if (featurep 'xemacs)
       (let ((pattern `((slime-search-suppressed-forms

--- a/contrib/slime-fontifying-fu.el
+++ b/contrib/slime-fontifying-fu.el
@@ -150,7 +150,7 @@ position, or nil."
 (defun slime-extend-region-for-font-lock ()
   (when slime-highlight-suppressed-forms
     (condition-case c
-        (let (changedp)
+        (progn
           (cl-multiple-value-setq (changedp font-lock-beg font-lock-end)
             (slime-compute-region-for-font-lock font-lock-beg font-lock-end))
           changedp)
@@ -203,7 +203,8 @@ position, or nil."
 (let ((byte-compile-warnings '()))
   (mapc (lambda (sym)
           (cond ((fboundp sym)
-                 (unless (byte-code-function-p (symbol-function sym))
+                 (unless (or (byte-code-function-p (symbol-function sym))
+                             (subrp (symbol-function sym)))
                    (byte-compile sym)))
                 (t (error "%S is not fbound" sym))))
         '(slime-extend-region-for-font-lock

--- a/contrib/slime-parse.el
+++ b/contrib/slime-parse.el
@@ -59,7 +59,7 @@
         (cl-decf depth))
       (nreverse (car sexps)))))
 
-(defun slime-compare-char-syntax (get-char-fn syntax &optional unescaped)
+(defun slime-compare-char-syntax (get-char-fn syntax &optional (unescaped nil))
   "Returns t if the character that `get-char-fn' yields has
 characer syntax of `syntax'. If `unescaped' is true, it's ensured
 that the character is not escaped."

--- a/contrib/slime-parse.el
+++ b/contrib/slime-parse.el
@@ -59,7 +59,7 @@
         (cl-decf depth))
       (nreverse (car sexps)))))
 
-(defun slime-compare-char-syntax (get-char-fn syntax &optional (unescaped nil))
+(defun slime-compare-char-syntax (get-char-fn syntax &optional unescaped)
   "Returns t if the character that `get-char-fn' yields has
 characer syntax of `syntax'. If `unescaped' is true, it's ensured
 that the character is not escaped."
@@ -112,7 +112,8 @@ that the character is not escaped."
 
 (mapc (lambda (sym)
         (cond ((fboundp sym)
-               (unless (byte-code-function-p (symbol-function sym))
+               (unless (or (byte-code-function-p (symbol-function sym))
+                           (subrp (symbol-function sym)))
                  (byte-compile sym)))
               (t (error "%S is not fbound" sym))))
       '(slime-parse-form-upto-point


### PR DESCRIPTION
GCC Emacs is have a feature of auto compile elisp using libgccjit, that is before in other branch but in current  merged to HEAD of GNU Emacs currently.
To use should add configure option '--with-native-compilation'.