### PR TITLE
Use cl-case instead of case

### DIFF
--- a/contrib/slime-references.el
+++ b/contrib/slime-references.el
@@ -103,7 +103,7 @@ See SWANK-BACKEND:CONDITION-REFERENCES for the datatype."
              (t
               (hyperspec-lookup what))))
           (t
-           (case slime-sbcl-manual-root
+           (cl-case slime-sbcl-manual-root
              (:info
               (info (format "(sbcl)%s" what)))
              (t


### PR DESCRIPTION
The native compiler treates `case` as a function and thus miscompiles slime-references.el