### PR TITLE
Fix slime-c-p-c-completion-at-point in slime-c-p-c.el

### DIFF
--- a/contrib/slime-c-p-c.el
+++ b/contrib/slime-c-p-c.el
@@ -172,8 +172,7 @@ terminates a current completion."
   (or (slime-maybe-complete-as-filename)
       (slime-expand-abbreviations-and-complete)))
 
-(defun slime-c-p-c-completion-at-point ()
-  #'slime-complete-symbol*)
+(defalias 'slime-c-p-c-completion-at-point #'slime-complete-symbol*)
 
 ;; FIXME: factorize
 (defun slime-expand-abbreviations-and-complete ()


### PR DESCRIPTION
It seems that slime-complete-symbol* is not called, this commit fixes that by chaning it to an alias definition instead.