### PR TITLE
abcl: Fix openjdk16+ inspection of Java objects fields

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,7 @@
 * SLIME News                                -*- mode: outline; coding: utf-8 -*-
+* 2.28 (Unreleased)
+** abcl
+*** Fix inspector failure for openjdk16+ Java fields
 * 2.27 (January 2022)
 ** Mostly improved compatibility with different implementations and bug fixes.
 


### PR DESCRIPTION
On inspection of Java fields which cannot be accessed through
reflection, use the label "unavailable".  This happens on openjdk16+
when various modules are not unsealed.

TODO: make underlying reason for field reflection failure available
somehow.