### PR TITLE
slime-indentation.el: use the canonical package name for comparisons

### DIFF
--- a/contrib/slime-cl-indent.el
+++ b/contrib/slime-cl-indent.el
@@ -32,8 +32,7 @@
 ;; (setq lisp-indent-function 'common-lisp-indent-function)
 ;;
 ;; This file is substantially patched from original cl-indent.el,
-;; which is in Emacs proper. It does not require SLIME, but is instead
-;; required by one of it's contribs, `slime-indentation'.
+;; which is in Emacs proper.
 ;;
 ;; Before making modifications to this file, consider adding them to
 ;; Emacs's own `cl-indent' and refactoring this file to be an
@@ -616,7 +615,8 @@ given point. Defaults to `common-lisp-guess-current-package'.")
                 (caar system-info)
               (let ((guess nil)
                     (guess-n 0)
-                    (package (common-lisp-symbol-package full)))
+                    (package (slime-canonicalize-package
+                              (common-lisp-symbol-package full))))
                 (cl-dolist (info system-info guess)
                   (let* ((pkgs (cdr info))
                          (n (length pkgs)))

--- a/slime.el
+++ b/slime.el
@@ -2080,6 +2080,24 @@ search for and read an `in-package' form."
         (widen)
         (slime-find-buffer-package))))
 
+(defun slime-canonicalize-package (package-name)
+  "Find the CL:PACKAGE-NAME of the package with PACKAGE-NAME,
+which may be a package designator. When connected, nicknames are
+resolved in `slime-current-package'."
+  (when package-name
+    (if (slime-current-connection)
+        (slime-eval `(cl:let ((pkg (swank::guess-package ,package-name)))
+                             (cl:when pkg (cl:package-name pkg))))
+      (upcase (cond ((string-prefix-p "#:" package-name)
+                     (substring package-name 2))
+                    ((string-prefix-p ":" package-name)
+                     (substring package-name 1))
+                    ((and (string-prefix-p "\"" package-name)
+                          (string-suffix-p "\"" package-name))
+                     (substring package-name 1 (1- (length package-name))))
+                    (t
+                     package-name))))))
+
 (defvar slime-find-buffer-package-function 'slime-search-buffer-package
   "*Function to use for `slime-find-buffer-package'.
 The result should be the package-name (a string)


### PR DESCRIPTION
Previously, common-lisp-get-indentation did not use the indentation associated with some symbol name in the current package reliably because it compared slime-current-package (e.g :pgkname, #:pkgname, or "pkgname") to PKGNAME. Without an exact package name match, it heuristically chose the indentation setting associated with the most packages.

This change looks up the canonical package name on the Common Lisp side, so the above heuristic need not trigger in most cases. If Slime is not connected, then the canonical package name is guessed heuristically, so that any leftover data in common-lisp-system-indentation may still be matched.