### PR TITLE
Ability to change buffer action for show-source-location

### DIFF
--- a/slime.el
+++ b/slime.el
@@ -5719,12 +5719,14 @@ This is 0 if START and END at the same line."
         (t
          (slime-show-source-location source-location t nil))))))
 
+(defvar slime-show-source-location--display-buffer-action t)
+
 (defun slime-show-source-location (source-location
                                    &optional highlight recenter-arg)
   "Go to SOURCE-LOCATION and display the buffer in the other window."
   (slime-goto-source-location source-location)
   ;; show the location, but don't hijack focus.
-  (slime--display-position (point) t recenter-arg)
+  (slime--display-position (point) slime-show-source-location--display-buffer-action recenter-arg)
   (when highlight (slime-highlight-sexp)))
 
 (defun slime--display-position (pos other-window recenter-arg)


### PR DESCRIPTION
Added a variable to be able to overwrite how `slime-show-source-location` handles the newly opened buffer.
Making changes to `display-buffer-alist` for this use case seems to be overly involved.

Example configuration (I like My buffers in new frames):
`(setq slime-show-source-location--display-buffer-action '(display-buffer-pop-up-frame . '()))`

I see that there are also some var customisation groups, could not decide which this variable would fit in with, if any at all:
slime-debugger or slime-ui.