### PR TITLE
Add slime-coalton contrib and small slime-arglists hook for extension

### DIFF
--- a/contrib/slime-coalton.el
+++ b/contrib/slime-coalton.el
@@ -1,0 +1,11 @@
+;;; slime-coalton.el --- Coalton support for SLIME  -*- lexical-binding: t; -*-
+
+(require 'slime)
+
+(define-slime-contrib slime-coalton
+  "Coalton support."
+  (:license "GPL")
+  (:slime-dependencies slime-autodoc)
+  (:swank-dependencies swank-coalton))
+
+(provide 'slime-coalton)

--- a/contrib/swank-arglists.lisp
+++ b/contrib/swank-arglists.lisp
@@ -77,6 +77,37 @@ Otherwise NIL is returned."
          (progn ,@body))))
 
 
+;;;; Optional autodoc extensions
+
+(defvar *autodoc-operator-functions* '()
+  "Functions called with an operator symbol.
+
+If any function returns non-NIL, the operator is treated as having
+autodoc support even when it does not have an ordinary Lisp arglist.")
+
+(defvar *autodoc-functions* '()
+  "Functions called to produce autodoc for a parsed form.
+
+Each function is called with FORM, ARGLIST, OBJ-AT-CURSOR, FORM-PATH,
+and PRINT-RIGHT-MARGIN. It should return NIL to decline, or two
+values: a documentation string and a boolean cache flag.")
+
+(defun extended-autodoc-operator-p (operator)
+  (some (lambda (function)
+          (funcall function operator))
+        *autodoc-operator-functions*))
+
+(defun extended-autodoc (form arglist obj-at-cursor form-path
+                         print-right-margin)
+  (dolist (function *autodoc-functions*)
+    (multiple-value-bind (doc cache-p)
+        (funcall function
+                 form arglist obj-at-cursor form-path print-right-margin)
+      (when doc
+        (return-from extended-autodoc
+          (values doc cache-p))))))
+
+
 ;;;; Arglist Definition
 
 (defstruct (arglist (:conc-name arglist.) (:predicate arglist-p))
@@ -1156,16 +1187,21 @@ Second, a boolean value telling whether the returned string can be cached."
         (cond ((boundp-and-interesting obj-at-cursor)
                (list (print-variable-to-string obj-at-cursor) nil))
               (t
-               (list
-                (with-available-arglist (arglist) arglist
-                  (decoded-arglist-to-string
-                   arglist
-                   :print-right-margin print-right-margin
-                   :operator (car form)
-                   :highlight (form-path-to-arglist-path form-path
-                                                         form
-                                                         arglist)))
-                t)))))))
+               (multiple-value-bind (doc cache-p)
+                   (extended-autodoc form arglist obj-at-cursor form-path
+                                     print-right-margin)
+                 (if doc
+                     (list doc cache-p)
+                     (list
+                      (with-available-arglist (arglist) arglist
+                        (decoded-arglist-to-string
+                         arglist
+                         :print-right-margin print-right-margin
+                         :operator (car form)
+                         :highlight (form-path-to-arglist-path form-path
+                                                               form
+                                                               arglist)))
+                      t)))))))))
 
 (defun boundp-and-interesting (symbol)
   (and symbol
@@ -1257,7 +1293,9 @@ to the context provided by RAW-FORM."
        (yield-failure ()
          (values nil :not-available))
        (operator-p (operator local-ops)
-         (or (and (symbolp operator) (valid-operator-symbol-p operator))
+         (or (and (symbolp operator)
+                  (or (valid-operator-symbol-p operator)
+                      (extended-autodoc-operator-p operator)))
              (assoc operator local-ops :test #'op=)))
        (op= (op1 op2)
          (cond ((and (symbolp op1) (symbolp op2))

--- a/contrib/swank-coalton.lisp
+++ b/contrib/swank-coalton.lisp
@@ -1,0 +1,77 @@
+;;; swank-coalton.lisp --- Coalton autodoc support
+;;
+;; License: Public Domain
+;;
+
+(in-package :swank)
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (swank-require :swank-arglists))
+
+(defun package-uses-package-p (package used-package)
+  (member used-package (package-use-list package) :test #'eq))
+
+(defun coalton-autodoc-candidate-p (operator)
+  (let* ((coalton-package (find-package "COALTON"))
+         (operator-package (and (symbolp operator) (symbol-package operator))))
+    (and coalton-package
+         operator-package
+         (or (eq operator-package coalton-package)
+             (package-uses-package-p operator-package coalton-package)))))
+
+(defun coalton-autodoc-info (operator)
+  (handler-case
+      (when (coalton-autodoc-candidate-p operator)
+        (let* ((tc-package (find-package "COALTON-IMPL/TYPECHECKER"))
+               (entry-package (find-package "COALTON-IMPL/ENTRY"))
+               (lookup-value-type (and tc-package
+                                       (find-symbol "LOOKUP-VALUE-TYPE"
+                                                    tc-package)))
+               (type-to-string (and tc-package
+                                    (find-symbol "TYPE-TO-STRING" tc-package)))
+               (global-environment (and entry-package
+                                        (find-symbol "*GLOBAL-ENVIRONMENT*"
+                                                     entry-package))))
+          (when (and lookup-value-type
+                     type-to-string
+                     global-environment
+                     (fboundp lookup-value-type)
+                     (fboundp type-to-string)
+                     (boundp global-environment))
+            (let* ((env (symbol-value global-environment))
+                   (type (funcall lookup-value-type env operator :no-error t)))
+              (when type
+                (values type env type-to-string))))))
+    (serious-condition ()
+      nil)))
+
+(defun coalton-autodoc-operator-p (operator)
+  (nth-value 0 (coalton-autodoc-info operator)))
+
+(defun coalton-autodoc-operator-string (operator)
+  (let ((*print-case* :downcase)
+        (*print-escape* nil)
+        (*print-readably* nil)
+        (*print-pretty* nil)
+        (*print-circle* nil)
+        (*print-level* 10)
+        (*print-length* 20))
+    (princ-to-string operator)))
+
+(defun coalton-autodoc (form _arglist _obj-at-cursor _form-path
+                        _print-right-margin)
+  (declare (ignore _arglist _obj-at-cursor _form-path _print-right-margin))
+  (when (and (consp form)
+             (symbolp (car form)))
+    (multiple-value-bind (type env type-to-string)
+        (coalton-autodoc-info (car form))
+      (when type
+        (values (format nil "~A :: ~A"
+                        (coalton-autodoc-operator-string (car form))
+                        (funcall type-to-string type env))
+                t)))))
+
+(pushnew #'coalton-autodoc-operator-p *autodoc-operator-functions*)
+(pushnew #'coalton-autodoc *autodoc-functions*)
+
+(provide :swank-coalton)


### PR DESCRIPTION
This adds a very small Coalton contrib that should be harmless to add. It allows Coalton users to see the type in the mini-buffer wherever their cursor is. Instead of a copy or replumb of the code, I added a little hook mechanism.

Here's a little video.


https://github.com/user-attachments/assets/4e735403-b6ce-48bc-89f9-711b37f15cea

