### PR TITLE
Append swank-loader's `dirname` to *default-fasl-dir*

### DIFF
--- a/swank-loader.lisp
+++ b/swank-loader.lisp
@@ -159,7 +159,8 @@ Return nil if nothing appropriate is available."
    (make-pathname
     :directory `(:relative ".slime" "fasl"
                  ,@(if (slime-version-string) (list (slime-version-string)))
-                 ,(unique-dir-name)))
+                 ,(unique-dir-name)
+                 ,@(if *load-truename* (cdr (pathname-directory *load-truename*)))))
    (user-homedir-pathname)))
 
 (defvar *fasl-directory* (default-fasl-dir)


### PR DESCRIPTION
At the moment, Slime's fasl files are getting cached inside a directory
whose location takes into account:

- The current user's home
- Slime's version
- A _fingerprint_ of the CL implementation / OS where Slime is getting
  run

However, if you had two different versions of Slime and wanted to
switch between them (e.g.
`(pushnew #P"~/opt/slime/__main__/" asdf:*central-registry*)` vs
`(pushnew #P"~/opt/slime/upstream-master/" asdf:*central-registry*)`),
in doing so you would also be foreced to _touch_ any .lisp file
contained inside the directory of the _acive_ version or chances are that
the fasls from the now _inactive_ version will end up getting loaded
instead (especially if more recent).

Having said that, appending to *default-fasl-dir* the directory where
swank-loader.lisp is getting loaded from should be enough to solve this
issue.

On my laptop, prior to this commit I would get:

    * swank-loader:*fasl-directory*
    #P"/Users/matteolandi/.slime/fasl/2.27/sbcl-2.1.9-darwin-x86-64/"

With this commit instead:

    * swank-loader:*fasl-directory*
    #P"/Users/matteolandi/.slime/fasl/2.27/sbcl-2.1.9-darwin-x86-64/Users/matteolandi/my-env/opt/slime/__main__/"