### PR TITLE
Handle case when there is no emacs-connection.

### DIFF
--- a/swank.lisp
+++ b/swank.lisp
@@ -3605,7 +3605,8 @@ after each command.")
        (handle-indentation-cache-request c request))
       (multithreaded-connection
        (without-slime-interrupts
-         (send (mconn.indentation-cache-thread c) request))))))
+         (send (mconn.indentation-cache-thread c) request)))
+      (null t))))
 
 (defun indentation-cache-loop (connection)
   (with-connection (connection)


### PR DESCRIPTION
Let send-to-indentation-cache be called without an Emacs connection.

----

Akin to https://github.com/joaotavora/sly/pull/619.

