### PR TITLE
haiku support

### DIFF
--- a/swank/sbcl.lisp
+++ b/swank/sbcl.lisp
@@ -151,8 +151,7 @@
 
 ;; The SIGIO stuff should probably be removed as it's unlikey that
 ;; anybody uses it.
-#+haiku
-#-win32
+#-(or win32 haiku)
 (progn
   (defimplementation install-sigint-handler (function)
     (sb-sys:enable-interrupt sb-unix:sigint

--- a/swank/sbcl.lisp
+++ b/swank/sbcl.lisp
@@ -151,6 +151,7 @@
 
 ;; The SIGIO stuff should probably be removed as it's unlikey that
 ;; anybody uses it.
+#+haiku
 #-win32
 (progn
   (defimplementation install-sigint-handler (function)


### PR DESCRIPTION
hello,

haiku does not have support for SIGIO so when trying to load slime errors like the below can occur when trying to use load slime in emacs. this patch lets slime work under haiku with sbcl. 

```
* ; loading #P"/boot/home/.emacs.d/elpa/slime-20220712.817/swank-loader.lisp"
; 
; caught ERROR:
;   READ error during COMPILE-FILE:
;   
;     Symbol "SIGIO" not found in the SB-UNIX package.
;   
;       Line: 176, Column: 42, File-Position: 6172
;   
;       Stream: #<SB-INT:FORM-TRACKING-STREAM for "file /boot/home/.emacs.d/elpa/slime-20220712.817/swank/sbcl.lisp" {1004E7E4F3}>
;; 
;; Error compiling /boot/home/.emacs.d/elpa/slime-20220712.817/swank/sbcl.lisp:
;;   COMPILE-FILE returned NIL.
;; 

debugger invoked on a SIMPLE-ERROR in thread
#<THREAD "main thread" RUNNING {10052F81E3}>:
  COMPILE-FILE returned NIL.

Type HELP for debugger help, or (SB-EXT:EXIT) to exit from SBCL.

restarts (invokable by number or by possibly-abbreviated name):
  0: [ABORT] Exit debugger, returning to top level.
```