### PR TITLE
slime: slime-print-apropos use buttons for dispay

### DIFF
--- a/slime.el
+++ b/slime.el
@@ -4384,12 +4384,12 @@ If PACKAGE is NIL, then search in all packages."
   (slime-eval-describe `(swank:describe-function ,symbol-name)))
 
 (defface slime-apropos-symbol
-  '((t (:inherit bold)))
+  '((t (:inherit apropos-symbol)))
   "Face for the symbol name in Apropos output."
   :group 'slime)
 
 (defface slime-apropos-label
-  '((t (:inherit italic)))
+  '((t (:inherit apropos-button)))
   "Face for label (`Function', `Variable' ...) in Apropos output."
   :group 'slime)
 
@@ -4434,13 +4434,44 @@ With prefix argument include internal symbols."
                      current-prefix-arg))
   (slime-apropos "" (not internal) package))
 
-(autoload 'apropos-mode "apropos")
+(defun slime-apropos-next-symbol ()
+  "Move cursor down to the next symbol in an `apropos-mode' buffer."
+  (interactive nil slime-apropos-mode)
+  (forward-line)
+  (while (and (not (eq (face-at-point) 'slime-apropos-symbol))
+              (< (point) (point-max)))
+    (forward-line)))
+
+(defun slime-apropos-previous-symbol ()
+  "Move cursor back to the last symbol in an `apropos-mode' buffer."
+  (interactive nil slime-apropos-mode)
+  (forward-line -1)
+  (while (and (not (eq (face-at-point) 'slime-apropos-symbol))
+              (> (point) (point-min)))
+    (forward-line -1)))
+
+(defvar slime-apropos-mode-map
+  (let ((map (copy-keymap button-buffer-map)))
+    (set-keymap-parent map apropos-mode-map)
+    ;; Movement keys
+    (define-key map "n" #'slime-apropos-next-symbol)
+    (define-key map "p" #'slime-apropos-previous-symbol)
+    map)
+  "Keymap used in Slime Apropos mode.")
+
+(define-derived-mode slime-apropos-mode
+  apropos-mode "Slime Apropos"
+  "Major mode for following hyperlinks in output of Slime apropos commands.
+
+\\{slime-apropos-mode-map}")
+
 (defun slime-show-apropos (plists string package summary)
   (if (null plists)
       (message "No apropos matches for %S" string)
+    (setq apropos--current (list #'slime-show-apropos plists string package summary))
     (slime-with-popup-buffer ((slime-buffer-name :apropos)
                               :package package :connection t
-                              :mode 'apropos-mode)
+                              :mode 'slime-apropos-mode)
       (if (boundp 'header-line-format)
           (setq header-line-format summary)
         (insert summary "\n\n"))
@@ -4463,6 +4494,13 @@ With prefix argument include internal symbols."
     (:alien-union "Alien type")
     (:alien-enum "Alien enum")))
 
+(define-button-type 'slime-apropos-symbol
+  'help-echo "\\`mouse-2', \\`RET': Display more help on this symbol"
+  'follow-link t
+  'face 'slime-apropos-label
+  'mouse-face 'highlight
+  'action 'slime-call-describer)
+
 (defun slime-print-apropos (plists)
   (dolist (plist plists)
     (let ((designator (plist-get plist :designator)))
@@ -4475,21 +4513,22 @@ With prefix argument include internal symbols."
                                         (error "Unknown property: %S" prop))))
                    (start (point)))
                (princ "  ")
-               (slime-insert-propertized `(face slime-apropos-label) namespace)
+               (insert-text-button
+                namespace
+                'type 'slime-apropos-symbol
+                'button t
+                'apropos-label namespace
+                'item-type prop
+                'item (plist-get plist :designator))
                (princ ": ")
                (princ (cl-etypecase value
                         (string value)
                         ((member nil :not-documented) "(not documented)")))
-               (add-text-properties
-                start (point)
-                (list 'type prop 'action 'slime-call-describer
-                      'button t 'apropos-label namespace
-                      'item (plist-get plist :designator)))
                (terpri)))))
 
 (defun slime-call-describer (arg)
   (let* ((pos (if (markerp arg) arg (point)))
-         (type (get-text-property pos 'type))
+         (type (get-text-property pos 'item-type))
          (item (get-text-property pos 'item)))
     (slime-eval-describe `(swank:describe-definition-for-emacs ,item ,type))))
 


### PR DESCRIPTION
Creates a derived mode from `apropos-mode`, this was done to fully support `n` and `p` for navigation between symbols.  The navigation functions inspect the face `slime-apropos-symbol` face, like `apropos-mode` does.

Make all apropos faces inherit from the Emacs apropos, this improves the theming by using the theme's face rather than requiring every theme to support slime.

`apropos--current` is now set before `slime-apropos-mode` is enabled, this fixes revert (pressing `g`).  Previously what would happen is reverting would result in some other Emacs native apropos buffer being reverted.

The display methods now use buttons to present the symbol types, it looked like the intent of the code was to support this, but it wasn't working.

![Screenshot_20230108_133543](https://user-images.githubusercontent.com/2660/211196573-f40e5aec-f927-44a6-a876-05c572796302.png)
