### PR TITLE
Upgrade license to GPLv3

### DIFF
--- a/contrib/inferior-slime.el
+++ b/contrib/inferior-slime.el
@@ -1,7 +1,19 @@
 ;;; inferior-slime.el --- Minor mode with Slime keys for comint buffers
 ;;
 ;; Author: Luke Gorrie  <luke@synap.se>
-;; License: GNU GPL (same license as Emacs)
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 ;;
 ;;; Installation:
 ;;

--- a/contrib/slime-cl-indent.el
+++ b/contrib/slime-cl-indent.el
@@ -10,18 +10,18 @@
 
 ;; This file is forked from cl-indent.el, which is part of GNU Emacs.
 
-;; GNU Emacs is free software: you can redistribute it and/or modify
+;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
 ;; (at your option) any later version.
 
-;; GNU Emacs is distributed in the hope that it will be useful,
+;; This program is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
 
 ;; You should have received a copy of the GNU General Public License
-;; along with GNU Emacs.  If not, see <http://www.gnu.org/licenses/>.
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 

--- a/slime-autoloads.el
+++ b/slime-autoloads.el
@@ -2,8 +2,18 @@
 
 ;; Copyright (C) 2007  Helmut Eller
 
-;; This file is protected by the GNU GPLv2 (or later), as distributed
-;; with GNU Emacs.
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 

--- a/slime-tests.el
+++ b/slime-tests.el
@@ -8,20 +8,18 @@
 ;;
 ;;     For a detailed list of contributors, see the manual.
 ;;
-;;     This program is free software; you can redistribute it and/or
-;;     modify it under the terms of the GNU General Public License as
-;;     published by the Free Software Foundation; either version 2 of
-;;     the License, or (at your option) any later version.
+;;     This program is free software; you can redistribute it and/or modify
+;;     it under the terms of the GNU General Public License as published by
+;;     the Free Software Foundation, either version 3 of the License, or
+;;     (at your option) any later version.
 ;;
 ;;     This program is distributed in the hope that it will be useful,
 ;;     but WITHOUT ANY WARRANTY; without even the implied warranty of
-;;     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+;;     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;;     GNU General Public License for more details.
 ;;
-;;     You should have received a copy of the GNU General Public
-;;     License along with this program; if not, write to the Free
-;;     Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,
-;;     MA 02111-1307, USA.
+;;     You should have received a copy of the GNU General Public License
+;;     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
 ;;;; Tests

--- a/slime.el
+++ b/slime.el
@@ -13,20 +13,18 @@
 ;;
 ;;     For a detailed list of contributors, see the manual.
 ;;
-;;     This program is free software; you can redistribute it and/or
-;;     modify it under the terms of the GNU General Public License as
-;;     published by the Free Software Foundation; either version 2 of
-;;     the License, or (at your option) any later version.
+;;     This program is free software; you can redistribute it and/or modify
+;;     it under the terms of the GNU General Public License as published by
+;;     the Free Software Foundation, either version 3 of the License, or
+;;     (at your option) any later version.
 ;;
 ;;     This program is distributed in the hope that it will be useful,
 ;;     but WITHOUT ANY WARRANTY; without even the implied warranty of
-;;     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+;;     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;;     GNU General Public License for more details.
 ;;
-;;     You should have received a copy of the GNU General Public
-;;     License along with this program; if not, write to the Free
-;;     Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,
-;;     MA 02111-1307, USA.
+;;     You should have received a copy of the GNU General Public License
+;;     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 


### PR DESCRIPTION
Please consider upgrading the license to GPLv3.

Reasons why:
https://lists.gnu.org/archive/html/emacs-devel/2017-07/msg01069.html
https://www.gnu.org/licenses/rms-why-gplv3.html

The main file of this project says:

```
;; This program is free software; you can redistribute it and/or modify
;; it under the terms of the GNU General Public License as published by
;; the Free Software Foundation, either version 2 of the License, or
;; (at your option) any later version.
```

So this upgrade should be unproblematic.

Thanks!