### PR TITLE
Restore source-path to position for SBCL's implementation of comma

### DIFF
--- a/slime-tests.el
+++ b/slime-tests.el
@@ -738,10 +738,8 @@ Confirm that SUBFORM is correctly located."
        (/ 1 0)))
   (slime-test--compile-defun program subform))
 
-;; SBCL used to pass this one but since they changed the
-;; backquote/unquote reader it fails.
 (def-slime-test (compile-defun-with-backquote
-                 (:fails-for "allegro" "lispworks" "clisp" "sbcl"))
+                 (:fails-for "allegro" "lispworks" "clisp" "sbcl-2.5.10"))
     (program subform)
     "Compile PROGRAM containing errors.
 Confirm that SUBFORM is correctly located."

--- a/swank/source-path-parser.lisp
+++ b/swank/source-path-parser.lisp
@@ -96,9 +96,18 @@ The source locations are stored in SOURCE-MAP."
 	       (multiple-value-bind (fun nt) (get-macro-character char rt)
 		 (when fun
 		   (let ((wrapper (make-source-recorder fun source-map)))
-		     (set-macro-character char wrapper nt rt))))))))
+		     (set-macro-character char wrapper nt rt)))))))
+	 (install-special-backquote-readers (rt)
+	   (set-macro-character #\` (lambda (s c) (list 'backq (read s t nil t))) t rt)
+	   (set-macro-character #\, (lambda (s c) (let ((n (read-char s)))
+						    (case n
+						      ((#\. #\@))
+						      (t (unread-char n s)))
+						    (list 'comma (read s t nil t))))
+				t rt)))
     (let ((rt (copy-readtable readtable)))
       (install-special-sharpdot-reader rt)
+      #+sbcl (install-special-backquote-readers rt)
       (install-wrappers rt)
       rt)))
 


### PR DESCRIPTION
This reverts commit 3d809df89ec05a3666c35075923eac0806e90659, and changes the `compile-defun-with-backquote` fails-for specification to sbcl-2.5.10.

I don't know why the CI job failed, but it doesn't look related (timing out while setting up the build environment)?  Tests pass locally for me both with old and new sbcls.  Let me know if there's anything else I should be doing.