### PR TITLE
Use defcustom for inferior-lisp-program

### DIFF
--- a/slime.el
+++ b/slime.el
@@ -963,8 +963,9 @@ MODE is the name of a major mode which will be enabled.
 
 ;; We no longer load inf-lisp, but we use this variable for backward
 ;; compatibility.
-(defvar inferior-lisp-program "lisp"
-  "*Program name for invoking an inferior Lisp with for Inferior Lisp mode.")
+(defcustom inferior-lisp-program "lisp"
+  "*Program name for invoking an inferior Lisp with Inferior Lisp mode."
+  :type 'string)
 
 (defvar slime-lisp-implementations nil
   "*A list of known Lisp implementations.


### PR DESCRIPTION
Fixes #697 

Users who set `inferior-lisp-program` with `custom-set-variables` will find that SLIME overrides its value. This is fixed by using `defcustom`, which only assigns a value if the specified variable is unbound.

This makes behaviour consistent with `inferior-lisp-mode`, which uses `defcustom` for this variable.

Also fixed a typo in the docstring.