### PR TITLE
common-lisp-hyperspec-root path handling

### DIFF
--- a/lib/hyperspec.el
+++ b/lib/hyperspec.el
@@ -112,7 +112,9 @@ If you copy the HyperSpec to another location, customize the variable
 `common-lisp-hyperspec-root' to point to that location."
   (interactive (list (common-lisp-hyperspec-read-symbol-name)))
   (let* ((name (common-lisp-hyperspec--strip-cl-package (downcase symbol-name)))
-	 (hyperspec-root-path (file-name-as-directory common-lisp-hyperspec-root)))
+	 (hyperspec-root-path (if (string-suffix-p "/" common-lisp-hyperspec-root)
+                                  common-lisp-hyperspec-root
+                                (concat common-lisp-hyperspec-root "/"))))
     (cl-maplist (lambda (entry)
 		  (browse-url (concat hyperspec-root-path "Body/" (car entry)))
 		  (when (cdr entry)

--- a/lib/hyperspec.el
+++ b/lib/hyperspec.el
@@ -111,13 +111,20 @@ Visit http://www.lispworks.com/reference/HyperSpec/ for more information.
 If you copy the HyperSpec to another location, customize the variable
 `common-lisp-hyperspec-root' to point to that location."
   (interactive (list (common-lisp-hyperspec-read-symbol-name)))
-  (let ((name (common-lisp-hyperspec--strip-cl-package
-	       (downcase symbol-name)))
-        (hyperspec-root-path (let ((root (file-name-as-directory
-                                          (expand-file-name common-lisp-hyperspec-root))))
-                               (if (file-name-absolute-p root)
-                                   (concat "file://" root)
-                                 root))))
+  (let* ((name (common-lisp-hyperspec--strip-cl-package (downcase symbol-name)))
+         (hyperspec-root-path (cond
+                               ((string-match-p "\\`https?://" common-lisp-hyperspec-root)
+                                common-lisp-hyperspec-root)
+                               ((string-match-p "\\`file://" common-lisp-hyperspec-root)
+                                (let* ((path (substring common-lisp-hyperspec-root (length "file://"))))
+                                  (unless (file-exists-p path)
+                                    (error "Common Lisp HyperSpec root %s does not exist" path))
+                                  common-lisp-hyperspec-root))
+                               (t
+                                (let* ((path (expand-file-name common-lisp-hyperspec-root)))
+                                  (unless (file-exists-p path)
+                                    (error "Common Lisp HyperSpec root %s does not exist" path))
+                                  (format "file://%s" (file-name-as-directory path)))))))
     (cl-maplist (lambda (entry)
 		  (browse-url (concat hyperspec-root-path "Body/" (car entry)))
 		  (when (cdr entry)

--- a/lib/hyperspec.el
+++ b/lib/hyperspec.el
@@ -112,10 +112,14 @@ If you copy the HyperSpec to another location, customize the variable
 `common-lisp-hyperspec-root' to point to that location."
   (interactive (list (common-lisp-hyperspec-read-symbol-name)))
   (let ((name (common-lisp-hyperspec--strip-cl-package
-	       (downcase symbol-name))))
+	       (downcase symbol-name)))
+        (hyperspec-root-path (let ((root (file-name-as-directory
+                                          (expand-file-name common-lisp-hyperspec-root))))
+                               (if (file-name-absolute-p root)
+                                   (concat "file://" root)
+                                 root))))
     (cl-maplist (lambda (entry)
-		  (browse-url (concat common-lisp-hyperspec-root "Body/"
-				      (car entry)))
+		  (browse-url (concat hyperspec-root-path "Body/" (car entry)))
 		  (when (cdr entry)
 		    (sleep-for 1.5)))
 		(or (common-lisp-hyperspec--find name)

--- a/lib/hyperspec.el
+++ b/lib/hyperspec.el
@@ -112,19 +112,7 @@ If you copy the HyperSpec to another location, customize the variable
 `common-lisp-hyperspec-root' to point to that location."
   (interactive (list (common-lisp-hyperspec-read-symbol-name)))
   (let* ((name (common-lisp-hyperspec--strip-cl-package (downcase symbol-name)))
-         (hyperspec-root-path (cond
-                               ((string-match-p "\\`https?://" common-lisp-hyperspec-root)
-                                common-lisp-hyperspec-root)
-                               ((string-match-p "\\`file://" common-lisp-hyperspec-root)
-                                (let* ((path (substring common-lisp-hyperspec-root (length "file://"))))
-                                  (unless (file-exists-p path)
-                                    (error "Common Lisp HyperSpec root %s does not exist" path))
-                                  common-lisp-hyperspec-root))
-                               (t
-                                (let* ((path (expand-file-name common-lisp-hyperspec-root)))
-                                  (unless (file-exists-p path)
-                                    (error "Common Lisp HyperSpec root %s does not exist" path))
-                                  (format "file://%s" (file-name-as-directory path)))))))
+	 (hyperspec-root-path (file-name-as-directory common-lisp-hyperspec-root)))
     (cl-maplist (lambda (entry)
 		  (browse-url (concat hyperspec-root-path "Body/" (car entry)))
 		  (when (cdr entry)


### PR DESCRIPTION
When `common-lisp-hyperspec-root` is set without the leading `file://`, the call to hyperspec-lookup is dropped silently.

When `common-lisp-hyperspec-root` is set without the trailing `/` (on Unix like OS), the hyperspec-lookup is also dropped silently.

Ideal fix for this would be to use something like this:

```elisp
(defcustom common-lisp-hyperspec-root
  "http://www.lispworks.com/reference/HyperSpec/"
  "The root of the Common Lisp HyperSpec URL.
If you copy the HyperSpec to your local system, set this variable to something like \"/usr/local/doc/HyperSpec/\" and it will automatically be prefixed with \"file://\" and normalized as a proper directory path."
  :type 'string
  :set (lambda (symbol value)
         (let ((processed-value
                (if (and (stringp value)
                         (not (string-match-p "^https?://" value))
                         (not (string-match-p "^file://" value)))
                    (concat "file://"
                            (file-name-as-directory
                             (expand-file-name value)))
                  value)))
                  (set-default symbol processed-value))))
```

But since SLIME is over 23 years old, and hyperspec.el is over 28 years old, there might be some backwards compatibiliy issues.

Because you can't set defcustom values with setq.
(Caveat, you theoretically can, in init.el. **So should this PR be revised and instead the above `defcustom` added instead?**)

This fix tries to treat those edge case potential errors by checking the value of `common-lisp-hyperspec-root` and ensures that it has proper formatting, so that the calls aren't dropped silently.

What do you think? Thanks