### PR TITLE
Fix emacs error when M-.-ing to nonexistent file

### DIFF
--- a/slime.el
+++ b/slime.el
@@ -3387,8 +3387,11 @@ are supported:
       (when edit-path (slime-search-edit-path edit-path))
       (when call-site (slime-search-call-site call-site))
       (when align
-        (slime-forward-sexp)
-        (beginning-of-sexp)))
+        (condition-case nil
+            (progn
+              (slime-forward-sexp)
+              (beginning-of-sexp))
+          (error (goto-char 0)))))
     (point)))
 
 


### PR DESCRIPTION
When the Lisp reports a source location is in a file that doesn't exist, and also gives the :align t hint, slime-location-offset will try to (slime-forward-sexp) (beginning-of-sexp) in a new empty buffer. This causes a pretty inscrutable "Wrong type argument: characterp, nil" error from emacs. This problem may also occur if the source file does not have sexp syntax, but I haven't tried that myself.

The change just silently ignores any errors from the sexp motion. It might be better to have slime report that the file isn't real and not do any motion to begin with.