### PR TITLE
slime-redirect-inferior-output is useful and still in use

### DIFF
--- a/contrib/slime-presentations.el
+++ b/contrib/slime-presentations.el
@@ -1,4 +1,5 @@
 (require 'slime)
+(require 'bridge)
 (require 'cl-lib)
 
 (define-slime-contrib slime-presentations
@@ -805,6 +806,19 @@ buffer. Presentations of old results are expanded into code."
     (slime-repl-grab-old-output end-of-input)
     (slime-repl-recenter-if-needed)
     t))
+
+(defun slime-presentation-bridge-insert (process output)
+  (slime-output-filter process (or output "")))
+
+(defun slime-presentation-on-stream-open (stream)
+  (install-bridge)
+  (setq bridge-insert-function #'slime-presentation-bridge-insert)
+  (setq bridge-destination-insert nil)
+  (setq bridge-source-insert nil)
+  (setq bridge-handlers
+	(cl-list* '("<" . slime-mark-presentation-start-handler)
+	          '(">" . slime-mark-presentation-end-handler)
+	          bridge-handlers)))
 
 (defun slime-clear-presentations ()
   "Forget all objects associated to SLIME presentations.

--- a/contrib/slime-repl.el
+++ b/contrib/slime-repl.el
@@ -1442,6 +1442,25 @@ expansion will be added to the REPL's history.)"
   (:handler 'slime-restart-inferior-lisp)
   (:one-liner "Restart *inferior-lisp* and reconnect SLIME."))
 
+(defun slime-redirect-inferior-output (&optional noerror)
+  "Redirect output of the inferior-process to the REPL buffer."
+  (interactive)
+  (let ((proc (slime-inferior-process)))
+    (cond (proc
+           (let ((filter (slime-rcurry #'slime-inferior-output-filter
+                                       (slime-current-connection))))
+             (set-process-filter proc filter)))
+	  (noerror)
+	  (t (error "No inferior lisp process")))))
+
+(defun slime-inferior-output-filter (proc string conn)
+  (cond ((eq (process-status conn) 'closed)
+         (message "Connection closed.  Removing inferior output filter.")
+         (message "Lost output: %S" string)
+         (set-process-filter proc nil))
+        (t
+         (slime-output-filter conn string))))
+
 (defun slime-redirect-trace-output ()
   "Redirect the trace output to a separate Emacs buffer."
   (interactive)

--- a/contrib/slime-repl.el
+++ b/contrib/slime-repl.el
@@ -189,6 +189,58 @@ input start, return it.  Otherwise, return 'slime-repl-input-start-mark'."
       (display-buffer (current-buffer) t))
     (slime-repl-show-maximum-output)))
 
+(defun slime-output-filter (process string)
+  (with-current-buffer (process-buffer process)
+    (when (and (cl-plusp (length string))
+               (eq (process-status slime-buffer-connection) 'open))
+      (slime-write-string string))))
+
+(defvar slime-open-stream-hooks)
+
+(defun slime-open-stream-to-lisp (port coding-system)
+  (let ((stream (open-network-stream "*lisp-output-stream*"
+                                     (slime-with-connection-buffer ()
+                                       (current-buffer))
+				     (car (process-contact (slime-connection)))
+                                     port))
+        (emacs-coding-system (car (cl-find coding-system
+                                           slime-net-valid-coding-systems
+                                           :key #'cl-third))))
+    (slime-set-query-on-exit-flag stream)
+    (set-process-filter stream 'slime-output-filter)
+    (set-process-coding-system stream emacs-coding-system emacs-coding-system)
+    (let ((secret (slime-secret)))
+      (when secret
+	(slime-net-send secret stream)))
+    (run-hook-with-args 'slime-open-stream-hooks stream)
+    stream))
+
+(defun slime-io-speed-test (&optional profile)
+  "A simple minded benchmark for stream performance.
+If a prefix argument is given, instrument the slime package for
+profiling before running the benchmark."
+  (interactive "P")
+  (eval-and-compile
+    (require 'elp))
+  (elp-reset-all)
+  (elp-restore-all)
+  (load "slime.el")
+  ;;(byte-compile-file "slime-net.el" t)
+  ;;(setq slime-log-events nil)
+  (setq slime-enable-evaluate-in-emacs t)
+  ;;(setq slime-repl-enable-presentations nil)
+  (when profile
+    (elp-instrument-package "slime-"))
+  (kill-buffer (slime-output-buffer))
+  (switch-to-buffer (slime-output-buffer))
+  (delete-other-windows)
+  (sit-for 0)
+  (slime-repl-send-string "(swank:io-speed-test 4000 1)")
+  (let ((proc (slime-inferior-process)))
+    (when proc
+      (display-buffer (process-buffer proc) t)
+      (goto-char (point-max)))))
+
 (defvar slime-write-string-function 'slime-repl-write-string)
 
 (defun slime-write-string (string &optional target)


### PR DESCRIPTION
Revert two recent CLs that removed useful -- and still in-use -- functionality.  