### PR TITLE
Fix slime-modeline-string

### DIFF
--- a/slime-tests.el
+++ b/slime-tests.el
@@ -1328,6 +1328,26 @@ Reconnect afterwards."
                               (not (member hook slime-connected-hook)))
                             5))))
 
+(def-slime-test slime-modeline-string-test
+  (expected current-connection buffer-connection
+   connection-name current-package modeline-state-string)
+  "slime-modeline-string returns string in proper format."
+  '((" Slime" nil nil nil nil nil)
+    (" {sbcl local-conn-1 state}" 'mocked-conn 'mocked-local-conn
+     "local-conn-1" "sbcl" " state")
+    (" [sbcl conn-1 state]" 'mocked-conn nil "conn-1" "sbcl" " state"))
+  (with-temp-buffer
+    (lisp-mode)
+    (slime-check ("slime-modeline-string returns \"%s\"" expected)
+      (cl-letf (((symbol-function 'slime-current-connection)
+		 (lambda () (or buffer-connection current-connection)))
+		((symbol-function 'slime-connection-name) (lambda (_) connection-name))
+		((symbol-function 'slime-current-package) (lambda () current-package))
+		((symbol-function 'slime-modeline-state-string)
+                 (lambda (_) modeline-state-string)))
+	(setq slime-buffer-connection buffer-connection)
+	(equal expected (slime-modeline-string))))))
+
 
 ;;;; SLIME-loading tests that launch separate Emacsen
 ;;;;

--- a/slime.el
+++ b/slime.el
@@ -504,7 +504,7 @@ information."
             (pkg   (slime-current-package)))
         (concat " "
                 (if local "{" "[")
-                (if pkg (string-replace "%" "%%" (slime-pretty-package-name pkg)) "?")
+                (if pkg (replace-regexp-in-string "%" "%%" (slime-pretty-package-name pkg)) "?")
                 " "
                 ;; ignore errors for closed connections
                 (ignore-errors (slime-connection-name conn))


### PR DESCRIPTION
Fixes slime/slime/issues/836

In emacs version < 28, slime-modeline-string execution throws (void-function string-replace). string-replace exists in emacs version > 28.

This commit changes string-replace usage with replace-regexp-in-string and also add tests for slime-modeline-string function.