### PR TITLE
Inspector: differentiate inactive array elements

### DIFF
--- a/swank.lisp
+++ b/swank.lisp
@@ -3439,12 +3439,44 @@ Return NIL if LIST is circular."
    (iline "Adjustable" (adjustable-array-p array))
    (iline "Fill pointer" (if (array-has-fill-pointer-p array)
                              (fill-pointer array)))
-   "Contents:" '(:newline)
-   (labels ((k (i max)
-              (cond ((= i max) '())
-                    (t (lcons (iline i (row-major-aref array i))
-                              (k (1+ i) max))))))
-     (k 0 (array-total-size array)))))
+   (if (array-has-fill-pointer-p array)
+       (emacs-inspect-vector-with-fill-pointer-aux array)
+       (emacs-inspect-array-aux array))))
+
+(defun emacs-inspect-array-aux (array)
+  (unless (= 0 (array-total-size array))
+    (lcons*
+     "Contents:" '(:newline)
+     (labels ((k (i max)
+                (cond ((= i max) '())
+                      (t (lcons (iline i (row-major-aref array i))
+                                (k (1+ i) max))))))
+       (k 0 (array-total-size array))))))
+
+(defun emacs-inspect-vector-with-fill-pointer-aux (array)
+  (let ((active-elements? (< 0 (fill-pointer array)))
+        (inactive-elements? (< (fill-pointer array)
+                               (array-total-size array))))
+    (labels ((k (i max cont)
+               (cond ((= i max) (funcall cont))
+                     (t (lcons (iline i (row-major-aref array i))
+                               (k (1+ i) max cont)))))
+             (collect-active ()
+               (if active-elements?
+                   (lcons*
+                    "Active elements:" '(:newline)
+                    (k 0 (fill-pointer array)
+                       (lambda () (collect-inactive))))
+                   (collect-inactive)))
+             (collect-inactive ()
+               (if inactive-elements?
+                   (lcons*
+                    "Inactive elements:" '(:newline)
+                    (k (fill-pointer array)
+                       (array-total-size array)
+                       (constantly '())))
+                   '())))
+      (collect-active))))
 
 ;;;;; Chars
 


### PR DESCRIPTION
Currently, the inspector displays all elements of a vector with a fill pointer without any visual indication of which ones are active and which are inactive; the user needs to manually look at the fill pointer value and then at element indices in order to be able to tell them apart.

This patch changes this in favor of displaying active and inactive elements separately, like this:

```lisp
CL-USER> (swank:inspect-in-emacs (make-array 4 :fill-pointer 0))

#<(VECTOR T 4) {100971FDFF}>
--------------------
Dimensions: (4)
Element type: T
Total size: 4
Adjustable: T
Fill pointer: 0
Inactive elements:
0: 0
1: 0
2: 0
3: 0
```

```lisp
CL-USER> (swank:inspect-in-emacs (make-array 4 :fill-pointer 2))

#<(VECTOR T 4) {1009830CFF}>
--------------------
Dimensions: (4)
Element type: T
Total size: 4
Adjustable: T
Fill pointer: 2
Active elements:
0: 0
1: 0
Inactive elements:
2: 0
3: 0
```

```lisp
CL-USER> (swank:inspect-in-emacs (make-array 4 :fill-pointer 4))

#<(VECTOR T 4) {10099830CF}>
--------------------
Dimensions: (4)
Element type: T
Total size: 4
Adjustable: T
Fill pointer: 4
Active elements:
0: 0
1: 0
2: 0
3: 0
```