### PR TITLE
Ignore errors in find-package during completion

### DIFF
--- a/swank.lisp
+++ b/swank.lisp
@@ -2729,7 +2729,7 @@ boundp fboundp generic-function class macro special-operator package accessor"
       (when (find-class symbol nil)   (flip #\c) )
       (when (macro-function symbol)   (flip #\m))
       (when (special-operator-p symbol) (flip #\s))
-      (when (find-package symbol)       (flip #\p))
+      (when (ignore-errors (find-package symbol)) (flip #\p))
       (when (structure-accessor-p symbol) (flip #\a))
       result)))
 


### PR DESCRIPTION
When typing `excl::` in Allegro Common Lisp an implementation-specific error occurred.

This was the backtrace
```
The parent of package #<The KEYWORD package> does not exist.
   [Condition of type SIMPLE-ERROR]

Restarts:
 0: [*ABORT] Return to SLIME's top level.
 1: [ABORT] Return to Top Level (an "abort" restart).
 2: [ABORT] Abort entirely from this (lisp) process.

Backtrace:
  0: (ERROR "The parent of package ~a does not exist." #<The KEYWORD package>)
  1: (PACKAGE-PARENT #<The KEYWORD package>)
  2: (RELATIVE-PACKAGE-NAME-TO-PACKAGE "..ENVIRONMENT..")
  3: (SWANK::SYMBOL-CLASSIFICATION-STRING EXCL::..ENVIRONMENT..)
  4: (SWANK::FORMAT-COMPLETION-SET ..)
```