### PR TITLE
Avoid infinite loop in slime-presentation-start/end

### DIFF
--- a/contrib/slime-presentations.el
+++ b/contrib/slime-presentations.el
@@ -217,6 +217,8 @@ Return buffer index and whether a start-tag was found."
                          (buffer (with-current-buffer object 1))
                          (string 0))
                        nil)))
+        (when (= change-point point)
+          (error "Unable to find presentation start"))
         (setq this-presentation (get-text-property change-point
                                                    presentation object))
         (unless this-presentation
@@ -240,6 +242,8 @@ end-tag was found."
                          (buffer (with-current-buffer object (point-max)))
                          (string (length object)))
                        nil)))
+        (when (= change-point point)
+          (error "Unable to find presentation end"))
         (setq point change-point)
         (setq this-presentation (get-text-property point
                                                    presentation object))))


### PR DESCRIPTION
Fixes #814

This doesn't fix the underlying problem, which is that `company-mode` copies parts of buffers that contain:

```
      (add-text-properties start end
                           `(modification-hooks (slime-after-change-function)
                             insert-in-front-hooks (slime-after-change-function)
                             insert-behind-hooks (slime-after-change-function)
                             syntax-table ,slime-presentation-syntax-table
                             rear-nonsticky t))
```

And then `slime-after-change-function` gets run on them.  Should `slime-after-change-function` be more defensive about where it's called from?