### PR TITLE
abcl: restore conditional guards for JSS

### DIFF
--- a/swank/abcl.lisp
+++ b/swank/abcl.lisp
@@ -476,11 +476,11 @@
     (backtrace start end)))
 
 ;; Don't count on JSS being loaded, but if it is then there's some more stuff we can do
-+#+#.(swank/backend:with-symbol 'invoke-restargs 'jss)
+#+#.(swank/backend:with-symbol 'invoke-restargs 'jss)
 (defun jss-p ()
   (and (member "JSS" *modules* :test 'string=) (intern "INVOKE-RESTARGS" "JSS")))
 
-+#+#.(swank/backend:with-symbol 'invoke-restargs 'jss)
+#+#.(swank/backend:with-symbol 'invoke-restargs 'jss)
 (defun matches-jss-call (form)
   (flet ((gensymp (s) (and (symbolp s) (null (symbol-package s))))
          (invokep (s)  (and (symbolp s) (eq s (jss-p)))))
@@ -1367,6 +1367,7 @@
                   `("  " (:label ,(string-downcase (string name))) ": " (:value ,value) (:newline))))
         `("No slots available for inspection."))))
 
+#+#.(swank/backend:with-symbol 'get-java-field 'jss)
 (defmethod emacs-inspect ((object sys::structure-class))
   (let* ((name (jss::get-java-field object "name" t))
          (def (get name  'system::structure-definition)))


### PR DESCRIPTION
Somehow, some of the conditional guards for the presence of JSS, had
acquired a extraneous character.  We fix that, but note that running
SLIME under ABCL in the absence of loading the JSS contrib does not
fully work as expected.  Since the usual deployment is that JSS will
be available by ACBL-CONTRIB, this should not effect the majority of
usage scenarios.