### PR TITLE
swank.asd: Do not reload SWANK.

### DIFF
--- a/swank.asd
+++ b/swank.asd
@@ -6,6 +6,13 @@
 ;; This is only useful if you want to start a Swank server in a Lisp
 ;; processes that doesn't run under Emacs. Lisp processes created by
 ;; `M-x slime' automatically start the server.
+;;
+;; If Swank is already loaded (e.g. the Lisp is running under SLIME),
+;; then attempts to load it via asdf do nothing, except for emitting a
+;; warning if Swank is to be loaded from a location that's different
+;; from the location where it was originally loaded from. This
+;; behavior is intended to prevent loading a possibly incompatible
+;; version of Swank with a running SLIME.
 
 ;; Usage:
 ;;
@@ -24,12 +31,21 @@
 ;;;; after loading run init
 
 (defmethod asdf:perform ((o asdf:load-op) (f swank-loader-file))
-  ;; swank-loader computes its own source/fasl relation based on the
-  ;; TRUENAME of the loader file, so we need a "manual" CL:LOAD
-  ;; invocation here.
-  (load (asdf::component-pathname f))
-  ;; After loading, run the swank-loader init routines.
-  (funcall (read-from-string "swank-loader::init") :reload t))
+  (let ((var (uiop:find-symbol* '#:*source-directory* '#:swank-loader nil)))
+    (cond ((and var (boundp var))
+           (let ((loaded (truename (symbol-value var)))
+                 (requested (truename (asdf:system-source-directory "swank"))))
+             (unless (equal requested loaded)
+               (warn "~@<Not loading SWANK from ~S because it was ~
+                      already loaded from ~S.~:@>"
+                     requested loaded))))
+          (t
+           ;; swank-loader computes its own source/fasl relation based
+           ;; on the TRUENAME of the loader file, so we need a "manual"
+           ;; CL:LOAD invocation here.
+           (load (asdf::component-pathname f))
+           ;; After loading, run the swank-loader init routines.
+           (funcall (read-from-string "swank-loader::init") :reload t)))))
 
 (asdf:defsystem :swank
   :default-component-class swank-loader-file


### PR DESCRIPTION
Previously, it was the case that starting SLIME in Emacs loaded Swank
with swank-loader.lisp. If Swank was then loaded via asdf (e.g. by
loading a system that depends on it), then swank-loader.lisp was run
again leading to lots of redefinition warnings and broke SLIME if the
version of Swank loaded by asdf was not compatible with the already
running version.

This change makes swank.asd never reload Swank. In particular, if it
finds that Swank is already loaded (because the SWANK-LOADER package
exists), then it compares the TRUENAMEs of the directories of the two
versions of Swank. If they are the same, then it silently does
nothing. If they are not the same, then it still does not reload
Swank, but it now emits a warning.

There is an unimportant corner case. Suppose the two versions are the
same, the sources of Swank change, and a reload is required. With this
change, swank-loader.lisp is to be invoked explicitly. Previously,
loading Swank via asdf _for the first time_ reloaded Swank and picked
up the changes, and subsequent attempts to load it via asdf silently
did nothing (unless swank-loader.lisp itself was changed).