### PR TITLE
More uniform sldb frame details

### DIFF
--- a/slime.el
+++ b/slime.el
@@ -5890,15 +5890,19 @@ The details include local variable bindings and CATCH-tags."
                                    'sldb-detailed-frame-line-face))
         (let ((indent1 "      ")
               (indent2 "        "))
-          (insert indent1 (sldb-in-face section
-                            (if locals "Locals:" "[No Locals]")) "\n")
-          (sldb-insert-locals locals indent2 frame)
+          (when locals
+            (insert indent1 (sldb-in-face section "Locals:") "\n")
+            (sldb-insert-locals locals indent2 frame))
           (when catches
             (insert indent1 (sldb-in-face section "Catch-tags:") "\n")
             (dolist (tag catches)
               (slime-propertize-region `(catch-tag ,tag)
                 (insert indent2 (sldb-in-face catch-tag (format "%s" tag))
                         "\n"))))
+          (when (and (not catches)
+                     (not locals))
+            (insert indent1 (sldb-in-face detailed-frame-line
+                                          "[Nothing here]") "\n"))
           (setq end (point)))))
     (slime--display-region (point) end)))
 


### PR DESCRIPTION
only display what's available, and display a `[Nothing here]` when needed