### PR TITLE
clasp: Replace TMP host with EXT:TEMPORARY-DIRECTORY when available

### DIFF
--- a/swank/clasp.lisp
+++ b/swank/clasp.lisp
@@ -32,7 +32,9 @@
     (pushnew :profile *features*))
   (when (probe-file "sys:serve-event")
     (require :serve-event)
-    (pushnew :serve-event *features*)))
+    (pushnew :serve-event *features*))
+  (when (find-symbol "TEMPORARY-DIRECTORY" "EXT")
+    (pushnew :temporary-directory *features*)))
 
 (declaim (optimize (debug 3)))
 
@@ -264,13 +266,20 @@
       (((or error warning) #'handle-compiler-condition))
     (funcall function)))
 
+(defun mkstemp (name)
+  (ext:mkstemp #+temporary-directory
+               (namestring (make-pathname :name name
+                                          :defaults (ext:temporary-directory)))
+               #-temporary-directory
+               (concatenate 'string "tmp:" name)))
+
 (defimplementation swank-compile-file (input-file output-file
                                        load-p external-format
                                        &key policy)
   (declare (ignore policy))
   (format t "Compiling file input-file = ~a   output-file = ~a~%" input-file output-file)
   ;; Ignore the output-file and generate our own
-  (let ((tmp-output-file (compile-file-pathname (si:mkstemp "TMP:clasp-swank-compile-file-"))))
+  (let ((tmp-output-file (compile-file-pathname (mkstemp "clasp-swank-compile-file-"))))
     (format t "Using tmp-output-file: ~a~%" tmp-output-file)
     (multiple-value-bind (fasl warnings-p failure-p)
         (with-compilation-hooks ()
@@ -297,7 +306,7 @@
   (with-compilation-hooks ()
     (let ((*buffer-name* buffer)        ; for compilation hooks
           (*buffer-start-position* position))
-      (let ((tmp-file (si:mkstemp "TMP:clasp-swank-tmpfile-"))
+      (let ((tmp-file (mkstemp "clasp-swank-tmpfile-"))
             (fasl-file)
             (warnings-p)
             (failure-p))


### PR DESCRIPTION
Clasp doesn't have the TMP logical host anymore, instead there is a function `ext:temporary-directory`,