### PR TITLE
abcl: implement frame-catch-tags

### DIFF
--- a/swank/abcl.lisp
+++ b/swank/abcl.lisp
@@ -614,6 +614,11 @@
       (append frame-arguments frame-locals))))
 
 #+abcl-introspect
+(defimplementation frame-catch-tags (index)
+  (mapcar 'second (remove :catch (caar (abcl-introspect/sys:find-locals index (backtrace 0 (1+ index))))
+                          :test-not 'eq :key 'car)))
+
+#+abcl-introspect
 (defimplementation frame-var-value (index id)
   (if (are-there-locals? (nth-frame index) index)
       (third (nth id (reverse (remove :lexical-variable


### PR DESCRIPTION
Requires a version of the unreleased abcl-1.8.1 based on
<https://github.com/armedbear/abcl/commit/fc291394f875349f4997ebc22f4fdbf5833ef37a>
aka <https://abcl.org/trac/changeset/15560> or later.