### PR TITLE
Fix for slime.info path for MELPA package

### DIFF
--- a/slime.el
+++ b/slime.el
@@ -4543,8 +4543,11 @@ With prefix argument include internal symbols."
 (defun slime-info ()
   "Open Slime manual"
   (interactive)
-  (let ((file (expand-file-name "doc/slime.info" slime-path)))
-    (if (file-exists-p file)
+  (let ((file (seq-some (lambda (name)
+                          (let ((f (expand-file-name name slime-path)))
+                            (and (file-exists-p f) f)))
+                        '("doc/slime.info" "slime.info"))))
+    (if file
         (info file)
       (message "No slime.info, run `make slime.info' in %s"
                (expand-file-name "doc/" slime-path)))))


### PR DESCRIPTION
By default, the function `slime-info` assumes that the location of `slime.info` is to be picked up from a sub-directory where the source of this package is located. But that doesn't work if the package is packaged & installed via MELPA since `slime.info` sits in the top level directory, where `doc` directory is omitted. See the contents of the package for MELPA:

```
$ ls 
contrib        packages.lisp           slime-tests.elc   swank
dir            sbcl-pprint-patch.lisp  slime.el          swank-loader.lisp
lib            slime-autoloads.el      slime.elc         swank.asd
metering.lisp  slime-pkg.el            slime.info        swank.lisp
nregex.lisp    slime-tests.el          start-swank.lisp  xref.lisp
```

The fix is to let the user know where to look for slime.info to create it, if they are using slime from source. Or to report it upstream, to the package manager maintainers, i.e. MELPA.