### PR TITLE
Fix top-level defvar detection in slime-eval-defun

### DIFF
--- a/slime.el
+++ b/slime.el
@@ -4118,7 +4118,7 @@ inserted in the current buffer."
 Use `slime-re-evaluate-defvar' if the from starts with '(defvar'"
   (interactive)
   (let ((form (slime-defun-at-point)))
-    (cond ((string-match "^(defvar " form)
+    (cond ((string-prefix-p "(defvar " form t)
            (slime-re-evaluate-defvar form))
           (t
            (slime-interactive-eval form)))))


### PR DESCRIPTION
Using ‘(string-match "^..." ..)’ would match against the beginning of every line, not just the start of the string. This trips over docstrings which have a (defvar..), e.g. in example usage.

Compare the old and new implementation on:

```
(defun foo (x)
  "Foo something

Example:

(defvar y 10)
(foo y)
=> 100
"
  (* x x))
```

I think ‘string-prefix-p’ goes back at least to 24.1, if even earlier support is needed maybe we should use a different regex instead?