### PR TITLE
abcl: fix edit location finding in jar files

### DIFF
--- a/swank/abcl.lisp
+++ b/swank/abcl.lisp
@@ -1005,7 +1005,7 @@
       (when (atom what)
         (setq what (list what sym)))
       (list (definition-specifier what)
-            (if (ext:pathname-jar-p path2)
+            (if (ext:pathname-jar-p (pathname path2))
                 `(:location
                   (:zip ,@(split-string (subseq path2 (length "jar:file:")) "!/"))
                   ;; pos never seems right. Use function name.


### PR DESCRIPTION
(Alan Ruttenberg)

Originally
<https://github.com/alanruttenberg/slime/commit/1d17cbcafb4c4c2675c037c12f036b1a90e76bc7>.

Addresses <https://github.com/armedbear/abcl/issues/411>.