### PR TITLE
Don't allow duplicate entries in the source file cache.

### DIFF
--- a/swank/source-file-cache.lisp
+++ b/swank/source-file-cache.lisp
@@ -71,7 +71,8 @@ If the exact version cannot be found then return the current one from disk."
   "Return the source code for FILENAME as written on DATE in a string.
 Return NIL if the right version cannot be found."
   (when *cache-sourcecode*
-    (let ((entry (gethash filename *source-file-cache*)))
+    (let* ((filename (pathname filename))
+           (entry (gethash filename *source-file-cache*)))
       (cond ((and entry (equal date (source-cache-entry.date entry)))
              ;; Cache hit.
              (source-cache-entry.text entry))
@@ -88,7 +89,7 @@ Return NIL if the right version cannot be found."
 
 (defun source-cached-p (filename)
   "Is any version of FILENAME in the source cache?"
-  (if (gethash filename *source-file-cache*) t))
+  (if (gethash (pathname filename) *source-file-cache*) t))
 
 (defun read-file (filename)
   "Return the entire contents of FILENAME as a string."


### PR DESCRIPTION
It's an EQUAL hash table, so make sure NAMESTRINGs are converted to
PATHNAMEs. This assumes that the filename is never NIL.