### PR TITLE
Align compilation artifact paths in swank-loader with ASDF

### DIFF
--- a/swank.asd
+++ b/swank.asd
@@ -20,9 +20,9 @@
 
 (asdf:defsystem "swank"
   :perform (load-op :after (o c)
-              (set (intern '*source-directory* 'swank-loader)
+              (set (intern '*SOURCE-DIRECTORY* 'swank-loader)
                    (asdf:system-source-directory :swank))
-              (set (intern '*fasl-directory* 'swank-loader)
+              (set (intern '*FASL-DIRECTORY* 'swank-loader)
                    (asdf:apply-output-translations (asdf:system-source-directory :swank)))
               (uiop:symbol-call :swank :before-init
                  (uiop:symbol-call :swank-loader :slime-version-string)

--- a/swank.asd
+++ b/swank.asd
@@ -9,17 +9,28 @@
 
 ;; Usage:
 ;;
-;;   (asdf:load-system "swank")
-;;   (swank:create-swank-server PORT) => ACTUAL-PORT
+;;   (asdf:load-system :swank)
+;;   (swank:create-server :dont-close t)
 ;;
-;; (PORT can be zero to mean "any available port".)
-;; Then the Swank server is running on localhost:ACTUAL-PORT. You can
+;; After which, the Swank server is running on localhost:4005. You can
 ;; use `M-x slime-connect' to connect Emacs to it.
 ;;
 ;; This code has been placed in the Public Domain.  All warranties
 ;; are disclaimed.
 
 (asdf:defsystem "swank"
+  :perform (load-op :after (o c)
+              (set (intern '*source-directory* 'swank-loader)
+                   (asdf:system-source-directory :swank))
+              (set (intern '*fasl-directory* 'swank-loader)
+                   (asdf:apply-output-translations (asdf:system-source-directory :swank)))
+              (uiop:symbol-call :swank :before-init
+                 (uiop:symbol-call :swank-loader :slime-version-string)
+                 (list
+                  (uiop:symbol-call :swank-loader :contrib-dir
+                     (symbol-value (intern "*FASL-DIRECTORY*" 'swank-loader)))
+                  (uiop:symbol-call :swank-loader :contrib-dir
+                     (symbol-value (intern "*SOURCE-DIRECTORY*" 'swank-loader))))))
   :components ((:file "swank-loader")
                (:file "packages")
                (:file "xref" :if-feature :clisp)
@@ -61,6 +72,7 @@
                (:file "swank-asdf" :if-feature (:or :asdf2 :asdf3 :sbcl :ecl))
                (:file "swank-package-fu")
                (:file "swank-hyperdoc")
+               (:file "swank-indentation")
                (:file "swank-sbcl-exts" :if-feature :sbcl)
                (:file "swank-mrepl")
                (:file "swank-trace-dialog")


### PR DESCRIPTION
When loaded via ASDF, we align the `swank-loader:*source-directory*` and `swank-loader:*fasl-directory*` special variables to the appropriate values.  This restores the ability to launch a Swank server from a Lisp image which has loaded SLIME via ASDF.

See
<https://github.com/slime/slime/commit/dd179f4a0c6874fe0e49fb6c460e9e52a5f58833> and <https://github.com/slime/slime/pull/760>.

-- 

In debugging ABCL/SLIME, I often start ABCL under a JVM debugger, using ASDF to locate and load SLIME.  Without these changes,  @dkochmanski's recent work on `swank.asd` broke this usage.  