### PR TITLE
Fix swank:ed-rpc when the RPC is undefined or not marked

### DIFF
--- a/packages.lisp
+++ b/packages.lisp
@@ -188,6 +188,7 @@
            #:quit-lisp
            #:eval-for-emacs
            #:eval-in-emacs
+           #:rpc-forbidden-error
            #:ed-rpc
            #:ed-rpc-no-wait
            #:y-or-n-p-in-emacs


### PR DESCRIPTION
Fix ed-rpc so when the RPC is undefined or not marked callable, a normal Lisp error is thrown.