### PR TITLE
Fix a bunch of Emacs compilation warnings.

### DIFF
--- a/contrib/slime-cl-indent.el
+++ b/contrib/slime-cl-indent.el
@@ -117,13 +117,13 @@ is nil."
 If t (the default), keywords in contexts where no other
 indentation rule takes precedence are aligned like this:
 
-\(make-instance 'foo :bar t
+\(make-instance \\='foo :bar t
                     :quux 42)
 
 If nil, they are indented like any other function
 call arguments:
 
-\(make-instance 'foo :bar t
+\(make-instance \\='foo :bar t
                :quux 42)"
   :type 'boolean
   :group 'lisp-indent)
@@ -1447,7 +1447,7 @@ minimiz\\(e\\|ing\\)\\)"
 
 (defvar common-lisp-indent-clause-joining-loop-macro-keyword
   "\\(#?:\\)?and"
-  "Regexp matching 'and', and anything else there ever comes to be like it.")
+  "Regexp matching `and', and anything else there ever comes to be like it.")
 
 (defvar common-lisp-indent-indented-loop-macro-keyword
   "\\(#?:\\)?\\(\\(up\\|down\\)?(from\\|to)\\|below\\|above\\|in\\(to\\)?\\|\

--- a/contrib/slime-highlight-edits.el
+++ b/contrib/slime-highlight-edits.el
@@ -20,8 +20,8 @@
   "Face for displaying edit but not compiled code."
   :group 'slime-mode-faces)
 
-(define-minor-mode slime-highlight-edits-mode 
-  "Minor mode to highlight not-yet-compiled code." nil)
+(define-minor-mode slime-highlight-edits-mode
+  "Minor mode to highlight not-yet-compiled code.")
 
 (add-hook 'slime-highlight-edits-mode-on-hook
           'slime-highlight-edits-init-buffer)

--- a/contrib/slime-parse.el
+++ b/contrib/slime-parse.el
@@ -316,7 +316,6 @@ Point is placed before the first expression in the list."
         ((:define-compiler-macro symbol)
          (format "(compiler-macro-function '%s)" symbol))
         ((:defmethod &rest args)
-         (declare (ignore args))
          (format "%s" toplevel))
         (((:defparameter :defvar :defconstant) symbol)
          (format "'%s" symbol))

--- a/contrib/slime-repl.el
+++ b/contrib/slime-repl.el
@@ -131,15 +131,15 @@ current repl's (as per slime-output-buffer) window."
   "A non-nil value means that history will be replaced from the mark.
 
 Instead of replacing form input-start, look up history and replace input
-from the mark. Calling 'slime-repl-previous-input',
- 'slime-repl-previous-matching-input' or their -next counterparts with a prefix
+from the mark. Calling `slime-repl-previous-input',
+ `slime-repl-previous-matching-input' or their -next counterparts with a prefix
  argument sets this variable for the duration of one history lookup.")
 
 (defun slime-repl-history-yank-start ()
-  "The position which 'slime-repl-previous-input' will replace from.
+  "The position which `slime-repl-previous-input' will replace from.
 
-When 'slime-repl-history-use-mark' is non-nil, and (mark) is after the current
-input start, return it.  Otherwise, return 'slime-repl-input-start-mark'."
+When `slime-repl-history-use-mark' is non-nil, and (mark) is after the current
+input start, return it.  Otherwise, return `slime-repl-input-start-mark'."
   (if (and slime-repl-history-use-mark (mark))
       (max (mark) slime-repl-input-start-mark)
       slime-repl-input-start-mark))
@@ -977,7 +977,7 @@ Empty strings and duplicates are ignored."
 
 (defun slime-repl-history-replace (direction &optional regexp)
   "Replace the current input with the next line in DIRECTION.
-DIRECTION is 'forward' or 'backward' (in the history list).
+DIRECTION is `forward' or `backward' (in the history list).
 If REGEXP is non-nil, only lines matching REGEXP are considered."
   (setq slime-repl-history-pattern regexp)
   (let* ((min-pos -1)

--- a/lib/hyperspec.el
+++ b/lib/hyperspec.el
@@ -1313,11 +1313,11 @@ If you copy the HyperSpec to another location, customize the variable
 
 ;;;; Glossary
 
-(defvar common-lisp-hyperspec-glossary-function 'common-lisp-glossary-6.0
-  "Function that creates a URL for a glossary term.")
-
 (define-obsolete-variable-alias 'common-lisp-glossary-fun
   'common-lisp-hyperspec-glossary-function "2015-12-29")
+
+(defvar common-lisp-hyperspec-glossary-function 'common-lisp-glossary-6.0
+  "Function that creates a URL for a glossary term.")
 
 (defvar common-lisp-hyperspec--glossary-terms (make-hash-table :test #'equal)
   "Collection of glossary terms and relative URLs.")

--- a/slime.el
+++ b/slime.el
@@ -105,10 +105,12 @@ the Emacs Lisp package.")
                  :test #'string-equal))))
 
 (defvar slime-lisp-modes '(lisp-mode))
-(defvar slime-contribs '(slime-fancy)
-  "A list of contrib packages to load with SLIME.")
+
 (define-obsolete-variable-alias 'slime-setup-contribs
 'slime-contribs "2.3.2")
+
+(defvar slime-contribs '(slime-fancy)
+  "A list of contrib packages to load with SLIME.")
 
 ;;;###autoload
 (cl-defun slime-setup (&optional (contribs nil contribs-p))
@@ -280,7 +282,8 @@ argument."
   "List of functions to perform completion.
 Works like `completion-at-point-functions'.
 `slime--completion-at-point' uses this variable."
-  :group 'slime-mode)
+  :group 'slime-mode
+  :type '(repeat function))
 
 ;;;;; slime-mode-faces
 
@@ -687,7 +690,6 @@ If BOTHP is true also add bindings with control modifier."
 ;;;;; Syntactic sugar
 
 (defmacro slime-dcase (value &rest patterns)
-  (declare (indent 1))
   "Dispatch VALUE to one of PATTERNS.
 A cross between `case' and `destructuring-bind'.
 The pattern syntax is:
@@ -695,6 +697,7 @@ The pattern syntax is:
 The list of patterns is searched for a HEAD `eq' to the car of
 VALUE. If one is found, the BODY is executed with ARGS bound to the
 corresponding values in the CDR of VALUE."
+  (declare (indent 1))
   (let ((operator (cl-gensym "op-"))
 	(operands (cl-gensym "rand-"))
 	(tmp (cl-gensym "tmp-")))
@@ -2408,7 +2411,7 @@ Debugged requests are ignored."
         (slime-pprint-event event (current-buffer)))
       (when (and (boundp 'outline-minor-mode)
                  outline-minor-mode)
-        (hide-entry))
+        (outline-hide-entry))
       (goto-char (point-max)))))
 
 (defun slime-pprint-event (event buffer)
@@ -3081,7 +3084,7 @@ first element of the source-path redundant."
                         (when more (down-list 1))))
           ;; Align at beginning
           (slime-forward-sexp)
-          (beginning-of-sexp))
+          (thing-at-point--beginning-of-sexp))
       (error (goto-char origin)))))
 
 
@@ -3392,7 +3395,7 @@ are supported:
         (condition-case nil
             (progn
               (slime-forward-sexp)
-              (beginning-of-sexp))
+              (thing-at-point--beginning-of-sexp))
           (error (goto-char 0)))))
     (point)))
 
@@ -4114,7 +4117,7 @@ inserted in the current buffer."
 
 (defun slime-eval-defun ()
   "Evaluate the current toplevel form.
-Use `slime-re-evaluate-defvar' if the from starts with '(defvar'"
+Use `slime-re-evaluate-defvar' if the from starts with `(defvar'"
   (interactive)
   (let ((form (slime-defun-at-point)))
     (cond ((string-match "^(defvar " form)
@@ -6333,7 +6336,7 @@ was called originally."
       (when (time-less-p end (current-time))
         (message "Quit timeout expired.  Disconnecting.")
         (delete-process connection))
-      (sit-for 0 100)))
+      (sit-for 0.100)))
   (slime-update-connection-list))
 
 (defun slime-restart-connection-at-point (connection)
@@ -6617,7 +6620,7 @@ that value.
 ;; FIXME: could probably use slime-search-property.
 (defun slime-find-inspectable-object (direction limit)
   "Find the next/previous inspectable object.
-DIRECTION can be either 'next or 'prev.
+DIRECTION can be either `next or `prev.
 LIMIT is the maximum or minimum position in the current buffer.
 
 Return a list of two values: If an object could be found, the
@@ -7318,7 +7321,7 @@ is setup, unless the user already set one explicitly."
 ;;; FIXME: this looks almost slime `slime-alistify', perhaps the two
 ;;;        functions can be merged.
 (defun slime-group-similar (similar-p list)
-  "Return the list of lists of 'similar' adjacent elements of LIST.
+  "Return the list of lists of similar adjacent elements of LIST.
 The function SIMILAR-P is used to test for similarity.
 The order of the input list is preserved."
   (if (null list)


### PR DESCRIPTION
Most of these changes fix documentation strings, but a few delete use of deprecated functions.  Let me know if you're not comfortable with some of the changes.  I can revert any you think are risky.
