### PR TITLE
fix for slime-after-change-function in narrowed regions

### DIFF
--- a/contrib/slime-presentations.el
+++ b/contrib/slime-presentations.el
@@ -324,8 +324,8 @@ string or buffer `object'."
   "Check all presentations within and adjacent to the change.
 When a presentation has been altered, change it to plain text."
   (let ((inhibit-modification-hooks t))
-    (let ((real-start (max 1 (1- start)))
-          (real-end   (min (1+ (buffer-size)) (1+ end)))
+    (let ((real-start (max (point-min) (1- start)))
+          (real-end   (min (point-max) (1+ end)))
           (any-change nil))
       ;; positions around the change
       (slime-for-each-presentation-in-region


### PR DESCRIPTION
I ran into an edge case that gets errors in the slime repl when you're dealing with a narrowed region. For me it triggers with a python backend I'm developing for slime as I set indent-line-function in the repl to a custom function that narrows the region to the active prompt input, and then runs the python indent function, so the python indenter isn't confused by prompts and prompt output. I'm not sure anyone will run into this in normal usage of slime with common lisp, but I think it could happen whenever slime-repl buffer is narrowed to some region, and the fix to have it work with narrowed regions is very minimal.

Problem is in slime-after-change-function it is calling slime-for-each-presentation-in-region with an end of `(min (1+ (buffer-size)) (1+ end))`, which can be one beyond the end of the region, which it then calls get-text-property on and errors with args-out-of-range. Just changing `(1+ (buffer-size))` to `(point-max)` it will be the same in non-narrowed buffers, and work in narrowed buffers.
