### PR TITLE
clasp: Fix detection of serve-event module

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,7 +3,12 @@
 ** Core
 *** Loading the system "swank" with ASDF produces compilation artifacts
 ** ABCL
-*** Fix missing source position from string buffer location 
+*** Fix missing source position from string buffer location
+** CLASP
+*** Add interface to debug stepper
+*** Update xref implmentation
+*** Close temp file before compile-file
+*** Fix detection of serve-event module
 * 2.28 (January 2023)
 ** Operations that produce a lot of output can be interrupted more easily. 
 ** Improved compatibility with implementations and newer Emacs versions.

--- a/swank/clasp.lisp
+++ b/swank/clasp.lisp
@@ -22,7 +22,7 @@
   (when (probe-file "sys:profile.fas")
     (require :profile)
     (pushnew :profile *features*))
-  (when (probe-file "sys:serve-event")
+  (when (probe-file "sys:src;lisp;modules;serve-event;")
     (require :serve-event)
     (pushnew :serve-event *features*))
   (when (find-symbol "TEMPORARY-DIRECTORY" "EXT")


### PR DESCRIPTION
The SYS logical host mapping was changed for Clasp in [v2.0.0](https://github.com/clasp-developers/clasp/blob/main/RELEASE_NOTES.md#changed-5).

Also update NEWS for the Clasp changes in the last year.

FYI @bike @drmeister 