### PR TITLE
Add keyword-args to macro "define-minor-mode" to eliminate deprecation

### DIFF
--- a/contrib/slime-fuzzy.el
+++ b/contrib/slime-fuzzy.el
@@ -126,9 +126,9 @@ temporarily during completion.")
 fuzzy completions in the target buffer. Most of the bindings will
 do an implicit select in the completion window and let the
 keypress be processed in the target buffer."
-  nil
-  nil
-  slime-target-buffer-fuzzy-completions-map)
+  :init-value nil
+  :lighter nil
+  :keymap slime-target-buffer-fuzzy-completions-map)
 
 (add-to-list 'minor-mode-alist
              '(slime-fuzzy-target-buffer-completions-mode

--- a/contrib/slime-repl.el
+++ b/contrib/slime-repl.el
@@ -479,9 +479,9 @@ joined together."))
 (define-minor-mode slime-repl-map-mode
   "Minor mode which makes slime-repl-mode-map available.
 \\{slime-repl-mode-map}"
-  nil
-  nil
-  slime-repl-mode-map)
+  :init-value nil
+  :lighter nil
+  :keymap slime-repl-mode-map)
 
 (defun slime-repl-mode ()
   "Major mode for interacting with a superior Lisp.
@@ -1223,8 +1223,8 @@ The handler will use qeuery to ask the use if the error should be ingored."
 (define-minor-mode slime-repl-read-mode
   "Mode to read input from Emacs
 \\{slime-repl-read-mode-map}"
-  nil
-  "[read]")
+  :init-value nil
+  :lighter "[read]")
 
 (make-variable-buffer-local
  (defvar slime-read-string-threads nil))

--- a/contrib/slime-trace-dialog.el
+++ b/contrib/slime-trace-dialog.el
@@ -135,7 +135,8 @@ inspecting details of traced functions. Invoke this dialog with C-c T."
 
 (define-minor-mode slime-trace-dialog-hide-details-mode
   "Hide details in `slime-trace-dialog-mode'"
-  nil " Brief"    
+  :init-value nil
+  :lighter " Brief"
   :group 'slime-trace-dialog
   (unless (derived-mode-p 'slime-trace-dialog-mode)
     (error "Not a SLIME Trace Dialog buffer"))
@@ -143,7 +144,8 @@ inspecting details of traced functions. Invoke this dialog with C-c T."
 
 (define-minor-mode slime-trace-dialog-autofollow-mode
   "Automatically open buffers with trace details from `slime-trace-dialog-mode'"
-  nil " Autofollow"
+  :init-value nil
+  :lighter " Autofollow"
   :group 'slime-trace-dialog
   (unless (derived-mode-p 'slime-trace-dialog-mode)
     (error "Not a SLIME Trace Dialog buffer")))

--- a/lib/macrostep.el
+++ b/lib/macrostep.el
@@ -497,7 +497,8 @@ Use \\[macrostep-collapse-all] or collapse all visible expansions to
 quit and return to normal editing.
 
 \\{macrostep-keymap}"
-  nil " Macro-Stepper"
+  :init-value nil
+  :lighter " Macro-Stepper"
   :keymap macrostep-keymap
   :group macrostep
   (if macrostep-mode

--- a/slime.el
+++ b/slime.el
@@ -672,9 +672,9 @@ If BOTHP is true also add bindings with control modifier."
 (define-minor-mode slime-editing-mode
   "Minor mode which makes slime-editing-map available.
 \\{slime-editing-map}"
-  nil
-  nil
-  slime-editing-map)
+  :init-value nil
+  :lighter nil
+  :keymap slime-editing-map)
 
 
 ;;;; Framework'ey bits
@@ -919,7 +919,9 @@ MODE is the name of a major mode which will be enabled.
 
 (define-minor-mode slime-popup-buffer-mode
   "Mode for displaying read only stuff"
-  nil nil nil
+  :init-value nil
+  :lighter nil
+  :keymap nil
   (setq buffer-read-only t))
 
 (add-to-list 'minor-mode-alist
@@ -4173,9 +4175,9 @@ in Lisp when committed with \\[slime-edit-value-commit]."
 
 (define-minor-mode slime-edit-value-mode
   "Mode for editing a Lisp value."
-  nil
-  " Edit-Value"
-  '(("\C-c\C-c" . slime-edit-value-commit)))
+  :init-value nil
+  :lighter " Edit-Value"
+  :keymap '(("\C-c\C-c" . slime-edit-value-commit)))
 
 (defun slime-edit-value-callback (form-string current-value package)
   (let* ((name (generate-new-buffer-name (format "*Edit %s*" form-string)))
@@ -4856,9 +4858,9 @@ When displaying XREF information, this goes to the previous reference."
 
 (define-minor-mode slime-macroexpansion-minor-mode
   "SLIME mode for macroexpansion"
-  nil
-  " Macroexpand"
-  '(("g" . slime-macroexpand-again)))
+  :init-value nil
+  :lighter " Macroexpand"
+  :keymap '(("g" . slime-macroexpand-again)))
 
 (cl-macrolet ((remap (from to)
                      `(dolist (mapping


### PR DESCRIPTION
The macro "define-minor-mode" takes keyword arguments rather than
positional arguments, and a "deprecation" warning is given wherever the keyword
arguments are missing.  These changes add keyword arguments where they are missing
to eliminate the warnings.