### PR TITLE
clasp: Close temp file before compile-file

### DIFF
--- a/swank/clasp.lisp
+++ b/swank/clasp.lisp
@@ -304,10 +304,10 @@
             (warnings-p)
             (failure-p))
         (unwind-protect
-             (with-open-file (tmp-stream tmp-file :direction :output
-                                                  :if-exists :supersede)
-               (write-string string tmp-stream)
-               (finish-output tmp-stream)
+             (progn
+               (with-open-file (tmp-stream tmp-file :direction :output
+                                                    :if-exists :overwrite)
+                 (write-string string tmp-stream))
                (multiple-value-setq (fasl-file warnings-p failure-p)
                  (let ((truename (or filename (note-buffer-tmpfile tmp-file buffer))))
                    (compile-file tmp-file


### PR DESCRIPTION
Clasp has changed the implementation of `:supersede`. It now attempts to preserve the original file in case of an abort in `close`. This breaks `tmpfile-to-buffer`. Using `:overwrite` and closing the stream before `compile-file` fixes it.

Conversation on IRC: https://irclog.tymoon.eu/libera/%23clasp?around=1701543150#1701543150

@drmeister @Bike 