### PR TITLE
Indent `("foo" ...) as data

### DIFF
--- a/contrib/slime-cl-indent.el
+++ b/contrib/slime-cl-indent.el
@@ -903,7 +903,12 @@ For example, the function `case' has an indent property
 
             (cond ((and (or (eq (char-after (1- containing-sexp)) ?\')
                             (and (not lisp-backquote-indentation)
-                                 (eq (char-after (1- containing-sexp)) ?\`)))
+                                 (eq (char-after (1- containing-sexp)) ?\`))
+                            ;; `("foo" ...) is not valid Lisp, indent it as data.
+                            (save-excursion
+                              (goto-char containing-sexp)
+                              (backward-char)
+                              (looking-at "`\\s-*\(\\s-*\\\"")))
                         (not (eq (char-after (- containing-sexp 2)) ?\#)))
                    ;; No indentation for "'(...)" elements
                    (setq calculated (1+ sexp-column)))

--- a/contrib/test/slime-cl-indent-test.txt
+++ b/contrib/test/slime-cl-indent-test.txt
@@ -1004,3 +1004,30 @@
  (list foo
        bar
        baz))
+
+;;; Test: indent-96
+
+`("foo"
+  "bar")
+
+;;; Test: indent-97
+
+`("foo" "baz" "quux"
+  "bar" "frob")
+
+;;; Test: indent-98
+
+`("foo" ()
+  "bar" "baz" "quux")
+
+;;; Test: indent-99
+
+`(    "foo" ()
+  "bar" "baz" "quux")
+
+;;; Test: indent-100
+
+`("foo" ()
+  ("bar" ())
+  ("baz" () "fred")
+  ("quux" ()))


### PR DESCRIPTION
Closes #904

The change works on my machine. I'm unsure if the tests are written correctly, I can't see `common-lisp-run-indentation-tests` in the code anywhere.