### PR TITLE
add a :load-contribs key to #'dump-image to preload *contribs*

### DIFF
--- a/swank-loader.lisp
+++ b/swank-loader.lisp
@@ -358,8 +358,8 @@ global variabes in SWANK."
   (when setup
     (setup)))
 
-(defun dump-image (filename)
-  (init :setup nil)
+(defun dump-image (filename &key load-contribs)
+  (init :setup nil :load-contribs load-contribs)
   (funcall (q "swank/backend:save-image") filename))
 
 (defun list-fasls (&key (include-contribs t) (compile t)


### PR DESCRIPTION
After discussing you were completely right! I have added the :load-contribs key to #'dump-image and kept the default as nil so there are no actual changes for those already using #'dump-image. 