### PR TITLE
swank-loader: load-swank: if asdf is available then use it

### DIFF
--- a/swank-loader.lisp
+++ b/swank-loader.lisp
@@ -278,6 +278,12 @@ If LOAD is true, load the fasl file."
 (defun load-swank (&key (src-dir *source-directory*)
                      (fasl-dir *fasl-directory*)
                         quiet)
+  #+asdf
+  (if (asdf:locate-system "swank")
+      (asdf:load-system "swank")
+      (with-compilation-unit ()
+        (compile-files (src-files *swank-files* src-dir) fasl-dir t quiet)))
+  #-asdf
   (with-compilation-unit ()
     (compile-files (src-files *swank-files* src-dir) fasl-dir t quiet))
   (funcall (q "swank::before-init")


### PR DESCRIPTION
This is to prevent redefinition warnings when a system is compiled that has swank in dependencies.