### PR TITLE
Escape %-Constructs in the Mode Line (manual 24.4.5)

### DIFF
--- a/slime.el
+++ b/slime.el
@@ -506,7 +506,7 @@ information."
             (pkg   (slime-current-package)))
         (concat " "
                 (if local "{" "[")
-                (if pkg (slime-pretty-package-name pkg) "?")
+                (if pkg (string-replace "%" "%%" (slime-pretty-package-name pkg)) "?")
                 " "
                 ;; ignore errors for closed connections
                 (ignore-errors (slime-connection-name conn))


### PR DESCRIPTION
Fixes #798. Uses `string-replace` to escape all `%` characters in the string.

I'm not sure if this is the most efficient solution; tests (make check) seems to be passing normally.