### PR TITLE
Handle null characters correctly in the Allegro backend.

### DIFF
--- a/slime-tests.el
+++ b/slime-tests.el
@@ -735,9 +735,10 @@ Confirm that SUBFORM is correctly located."
 (def-slime-test utf-8-source
     (input output)
     "Source code containing utf-8 should work"
-    (list (let*  ((bytes "\343\201\212\343\201\257\343\202\210\343\201\206")
-                  ;;(encode-coding-string (string #x304a #x306f #x3088 #x3046)
-                  ;;                      'utf-8)
+    (list (let*  ((bytes "\000\343\201\212\343\201\257\343\202\210\343\201\206")
+                  ;; (encode-coding-string
+                  ;;   (string #x0000 #x304a #x306f #x3088 #x3046)
+                  ;;   'utf-8)
                   (string (decode-coding-string bytes 'utf-8-unix)))
             (cl-assert (equal bytes (encode-coding-string string 'utf-8-unix)))
             (list (concat "(defun cl-user::foo () \"" string "\")")

--- a/swank/allegro.lisp
+++ b/swank/allegro.lisp
@@ -41,8 +41,13 @@
   (excl:string-to-octets s :external-format utf8-ef
                          :null-terminate nil))
 
-(defimplementation utf8-to-string (u)
-  (excl:octets-to-string u :external-format utf8-ef))
+(defimplementation utf8-to-string (octets)
+  (let ((string (make-string (length octets))))
+    (multiple-value-bind (string chars-copied)
+        ;; Allegro 10.1 stops processing octets when it sees a zero,
+        ;; unless it is copying into an existing string.
+        (excl:octets-to-string octets :string string :external-format utf8-ef)
+      (subseq string 0 chars-copied))))
 
 
 ;;;; TCP Server


### PR DESCRIPTION
The Allegro function EXCL:OCTETS-TO-STRING, at least in Free Express Edition
10.1, stops processing octets when it encounters a null character, unless the
target of octet conversion is an existing string.  Work around the behavior
in UTF8-TO-STRING.

Modify test utf-8-source in slime-tests.el so that it includes a null
character.