### PR TITLE
Fix file URI example in common-lisp-hyperspec-root docstring

### DIFF
--- a/lib/hyperspec.el
+++ b/lib/hyperspec.el
@@ -42,7 +42,7 @@
   "http://www.lispworks.com/reference/HyperSpec/"
   "The root of the Common Lisp HyperSpec URL.
 If you copy the HyperSpec to your local system, set this variable to
-something like \"file://usr/local/doc/HyperSpec/\".")
+something like \"file:///usr/local/doc/HyperSpec/\".")
 
 ;;; Added variable for CLHS symbol table. See details below.
 ;;;


### PR DESCRIPTION
Fix the example URI in the `common-lisp-hyperspec-root` docstring from `file://usr/local/doc/HyperSpec/` to `file:///usr/local/doc/HyperSpec/` (triple slash).

With only two slashes, `usr` is interpreted as a hostname per the file URI scheme (RFC 8089). Three slashes indicate an empty authority (local host) followed by an absolute path.

Fixes #607