### PR TITLE
Fix buttons in slime-trace-dialog

### DIFF
--- a/contrib/slime-trace-dialog.el
+++ b/contrib/slime-trace-dialog.el
@@ -340,8 +340,7 @@ inspecting details of traced functions. Invoke this dialog with C-c T."
                            (funcall lambda button))
            'mouse-face 'highlight
            'face       'slime-inspector-action-face
-           props)
-    string))
+           props)))
 
 (defun slime-trace-dialog--call-maintaining-properties (pos fn)
   (save-excursion


### PR DESCRIPTION
This small fix is needed for buttons to work in slime-trace-dialog.