### PR TITLE
Add contrib folder to load-path to allow loading slime-fancy

### DIFF
--- a/slime.el
+++ b/slime.el
@@ -126,6 +126,12 @@ CONTRIBS is a list of contrib packages to load. If `nil', use
 
 (defun slime--setup-contribs ()
   "Load and initialize contribs."
+  (when slime-contribs
+    (let ((this-file (or
+                      load-file-name
+                      (and (boundp 'byte-compile-current-file) byte-compile-current-file)
+                      (buffer-file-name))))
+      (add-to-list 'load-path (expand-file-name "contrib" this-file))))
   (dolist (c slime-contribs)
     (unless (featurep c)
       (require c)


### PR DESCRIPTION
`slime-fancy` was added as a default `slime-contribs` package
at 921457d5bcc97dcae0cc1e0a8dc4259b14306557.
However, most users does not add `contrib` folder to `load-path`,
the require will fail.
This commit adds `contrib` folder path to user's `load-path`.

### Repro steps
1. Save below snippet as `~/.debug.emacs.d/slime/init.el`
   ```elisp
   ;;; init.el --- Sample clean init.el  -*- lexical-binding: t; -*-
   
   ;; ~/.debug.emacs.d/slime/init.el
   
   ;; you can run like 'emacs -q -l ~/.debug.emacs.d/slime/init.el'
   (when load-file-name
     (setq user-emacs-directory
           (expand-file-name (file-name-directory load-file-name))))
   
   (setq debug-on-error t)
   (setq init-file-debug t)
   
   (setq package-archives '(("org"   . "https://orgmode.org/elpa/")
                            ("melpa" . "https://melpa.org/packages/")
                            ("gnu"   . "https://elpa.gnu.org/packages/")))
   (package-initialize)
   
   (package-refresh-contents)
   
   (package-install 'slime)
   (require 'slime)
   ```
2. Run Emacs via `emacs -q -l ~/.debug.emacs.d/slime/init.el`
3. M-x `slime`
4. You should see like below error/stacktrace.
   ```
   Debugger entered--Lisp error: (file-missing "Cannot open load file" "No such file or directory" "slime-fancy")
     require(slime-fancy)
     (if (featurep c) nil (require c) (let ((init (intern (format "%s-init" c)))) (if (fboundp init) (progn (func
     (let ((c (car --dolist-tail--))) (if (featurep c) nil (require c) (let ((init (intern (format "%s-init" c)))
     (while --dolist-tail-- (let ((c (car --dolist-tail--))) (if (featurep c) nil (require c) (let ((init (intern
     (let ((--dolist-tail-- slime-contribs)) (while --dolist-tail-- (let ((c (car --dolist-tail--))) (if (feature
     slime--setup-contribs()
     (progn (if (member 'lisp-mode slime-lisp-modes) (progn (add-hook 'lisp-mode-hook 'slime-lisp-mode-hook))) (i
     (progn (if --cl-rest-- (signal 'wrong-number-of-arguments (list 'slime-setup (+ 1 (length --cl-rest--))))) (
     (let* ((contribs-p (and --cl-rest-- t)) (contribs (car-safe (prog1 --cl-rest-- (setq --cl-rest-- (cdr --cl-r
     slime-setup()
     slime()
     funcall-interactively(slime)
     call-interactively(slime record nil)
     command-execute(slime record)
     execute-extended-command(nil "slime" "slime")
     funcall-interactively(execute-extended-command nil "slime" "slime")
     call-interactively(execute-extended-command nil nil)
     command-execute(execute-extended-command)
   ```