### PR TITLE
Fix: Improve slime autodoc mode definition 

### DIFF
--- a/contrib/slime-autodoc.el
+++ b/contrib/slime-autodoc.el
@@ -198,10 +198,8 @@ If it's not in the cache, the cache will be updated asynchronously."
     (if (boundp 'eldoc-documentation-functions)
         (remove-hook 'eldoc-documentation-functions 'slime-autodoc t)
       ;; Reset eldoc-documentation-function to its (global) default value:
-    (eldoc-mode 0)))
-  (when (called-interactively-p 'interactive)
-    (message "Slime autodoc mode %s."
-             (if slime-autodoc-mode "enabled" "disabled"))))
+      (kill-local-variable 'eldoc-documentation-function))
+    (eldoc-mode 0))))
 
 
 ;;; Noise to enable/disable slime-autodoc-mode

--- a/contrib/slime-autodoc.el
+++ b/contrib/slime-autodoc.el
@@ -198,7 +198,6 @@ If it's not in the cache, the cache will be updated asynchronously."
     (if (boundp 'eldoc-documentation-functions)
         (remove-hook 'eldoc-documentation-functions 'slime-autodoc t)
       ;; Reset eldoc-documentation-function to its (global) default value:
-      (kill-local-variable 'eldoc-documentation-function 'slime-autodoc))
     (eldoc-mode 0)))
   (when (called-interactively-p 'interactive)
     (message "Slime autodoc mode %s."


### PR DESCRIPTION
A minor improvement and a fix to the previous pull request #914 (original issue: #898).

As Stefan Monnier suggested in the emacs-devel mailing list I removed the redundant minor mode message (define-minor-mode takes care of that already). 

Also, I found a dangling/erroneous argument provided to kill-local-variable in an untested code branch. 
