### PR TITLE
add command slime-presentation-menu-at-point

### DIFF
--- a/contrib/slime-presentations.el
+++ b/contrib/slime-presentations.el
@@ -648,6 +648,21 @@ A negative argument means move backward instead."
           (when choice
             (call-interactively (gethash choice choice-to-lambda))))))))
 
+(defun slime-presentation-menu-at-point (point)
+  (interactive "d")
+  (let* ((buffer (current-buffer))
+         (choice-to-lambda (make-hash-table)))
+    (cl-multiple-value-bind (presentation from to)
+        (with-current-buffer buffer
+          (slime-presentation-around-point point))
+      (unless presentation
+        (error "No presentation at point"))
+      (let ((menu (slime-menu-choices-for-presentation
+                   presentation buffer from to choice-to-lambda)))
+        (let ((choice (x-popup-menu t menu)))
+          (when choice
+            (call-interactively (gethash choice choice-to-lambda))))))))
+
 (defun slime-presentation-expression (presentation)
   "Return a string that contains a CL s-expression accessing
 the presented object."


### PR DESCRIPTION
to be able to open a presentation's menu without having to click using the mouse, which might not even be possible when using emacs in the terminal.