### PR TITLE
Fix restart frame for methods

### DIFF
--- a/swank/sbcl.lisp
+++ b/swank/sbcl.lisp
@@ -1522,7 +1522,7 @@ stack."
               (if (and (sb-int:legal-fun-name-p fname) (fboundp fname))
                   (values (fdefinition fname) args)
                   (values (sb-di:debug-fun-fun (sb-di:frame-debug-fun frame))
-                          (sb-debug::frame-args-as-list frame)))
+                          (sb-debug::frame-args-as-list frame 255)))
             (when (functionp fun)
               (sb-debug:unwind-to-frame-and-call
                frame


### PR DESCRIPTION
This has been broken since Dec 2022.  It does not show up for normal function calls, seems to be method calls at least.  I have no idea what number to put for the limit.  Here is an over complex demonstration of the bug (the idea here being that the user would potentially edit the slots of blarg to change it to an integer, and then restart at add-5):

`(defgeneric add-5 (x)
  (:method (blarg)
    (print (+ (slot-value blarg 'x) 5))))

(defclass blarg ()
  ((x :initarg :x)))

(add-5 (make-instance 'blarg :x "hello"))
`