### PR TITLE
SBCL: in definition-source-file-location, character-offset is first

### DIFF
--- a/swank/sbcl.lisp
+++ b/swank/sbcl.lisp
@@ -869,7 +869,8 @@ QUALITIES is an alist with (quality . value)"
   (with-definition-source (pathname form-path character-offset plist
                            file-write-date) definition-source
     (let* ((namestring (namestring (translate-logical-pathname pathname)))
-           (pos (or (and form-path
+           (pos (or character-offset
+                    (and form-path
                          (or
                           #+#.(swank/backend:with-symbol 'definition-source-form-number 'sb-introspect)
                           (and (sb-introspect:definition-source-form-number definition-source)
@@ -877,7 +878,6 @@ QUALITIES is an alist with (quality . value)"
                           (ignore-errors
                            (source-file-position namestring file-write-date
                                                  form-path))))
-                    character-offset
                     0))
            (snippet (source-hint-snippet namestring file-write-date pos)))
       (make-location `(:file ,namestring)


### PR DESCRIPTION
This is incredibly silly, but it works for what I want to do - 

I'm trying to add `slime-edit-definition` support to [a non-lispy layer that transpiles to Common Lisp](https://moonli-lang.github.io/docs/intro-lisp/). The current transpilation process creates a .lisp file from a .moonli file and then the .lisp file is processed as usual. Unfortunately, this means, `slime-edit-definition` will go to the .lisp file. However, I want to send it to the appropriate place in .moonli file. 

I can obtain character-offsets in my transpiler. However, currently SLIME and SBCL insist on navigating using sexpressions, even if character-offsets are recorded. This PR first makes `swank/sbcl::definition-source-file-location` first check the character-offset instead of computing it from the form-path and sexpressions.. I'm not sure if there's a better way to achieve what I want to do (use SLIME seamlessly between lisp and moonli files).

`make check` does not break any tests. But let me know if this might cause some other issues!

