### PR TITLE
Triage for ABCL not working with contrib/slime-repl.lisp

### DIFF
--- a/swank-loader.lisp
+++ b/swank-loader.lisp
@@ -46,7 +46,7 @@
   #+lispworks '((swank lispworks) (swank gray))
   #+allegro '((swank allegro) (swank gray))
   #+clisp '(xref metering (swank clisp) (swank gray))
-  #+armedbear '((swank abcl))
+  #+armedbear '((swank abcl) (swank gray))
   #+cormanlisp '((swank corman) (swank gray))
   #+ecl '((swank ecl) (swank gray))
   #+clasp '(metering (swank clasp) (swank gray))

--- a/swank.asd
+++ b/swank.asd
@@ -42,7 +42,7 @@
                              (:file "clasp" :if-feature :clasp)
                              (:file "mkcl" :if-feature :mkcl)
                              (:file "mezzano" :if-feature :mezzano)
-                             (:file "gray" :if-feature (:not :armedbear))
+                             (:file "gray")
                              (:file "match")
                              (:file "rpc")))
                (:file "swank")))

--- a/swank/abcl.lisp
+++ b/swank/abcl.lisp
@@ -49,10 +49,13 @@
 (defimplementation gray-package-name ()
   "GRAY-STREAMS")
 
-;; FIXME: switch to shared Gray stream implementation when the
-;; architecture for booting streams allows us to replace the Java-side
-;; implementation of a Slime{Input,Output}Stream.java classes are
-;; subsumed <http://abcl.org/trac/ticket/373>.
+;;;; abcl-1.9.2 revamped Gray Streams, so it uses the default
+;;;; implementation of MAKE-{INPUT,OUTPUT}-STREAM.
+
+;;;; Previous ABCL versions use the specialized Java implementations,
+;;;; which won't work with all SLIME contribs, notably the
+;;;; <file:../contrib/slime-repl.lisp> one
+#-#.(swank/backend:with-symbol 'java/element-type 'gray-streams/java)
 (progn
   (defimplementation make-output-stream (write-string)
     (ext:make-slime-output-stream write-string))


### PR DESCRIPTION
~~Work in progress at getting Gray streams working with ABCL.  This is going to involve a fair amount of work on the ABCL Gray stream implementation, so some amount of implementation conditionalization will be necessary to make this smooth.~~

WARNING: Since ABCL's Gray stream implementation has long been
unusable as the basis of communication with SWANK, this doesn't
currently work with any released version of the Bear.  One needs the
changes from <https://github.com/armedbear/abcl/pull/586> for this to
work.

