### PR TITLE
Properly comment out multiline error messages during printout

### DIFF
--- a/contrib/slime-repl.el
+++ b/contrib/slime-repl.el
@@ -578,8 +578,10 @@ joined together."))
       (slime-save-marker slime-output-start
         (slime-save-marker slime-output-end
           (goto-char slime-output-end)
-          (insert-before-markers (format "; Evaluation aborted on %s.\n"
-                                         condition))
+          (insert-before-markers
+           ;; Comment-out multi-line error messages.
+           (format "; Evaluation aborted on %s.\n"
+                   (replace-regexp-in-string "\n" "\n; " condition)))
           (slime-repl-insert-prompt))))
     (slime-repl-show-maximum-output)))
 


### PR DESCRIPTION
This closes #721, in which multi-line error messages could get written to the repl without the second line being commented. This made the indentation fail in some cases. 