### PR TITLE
Fix build under SBCL

### DIFF
--- a/swank.asd
+++ b/swank.asd
@@ -20,9 +20,9 @@
 
 (asdf:defsystem "swank"
   :perform (load-op :after (o c)
-              (set (intern '*SOURCE-DIRECTORY* 'swank-loader)
+              (set (intern "*SOURCE-DIRECTORY*" 'swank-loader)
                    (asdf:system-source-directory :swank))
-              (set (intern '*FASL-DIRECTORY* 'swank-loader)
+              (set (intern "*FASL-DIRECTORY*" 'swank-loader)
                    (asdf:apply-output-translations (asdf:system-source-directory :swank)))
               (uiop:symbol-call :swank :before-init
                  (uiop:symbol-call :swank-loader :slime-version-string)


### PR DESCRIPTION
Interning symbols is not standard complient and does not work under SBCL.

For example, code like `(intern 'foo)` produces such error:

```
The value
  FOO
is not of type
  STRING
when binding SB-IMPL::NAME
   [Condition of type TYPE-ERROR]
```

You should pass only strings as a first argument of INTERN function.

The bug was introduced on 11 June 2023 in this commit:
https://github.com/slime/slime/commit/8f166c4149e71a9f67e3d741fb6716b31aa4920e

I've tested under:

- SBCL 2.2.2 on OSX and Ubuntu.
- SBLC 2.3.5 on Ubuntu.

I don't know how commit 8f166c4149e71a9f67e3d741fb6716b31aa4920e passed all tests: https://github.com/slime/slime/actions/runs/5234438802/jobs/9450592439