### PR TITLE
Restore source-path to position for SBCL's implementation of comma

### DIFF
--- a/slime-tests.el
+++ b/slime-tests.el
@@ -717,10 +717,8 @@ Confirm that SUBFORM is correctly located."
        (/ 1 0)))
   (slime-test--compile-defun program subform))
 
-;; SBCL used to pass this one but since they changed the
-;; backquote/unquote reader it fails.
 (def-slime-test (compile-defun-with-backquote
-                 (:fails-for "allegro" "lispworks" "clisp" "sbcl"))
+                 (:fails-for "allegro" "lispworks" "clisp"))
     (program subform)
     "Compile PROGRAM containing errors.
 Confirm that SUBFORM is correctly located."

--- a/swank/source-path-parser.lisp
+++ b/swank/source-path-parser.lisp
@@ -96,9 +96,18 @@ The source locations are stored in SOURCE-MAP."
 	       (multiple-value-bind (fun nt) (get-macro-character char rt)
 		 (when fun
 		   (let ((wrapper (make-source-recorder fun source-map)))
-		     (set-macro-character char wrapper nt rt))))))))
+		     (set-macro-character char wrapper nt rt)))))))
+	 (install-special-backquote-readers (rt)
+	   (set-macro-character #\` (lambda (s c) (list 'backq (read s t nil t))) t rt)
+	   (set-macro-character #\, (lambda (s c) (let ((n (read-char s)))
+						    (case n
+						      ((#\. #\@))
+						      (t (unread-char n s)))
+						    (list 'comma (read s t nil t))))
+				t rt)))
     (let ((rt (copy-readtable readtable)))
       (install-special-sharpdot-reader rt)
+      #+sbcl (install-special-backquote-readers rt)
       (install-wrappers rt)
       rt)))
 


### PR DESCRIPTION
The source path behaves as if the comma were implemented as a two-element list (COMMA <expr>), so install a read macro to make it so.

(depends for full workingness on change 35b52dd65045b856e7e406ab79bfb4b10050a7d9, which I have just pushed to SBCL)