### PR TITLE
Add: local systems to swank-quicklisp systems list

### DIFF
--- a/contrib/swank-quicklisp.lisp
+++ b/contrib/swank-quicklisp.lisp
@@ -10,8 +10,10 @@
   "Returns the Quicklisp systems list."
   (if (member :quicklisp *features*)
       (let ((ql-dist-name (find-symbol "NAME" "QL-DIST"))
-            (ql-system-list (find-symbol "SYSTEM-LIST" "QL")))
-        (mapcar ql-dist-name (funcall ql-system-list)))
+            (ql-system-list (find-symbol "SYSTEM-LIST" "QL"))
+	    (ql-local-systems (find-symbol "LIST-LOCAL-SYSTEMS" "QL")))
+        (append (mapcar ql-dist-name (funcall ql-system-list))
+		(funcall ql-local-systems)))
       (error "Could not find Quicklisp already loaded.")))
 
 (provide :swank-quicklisp)


### PR DESCRIPTION
I am often using quicklisp to load local systems while developing. This seems like a useful addition to the functionality that ends up being used by the slime-quicklisp package.