### PR TITLE
Use xref-push-marker-stack when available

### DIFF
--- a/slime.el
+++ b/slime.el
@@ -3674,7 +3674,9 @@ alist but ignores CDRs."
 (defun slime-push-definition-stack ()
   "Add point to find-tag-marker-ring."
   (require 'etags)
-  (ring-insert find-tag-marker-ring (point-marker)))
+  (if (fboundp 'xref-push-marker-stack)
+      (xref-push-marker-stack)
+    (ring-insert find-tag-marker-ring (point-marker))))
 
 (defun slime-pop-find-definition-stack ()
   "Pop the edit-definition stack and goto the location."


### PR DESCRIPTION
Inserting directly into `find-tag-marker-ring` is obsolete since emacs 25.1.  As
of emacs 29 slime no longer is able to jump back and forth between definition
and usage with `M-.` and `M-,`.  As a precaution for backwards compatibility, we
use `xref-push-marker-stack` only when it is bound.