### PR TITLE
fix indentation for defslimefun macros

### DIFF
--- a/slime.el
+++ b/slime.el
@@ -3950,6 +3950,7 @@ The result is a (possibly empty) list of definitions."
 
 (defmacro defslimefun (name arglist &rest body)
   "Define a function via `cl-defun' that can be invoked from SWANK."
+  (declare (indent defun))
   `(progn
      (put ',name 'slime-rpc t)
      (cl-defun ,name ,arglist ,@body)))


### PR DESCRIPTION
Previously defslimefun macros would be indented as:

```lisp
(defslimefun slime-py--import (name)
             "Prompt with candidates for name, import it, and insert import statement into
the buffer."
             (let ((...)))
```

This small change just tells emacs it should be indented as defun, so it will now be automatically indented as expected:
```lisp
(defslimefun slime-py--import (name)
  "Prompt with candidates for name, import it, and insert import statement into
the buffer."
  (let ((...)))
```