### PR TITLE
Fix slime-sexp-at-point in almost empty buffer

### DIFF
--- a/slime-tests.el
+++ b/slime-tests.el
@@ -259,8 +259,6 @@ conditions (assertions)."
                            (slime-symbol-at-point)
                            #'equal)))))
 
-
-
 (def-slime-test symbol-at-point.2 (sym)
   "fancy symbol-name _not_ at BOB/EOB"
   slime-test-symbols
@@ -336,9 +334,8 @@ conditions (assertions)."
   slime-test-symbols
   (slime-check-symbol-at-point "#+" sym ""))
 
-
 (def-slime-test sexp-at-point.1 (string)
-  "symbol-at-point after #'"
+  "sexp-at-point after noise"
   '(("foo")
     ("#:foo")
     ("#'foo")
@@ -353,6 +350,29 @@ conditions (assertions)."
                        string
                        (slime-sexp-at-point)
                        #'equal)))
+
+(def-slime-test sexp-at-point.2 (string)
+  "sexp-at-point top comment"
+  '((";\n")
+    ("; x\n")
+    (" ;\n")
+    (" ; x\n")
+    ("\n;\n")
+    ("\n; x\n"))
+  (with-temp-buffer
+    (lisp-mode)
+    (insert string)
+    (slime-test-expect (format "Check sexp `%s' (at %d)..."
+                               (buffer-string) (point))
+                       nil
+                       (slime-sexp-at-point)
+                       #'eq)
+    (goto-char (point-min))
+    (slime-test-expect (format "Check sexp `%s' (at %d)..."
+                               (buffer-string) (point))
+                       nil
+                       (slime-sexp-at-point)
+                       #'eq)))
 
 (def-slime-test narrowing ()
     "Check that narrowing is properly sustained."

--- a/slime.el
+++ b/slime.el
@@ -7617,7 +7617,17 @@ The returned bounds are either nil or non-empty."
            (save-restriction
              (narrow-to-region (point) (point-max))
              (bounds-of-thing-at-point 'sexp)))
-      (bounds-of-thing-at-point 'sexp)))
+      (let ((bounds (bounds-of-thing-at-point 'sexp)))
+        ;; Regardless of `parse-sexp-ignore-comments', if there are no
+        ;; sexps before or after point, the bounds may include
+        ;; whitespace and comments. Detect this, and return nil.
+        (if (and bounds
+                 (= (car bounds) (point-min))
+                 (save-excursion
+                   (goto-char (car bounds))
+                   (looking-at "[;\n[:space:]]")))
+            nil
+          bounds))))
 
 (defun slime-sexp-at-point ()
   "Return the sexp at point as a string, otherwise nil."


### PR DESCRIPTION
If there are no sexps before or after point, slime-sexp-at-point used to return the buffer contents between (point-min) and (point). With this change, it returns nil.