### PR TITLE
UNIX domain socket support in a non-exclusive way

### DIFF
--- a/packages.lisp
+++ b/packages.lisp
@@ -137,6 +137,7 @@
   (:export #:startup-multiprocessing
            #:start-server
            #:create-server
+           #:create-server-unix
            #:stop-server
            #:restart-server
            #:ed-in-emacs

--- a/slime-tests.el
+++ b/slime-tests.el
@@ -1292,10 +1292,29 @@ This test will fail more likely before dispatch caches are warmed up."
                                              :dont-close nil)))))
            (slime-sync-to-top-level 3)
            (slime-disconnect)
-           (slime-test-expect "Number of connections must remane the same"
+           (slime-test-expect "Number of connections must remain the same"
                               connection-count
                               (length slime-net-processes)))
       (slime-select-connection old-connection))))
+
+(def-slime-test (unix-connect-disconnect (:style :spawn)) ()
+    "`create-serve-unix' should be able to connect to a UNIX domain socket"
+    '(())
+  (let ((connection-count (length slime-net-processes))
+        (old-connection slime-default-connection)
+        (slime-connected-hook nil))
+    (unwind-protect
+        (progn
+          (slime-eval `(swank:create-server-unix "/tmp/slime-socket"))
+          (let ((slime-dispatching-connection
+                 (slime-connect-unix "/tmp/slime-socket" t)))
+            (slime-sync-to-top-level 3)
+            (slime-disconnect)
+            (slime-test-expect "Number of connections must remain the same"
+                               connection-count
+                               (length slime-net-processes))))
+      (slime-select-connection old-connection))))
+
 
 (def-slime-test disconnect-and-reconnect
     ()

--- a/slime.el
+++ b/slime.el
@@ -1096,6 +1096,12 @@ DIRECTORY change to this directory before starting the process.
 (defun slime-start* (options)
   (apply #'slime-start options))
 
+(defun slime--maybe-ask-for-closing-connections ()
+  "Ask for closing old connections if there are any."
+  (when (and slime-net-processes
+             (y-or-n-p "Close old connections first? "))
+    (slime-disconnect-all)))
+
 (defun slime-connect (host port &optional _coding-system interactive-p &rest parameters)
   "Connect to a running Swank server. Return the connection."
   (interactive (list (read-from-minibuffer
@@ -1107,12 +1113,23 @@ DIRECTORY change to this directory before starting the process.
                        nil nil '(slime-connect-port-history . 1)))
                      nil t))
   (slime-setup)
-  (when (and interactive-p
-             slime-net-processes
-             (y-or-n-p "Close old connections first? "))
-    (slime-disconnect-all))
+
+  (when interactive-p
+    (slime--maybe-ask-for-closing-connections))
+
   (message "Connecting to Swank on port %S.." port)
   (slime-setup-connection (apply 'slime-net-connect host port parameters)))
+
+(defun slime-connect-unix (socket-path &optional skip-close-check &rest parameters)
+  "Connect to a running Swank server via a UNIX socket. Return the connection."
+  (interactive "fUNIX socket: ")
+  (slime-setup)
+
+  (unless skip-close-check
+    (slime--maybe-ask-for-closing-connections))
+
+  (message "Connecting to Swank on UNIX socket %S..." socket-path)
+  (slime-setup-connection (apply 'slime-net-connect-unix socket-path parameters)))
 
 ;; FIXME: seems redundant
 (defun slime-start-and-init (options fun)
@@ -1427,6 +1444,23 @@ first line of the file."
     (slime-set-query-on-exit-flag proc)
     (when (fboundp 'set-process-coding-system)
       (set-process-coding-system proc 'binary 'binary))
+    (slime-send-secret proc)
+    proc))
+
+(defun slime-net-connect-unix (socket-path &rest parameters)
+  "Establish a connection with a CL via a UNIX domain socket."
+  (let* ((inhibit-quit nil)
+         (buffer (slime-make-net-buffer "*cl-connection*"))
+         (proc (make-network-process
+                :name "SLIME Lisp (local socket)"
+                :buffer buffer
+                :filter 'slime-net-filter
+                :sentinel 'slime-net-sentinel
+                :family 'local
+                :service socket-path
+                :coding 'binary)))
+    (push proc slime-net-processes)
+    (slime-set-query-on-exit-flag proc)
     (slime-send-secret proc)
     proc))
 

--- a/swank.lisp
+++ b/swank.lisp
@@ -712,9 +712,9 @@ If PACKAGE is not specified, the home package of SYMBOL is used."
                                     (dont-close *dont-close*))
   "Start the server and write the listen port number to PORT-FILE.
 This is the entry point for Emacs."
-  (setup-server 0
+  (setup-server (lambda () (socket-quest 0 nil)) ;; socket-provider-fn
                 (lambda (port) (announce-server-port port-file port))
-                style dont-close nil))
+                style dont-close))
 
 (defun create-server (&key (port default-server-port)
                         (style *communication-style*)
@@ -729,8 +729,21 @@ Optionally, an INTERFACE could be specified and swank will bind
 the PORT on this interface. By default, interface is \"localhost\"."
   (let ((*loopback-interface* (or interface
                                   *loopback-interface*)))
-    (setup-server port #'simple-announce-function
-                  style dont-close backlog)))
+    (setup-server (lambda () (socket-quest port backlog)) ;; socket-provider-fn
+                  #'simple-announce-function
+                  style dont-close)))
+
+(defun create-server-unix (socket-path &key
+                                         (style *communication-style*)
+                                         (dont-close nil)
+                                         backlog)
+  "Start a SWANK server on the UNIX socket at SOCKET-PATH running in STYLE.
+If DONT-CLOSE is true then the listen socket will accept multiple
+connections, otherwise it will be closed after the first."
+  (setup-server
+   (lambda () (create-local-socket socket-path :backlog backlog))
+   #'simple-announce-function
+   style dont-close))
 
 (defun find-external-format-or-lose (coding-system)
   (or (find-external-format coding-system)
@@ -754,9 +767,9 @@ e.g.: (restart-loop (http-request url) (use-value (new) (setq url new)))"
         (ignore-errors (list (parse-integer (read-line *query-io*)))))
       (setq port new-port))))
 
-(defun setup-server (port announce-fn style dont-close backlog)
+(defun setup-server (socket-provider-fn announce-fn style dont-close)
   (init-log-output)
-  (let* ((socket (socket-quest port backlog))
+  (let* ((socket (funcall socket-provider-fn))
          (port (local-port socket)))
     (funcall announce-fn port)
     (labels ((serve () (accept-connections socket style dont-close))

--- a/swank/backend.lisp
+++ b/swank/backend.lisp
@@ -336,10 +336,14 @@ form suitable for testing with #+."
   (default-utf8-to-string octets))
 
 
-;;;; TCP server
+;;;; Socket server
 
 (definterface create-socket (host port &key backlog)
   "Create a listening TCP socket on interface HOST and port PORT.
+BACKLOG queue length for incoming connections.")
+
+(definterface create-local-socket (socket-path &key backlog)
+  "Create a listening local (currently: UNIX domain) socket at SOCKET-PATH.
 BACKLOG queue length for incoming connections.")
 
 (definterface local-port (socket)

--- a/swank/sbcl.lisp
+++ b/swank/sbcl.lisp
@@ -92,7 +92,7 @@
                                                      #+sb-unicode #\Replacement_Character
                                                      #-sb-unicode #\? )))
 
-;;; TCP Server
+;;; Socket Server
 
 (defimplementation preferred-communication-style ()
   (cond
@@ -130,6 +130,21 @@
 
     (sb-bsd-sockets:socket-listen socket (or backlog 5))
     socket))
+
+#+unix
+(defimplementation create-local-socket (socket-path &key backlog)
+  (handler-case
+      (sb-posix:unlink socket-path)
+    ;; We don't care if it doesn't exist yet
+    (sb-posix:syscall-error ()))
+  (let ((socket (make-instance 'sb-bsd-sockets:local-socket :type :stream)))
+    (sb-bsd-sockets:socket-bind socket socket-path)
+    (sb-bsd-sockets:socket-listen socket (or backlog 5))
+    socket))
+
+;; #-unix
+;; (defimplementation create-local-socket (socket-path &key backlog)
+;;   )
 
 (defimplementation local-port (socket)
   (nth-value 1 (sb-bsd-sockets:socket-name socket)))


### PR DESCRIPTION
Opening TCP sockets, even locally, is somewhat tricky from a security point of view (see #286)... especially when connecting to remote Lisps when we don't want to close the port immediately.

#291 was aiming to solve this problem by switching over to UNIX domain sockets entirely when connecting to Lisps on UNIX systems, and sticking with TCP ports e.g. on Windows. However, this doesn't account for cases when we'd still want to keep using TCP ports on UNIX; also, its author is not interested in working on this anymore.

This PR follows a slightly different approach: instead of replacing the existing, TCP-based connection mechanism, it adds UNIX domain sockets as an additional, optional mechanism. We still connect to local Lisps via TCP; the use case for this is long-running Lisp images on servers, that we'd want to connect to remotely (e.g. by using ssh to forward the UNIX socket, or wrapping it into a client-cert-checked SSL tunnel using e.g. socat). It's definitely possible to use this sort of mechanism for local Lisps too in the future; it's just not being done yet, to keep things simple (& avoid breaking too many things).

I also added a test to make sure that this does in fact work, end to end.

It currently only supports SBCL; I can definitely put in backend functions for other Lisps, too, before merging, if you think this entire PR is a good idea in general (... if it isn't, universal support is kinda pointless :) so the first commit is mainly to start a discussion.) 

Thanks for taking a look!