### PR TITLE
Fixed one compilation error & some warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 # Variables
 #
-EMACS=emacs
+EMACS?=emacs
 LISP=sbcl
 
 LOAD_PATH=-L .

--- a/contrib/slime-autodoc.el
+++ b/contrib/slime-autodoc.el
@@ -103,7 +103,7 @@
       (lisp-mode-variables t))
     (insert string)
     (let ((font-lock-verbose nil))
-      (font-lock-fontify-buffer))
+      (font-lock-ensure (point-min) (point-max)))
     (goto-char (point-min))
     (when (re-search-forward "===> \\(\\(.\\|\n\\)*\\) <===" nil t)
       (let ((highlight (match-string 1)))

--- a/contrib/slime-sprof.el
+++ b/contrib/slime-sprof.el
@@ -84,7 +84,7 @@
            (slime-sprof-browser-insert-line data 54))))
       (if (= line 1)
           (goto-char point)
-          (goto-line 2)))))
+          (slime-goto-line 2)))))
 
 (defun slime-sprof-sort (arg)
   (let* ((pos (if (markerp arg) arg (point)))
@@ -207,7 +207,7 @@
 
 ;; "Go to function"
 
-(defun slime-sprof-browser-go-to ()                                           
+(defun slime-sprof-browser-go-to ()
   (interactive)
   (let ((sub-index (get-text-property (point) 'profile-sub-index)))
     (when sub-index

--- a/contrib/slime-tramp.el
+++ b/contrib/slime-tramp.el
@@ -55,34 +55,34 @@ See also `slime-create-filename-translator'."
                            slime-filename-translations)))
         (t (list #'identity #'identity))))
 
-(defmacro tramp-make-tramp-file-name-args (username remote-host lisp-filename)
+(defmacro compat-tramp-make-tramp-file-name (username remote-host lisp-filename)
   (cond
    ((>= emacs-major-version 29)
-    `(list (tramp-find-method nil ,username ,remote-host)
-           (concat ,username
-                   "@"
-                   ,remote-host
-                   ":"
-                   ,lisp-filename)))
+    `(tramp-make-tramp-file-name (tramp-find-method nil ,username ,remote-host)
+                                 (concat ,username
+                                         "@"
+                                         ,remote-host
+                                         ":"
+                                         ,lisp-filename)))
    ((and (>= emacs-major-version 26) (< emacs-major-version 29))
     ;; Emacs 26 requires the method to be provided and the signature of
     ;; `tramp-make-tramp-file-name' has changed.
-    `(list (tramp-find-method nil ,username ,remote-host)
-           ,username
-           nil
-           ,remote-host
-           nil
-           ,lisp-filename))
+    `(tramp-make-tramp-file-name (tramp-find-method nil ,username ,remote-host)
+                                 ,username
+                                 nil
+                                 ,remote-host
+                                 nil
+                                 ,lisp-filename))
    ((boundp 'tramp-multi-methods)
-    `(list nil nil
-           ,username
-           ,remote-host
-           ,lisp-filename))
+    `(tramp-make-tramp-file-name nil nil
+                                 ,username
+                                 ,remote-host
+                                 ,lisp-filename))
    (t
-    `(list nil
-           ,username
-           ,remote-host
-           ,lisp-filename))))
+    `(tramp-make-tramp-file-name nil
+                                 ,username
+                                 ,remote-host
+                                 ,lisp-filename))))
 
 (defun slime-make-tramp-file-name (username remote-host lisp-filename)
   "Tramp compatability function.
@@ -91,8 +91,7 @@ Handles the signature of `tramp-make-tramp-file-name' changing
 over time."
   ;; Use the tramp-make-tramp-file-name-args macro, to avoid
   ;; compilation warnings.
-  (apply #'tramp-make-tramp-file-name
-         (tramp-make-tramp-file-name-args username remote-host lisp-filename)))
+  (compat-tramp-make-tramp-file-name username remote-host lisp-filename))
 
 (cl-defun slime-create-filename-translator (&key machine-instance
                                                  remote-host

--- a/contrib/slime-tramp.el
+++ b/contrib/slime-tramp.el
@@ -7,12 +7,12 @@
   "Filename translations for tramp"
   (:authors "Marco Baringer <mb@bese.it>")
   (:license "GPL")
-  (:on-load 
+  (:on-load
    (setq slime-to-lisp-filename-function #'slime-tramp-to-lisp-filename)
    (setq slime-from-lisp-filename-function #'slime-tramp-from-lisp-filename)))
 
 (defcustom slime-filename-translations nil
-  "Assoc list of hostnames and filename translation functions.  
+  "Assoc list of hostnames and filename translation functions.
 Each element is of the form (HOSTNAME-REGEXP TO-LISP FROM-LISP).
 
 HOSTNAME-REGEXP is a regexp which is applied to the connection's
@@ -55,31 +55,44 @@ See also `slime-create-filename-translator'."
                            slime-filename-translations)))
         (t (list #'identity #'identity))))
 
+(defmacro tramp-make-tramp-file-name-args (username remote-host lisp-filename)
+  (cond
+   ((>= emacs-major-version 29)
+    `(list (tramp-find-method nil ,username ,remote-host)
+           (concat ,username
+                   "@"
+                   ,remote-host
+                   ":"
+                   ,lisp-filename)))
+   ((and (>= emacs-major-version 26) (< emacs-major-version 29))
+    ;; Emacs 26 requires the method to be provided and the signature of
+    ;; `tramp-make-tramp-file-name' has changed.
+    `(list (tramp-find-method nil ,username ,remote-host)
+           ,username
+           nil
+           ,remote-host
+           nil
+           ,lisp-filename))
+   ((boundp 'tramp-multi-methods)
+    `(list nil nil
+           ,username
+           ,remote-host
+           ,lisp-filename))
+   (t
+    `(list nil
+           ,username
+           ,remote-host
+           ,lisp-filename))))
+
 (defun slime-make-tramp-file-name (username remote-host lisp-filename)
   "Tramp compatability function.
 
 Handles the signature of `tramp-make-tramp-file-name' changing
 over time."
-  (cond
-   ((>= emacs-major-version 26)
-    ;; Emacs 26 requires the method to be provided and the signature of
-    ;; `tramp-make-tramp-file-name' has changed.
-    (tramp-make-tramp-file-name (tramp-find-method nil username remote-host)
-                                username
-                                nil
-                                remote-host
-                                nil
-                                lisp-filename))
-   ((boundp 'tramp-multi-methods)
-    (tramp-make-tramp-file-name nil nil
-                                username
-                                remote-host
-                                lisp-filename))
-   (t
-    (tramp-make-tramp-file-name nil
-                                username
-                                remote-host
-                                lisp-filename))))
+  ;; Use the tramp-make-tramp-file-name-args macro, to avoid
+  ;; compilation warnings.
+  (apply #'tramp-make-tramp-file-name
+         (tramp-make-tramp-file-name-args username remote-host lisp-filename)))
 
 (cl-defun slime-create-filename-translator (&key machine-instance
                                                  remote-host

--- a/slime.el
+++ b/slime.el
@@ -4653,7 +4653,7 @@ source-location."
                       (slime-one-line-ify label))
                      (insert "\n"))))
   ;; Remove the final newline to prevent accidental window-scrolling
-  (backward-delete-char 1)
+  (delete-char -1)
   (insert " "))
 
 (defun slime-xref-next-line ()
@@ -5080,7 +5080,7 @@ This variable specifies both what was expanded and how.")
     (erase-buffer)
     (insert expansion)
     (goto-char (point-min))
-    (font-lock-fontify-buffer)))
+    (font-lock-ensure (point-min) (point-max))))
 
 (defun slime-create-macroexpansion-buffer ()
   (let ((name (slime-buffer-name :macroexpansion)))
@@ -6586,7 +6586,7 @@ KILL-BUFFER hooks for the inspector buffer."
                     'face 'slime-inspector-value-face)
             (insert title))
           (while (eq (char-before) ?\n)
-            (backward-delete-char 1))
+            (delete-char -1))
           (insert "\n" (fontify label "--------------------") "\n")
           (save-excursion
             (slime-inspector-insert-content content))

--- a/slime.el
+++ b/slime.el
@@ -1176,11 +1176,10 @@ DIRECTORY change to this directory before starting the process.
 (defun slime-recompile-bytecode ()
   "Recompile and reload slime."
   (interactive)
-  (let* ((slime-lib (file-name-sans-extension (locate-library "slime")))
-         (sourcefile (concat slime-lib
-                             ".el")))
+  (let ((sourcefile (concat (file-name-sans-extension (locate-library "slime"))
+                            ".el")))
     (byte-compile-file sourcefile)
-    (load slime-lib)))
+    (load (byte-compile-dest-file sourcefile))))
 
 (defun slime-urge-bytecode-recompile ()
   "Urge the user to recompile slime.elc.

--- a/slime.el
+++ b/slime.el
@@ -468,14 +468,14 @@ SLIME: The Superior Lisp Interaction Mode for Emacs (minor-mode).
 
 Commands to compile the current buffer's source file and visually
 highlight any resulting compiler notes and warnings:
-\\[slime-compile-and-load-file]	- Compile and load the current buffer's file.
-\\[slime-compile-file]	- Compile (but not load) the current buffer's file.
-\\[slime-compile-defun]	- Compile the top-level form at point.
+\\[slime-compile-and-load-file] - Compile and load the current buffer's file.
+\\[slime-compile-file]  - Compile (but not load) the current buffer's file.
+\\[slime-compile-defun] - Compile the top-level form at point.
 
 Commands for visiting compiler notes:
-\\[slime-next-note]	- Goto the next form with a compiler note.
-\\[slime-previous-note]	- Goto the previous form with a compiler note.
-\\[slime-remove-notes]	- Remove compiler-note annotations in buffer.
+\\[slime-next-note]     - Goto the next form with a compiler note.
+\\[slime-previous-note] - Goto the previous form with a compiler note.
+\\[slime-remove-notes]  - Remove compiler-note annotations in buffer.
 
 Finding definitions:
 \\[slime-edit-definition]
@@ -484,14 +484,14 @@ Finding definitions:
 - Pop the definition stack to go back from a definition.
 
 Documentation commands:
-\\[slime-describe-symbol]	- Describe symbol.
-\\[slime-apropos]	- Apropos search.
-\\[slime-disassemble-symbol]	- Disassemble a function.
+\\[slime-describe-symbol]       - Describe symbol.
+\\[slime-apropos]       - Apropos search.
+\\[slime-disassemble-symbol]    - Disassemble a function.
 
 Evaluation commands:
-\\[slime-eval-defun]	- Evaluate top-level from containing point.
-\\[slime-eval-last-expression]	- Evaluate sexp before point.
-\\[slime-pprint-eval-last-expression]	\
+\\[slime-eval-defun]    - Evaluate top-level from containing point.
+\\[slime-eval-last-expression]  - Evaluate sexp before point.
+\\[slime-pprint-eval-last-expression]   \
 - Evaluate sexp before point, pretty-print result.
 
 Full set of commands:
@@ -562,7 +562,7 @@ information."
     ("\C-x\C-e"  slime-eval-last-expression)
     ("\C-\M-x"   slime-eval-defun)
     ;; Include PREFIX keys...
-    ("\C-c"	 slime-prefix-map)))
+    ("\C-c"      slime-prefix-map)))
 
 (defvar slime-prefix-map nil
   "Keymap for commands prefixed with `slime-prefix-key'.")
@@ -711,13 +711,13 @@ The list of patterns is searched for a HEAD `eq' to the car of
 VALUE. If one is found, the BODY is executed with ARGS bound to the
 corresponding values in the CDR of VALUE."
   (let ((operator (cl-gensym "op-"))
-	(operands (cl-gensym "rand-"))
-	(tmp (cl-gensym "tmp-")))
+        (operands (cl-gensym "rand-"))
+        (tmp (cl-gensym "tmp-")))
     `(let* ((,tmp ,value)
-	    (,operator (car ,tmp))
-	    (,operands (cdr ,tmp)))
+            (,operator (car ,tmp))
+            (,operands (cdr ,tmp)))
        (cl-case ,operator
-	 ,@(mapcar (lambda (clause)
+         ,@(mapcar (lambda (clause)
                      (if (eq (car clause) t)
                          `(t ,@(cdr clause))
                        (cl-destructuring-bind ((op &rest rands) &rest body)
@@ -726,16 +726,16 @@ corresponding values in the CDR of VALUE."
                                  . ,(or body
                                         '((ignore)) ; suppress some warnings
                                         ))))))
-		   patterns)
-	 ,@(if (eq (caar (last patterns)) t)
-	       '()
-	     `((t (error "slime-dcase failed: %S" ,tmp))))))))
+                   patterns)
+         ,@(if (eq (caar (last patterns)) t)
+               '()
+             `((t (error "slime-dcase failed: %S" ,tmp))))))))
 
 (defmacro slime-define-keys (keymap &rest key-command)
   "Define keys in KEYMAP. Each KEY-COMMAND is a list of (KEY COMMAND)."
   (declare (indent 1))
   `(progn . ,(mapcar (lambda (k-c) `(define-key ,keymap . ,k-c))
-		     key-command)))
+                     key-command)))
 
 (cl-defmacro with-struct ((conc-name &rest slots) struct &body body)
   "Like with-slots but works only for structs.
@@ -809,7 +809,7 @@ It should be used for \"background\" messages such as argument lists."
     (completing-read prompt (slime-bogus-completion-alist
                              (slime-eval
                               `(swank:list-all-package-names t)))
-		     nil t initial-value)))
+                     nil t initial-value)))
 
 ;; Interface
 (defun slime-read-symbol-name (prompt &optional query)
@@ -829,7 +829,7 @@ positions before and after executing BODY."
   (let ((start (cl-gensym)))
     `(let ((,start (point)))
        (prog1 (progn ,@body)
-	 (add-text-properties ,start (point) ,props)))))
+         (add-text-properties ,start (point) ,props)))))
 
 (defun slime-add-face (face string)
   (declare (indent 1))
@@ -1176,9 +1176,11 @@ DIRECTORY change to this directory before starting the process.
 (defun slime-recompile-bytecode ()
   "Recompile and reload slime."
   (interactive)
-  (let ((sourcefile (concat (file-name-sans-extension (locate-library "slime"))
-                            ".el")))
-    (byte-compile-file sourcefile t)))
+  (let* ((slime-lib (file-name-sans-extension (locate-library "slime")))
+         (sourcefile (concat slime-lib
+                             ".el")))
+    (byte-compile-file sourcefile)
+    (load slime-lib)))
 
 (defun slime-urge-bytecode-recompile ()
   "Urge the user to recompile slime.elc.
@@ -1429,9 +1431,9 @@ Return nil if the file doesn't exist or is empty; otherwise the
 first line of the file."
   (condition-case _err
       (with-temp-buffer
-	(insert-file-contents "~/.slime-secret")
-	(goto-char (point-min))
-	(buffer-substring (point-min) (line-end-position)))
+        (insert-file-contents "~/.slime-secret")
+        (goto-char (point-min))
+        (buffer-substring (point-min) (line-end-position)))
     (file-error nil)))
 
 ;;; Interface
@@ -2166,7 +2168,7 @@ or nil if nothing suitable can be found.")
   (when (null package) (setq package (slime-current-package)))
   (let* ((tag (cl-gensym (format "slime-result-%d-"
                                  (1+ (slime-continuation-counter)))))
-	 (slime-stack-eval-tags (cons tag slime-stack-eval-tags)))
+         (slime-stack-eval-tags (cons tag slime-stack-eval-tags)))
     (apply
      #'funcall
      (catch tag
@@ -2475,8 +2477,8 @@ Debugged requests are ignored."
 (defun slime-pprint-event (event buffer)
   "Pretty print EVENT in BUFFER with limited depth and width."
   (let ((print-length 20)
-	(print-level 6)
-	(pp-escape-newlines t))
+        (print-level 6)
+        (pp-escape-newlines t))
     (pp event buffer)))
 
 (defun slime-events-buffer ()
@@ -3379,7 +3381,7 @@ you should check twice before modifying.")
                          qualifiers specializers)))
     (or (and (re-search-forward regexp  nil t)
              (goto-char (match-beginning 0)))
-        ;;	(slime-goto-location-position `(:function-name ,name))
+        ;;      (slime-goto-location-position `(:function-name ,name))
         )))
 
 (defun slime-search-call-site (fname)
@@ -3728,7 +3730,7 @@ If INITIAL-VALUE is non-nil, it is inserted into the minibuffer before
 reading input.  The result is a string (\"\" if no input was given)."
   (let ((minibuffer-setup-hook (slime-minibuffer-setup-hook)))
     (read-from-minibuffer prompt initial-value slime-minibuffer-map
-			  nil (or history 'slime-minibuffer-history))))
+                          nil (or history 'slime-minibuffer-history))))
 
 (defun slime-bogus-completion-alist (list)
   "Make an alist out of list.
@@ -4289,8 +4291,8 @@ in Lisp when committed with \\[slime-edit-value-commit]."
 (defun slime-load-file (filename)
   "Load the Lisp file FILENAME."
   (interactive (list
-		(read-file-name "Load file: " nil nil
-				nil (if (buffer-file-name)
+                (read-file-name "Load file: " nil nil
+                                nil (if (buffer-file-name)
                                         (file-name-nondirectory
                                          (buffer-file-name))))))
   (let ((lisp-filename (slime-to-lisp-filename (expand-file-name filename))))
@@ -4584,9 +4586,9 @@ With prefix argument include internal symbols."
   "slime-xref-mode: Major mode for cross-referencing.
 \\<slime-xref-mode-map>\
 The most important commands:
-\\[slime-xref-quit]	- Dismiss buffer.
-\\[slime-show-xref]	- Display referenced source and keep xref window.
-\\[slime-goto-xref]	- Jump to referenced source and dismiss xref window.
+\\[slime-xref-quit]     - Dismiss buffer.
+\\[slime-show-xref]     - Display referenced source and keep xref window.
+\\[slime-goto-xref]     - Jump to referenced source and dismiss xref window.
 
 \\{slime-xref-mode-map}
 \\{slime-popup-buffer-mode-map}
@@ -5252,7 +5254,7 @@ argument is given, with CL:MACROEXPAND."
   "Return STRING propertised with face sldb-NAME-face."
   (declare (indent 1))
   (let ((facename (intern (format "sldb-%s-face" (symbol-name name))))
-	(var (cl-gensym "string")))
+        (var (cl-gensym "string")))
     `(let ((,var ,string))
        (slime-add-face ',facename ,var)
        ,var)))
@@ -5653,12 +5655,12 @@ Called on the `point-entered' text-property hook."
 (defun sldb-frame-number-at-point ()
   (let ((frame (get-text-property (point) 'frame)))
     (cond (frame (car frame))
-	  (t (user-error "No frame at point")))))
+          (t (user-error "No frame at point")))))
 
 (defun sldb-var-number-at-point ()
   (let ((var (get-text-property (point) 'var)))
     (cond (var var)
-	  (t (user-error "No variable at point")))))
+          (t (user-error "No variable at point")))))
 
 (defun sldb-previous-frame-number ()
   (save-excursion
@@ -5763,7 +5765,7 @@ This is 0 if START and END at the same line."
     (save-excursion
       (goto-char pos)
       (let ((fn (get-text-property (point) 'sldb-default-action)))
-	(if fn (funcall fn))))))
+        (if fn (funcall fn))))))
 
 (defun sldb-cycle ()
   "Cycle between restart list and backtrace."
@@ -5870,7 +5872,7 @@ Minimize point motion."
 (defun slime-highlight-sexp (&optional start end)
   "Highlight the first sexp after point."
   (let ((start (or start (point)))
-	(end (or end (save-excursion (ignore-errors (forward-sexp)) (point)))))
+        (end (or end (save-excursion (ignore-errors (forward-sexp)) (point)))))
     (slime-flash-region start end)))
 
 (defun slime-highlight-line (&optional timeout)
@@ -5889,7 +5891,7 @@ The details include local variable bindings and CATCH-tags."
   (let ((inhibit-read-only t)
         (inhibit-point-motion-hooks t))
     (if (or on (not (sldb-frame-details-visible-p)))
-	(sldb-show-frame-details)
+        (sldb-show-frame-details)
       (sldb-hide-frame-details))))
 
 (defun sldb-show-frame-details ()
@@ -6535,7 +6537,7 @@ was called originally."
   "Eval an expression and inspect the result."
   (interactive
    (list (slime-read-from-minibuffer "Inspect value (evaluated): "
-				     (slime-sexp-at-point))))
+                                     (slime-sexp-at-point))))
   (slime-eval-async `(swank:init-inspector ,string ,definition) 'slime-open-inspector))
 
 (define-derived-mode slime-inspector-mode fundamental-mode
@@ -6706,10 +6708,10 @@ that value.
   (interactive)
   (let ((result (slime-eval `(swank:inspector-next))))
     (cond (result
-	   (push (slime-inspector-position) slime-inspector-mark-stack)
-	   (slime-open-inspector result))
-	  (t (message "No next object")
-	     (ding)))))
+           (push (slime-inspector-position) slime-inspector-mark-stack)
+           (slime-open-inspector result))
+          (t (message "No next object")
+             (ding)))))
 
 (defun slime-inspector-quit ()
   "Quit the inspector and kill the buffer."
@@ -7441,9 +7443,9 @@ keys."
   (let ((alist '()))
     (dolist (e list)
       (let* ((k (funcall key e))
-	     (probe (cl-assoc k alist :test test)))
-	(if probe
-	    (push e (cdr probe))
+             (probe (cl-assoc k alist :test test)))
+        (if probe
+            (push e (cdr probe))
           (push (cons k (list e)) alist))))
     ;; Put them back in order.
     (cl-loop for (key . value) in (reverse alist)
@@ -7502,7 +7504,7 @@ keys."
 (defun slime-cl-symbol-name (symbol)
   (let ((n (if (stringp symbol) symbol (symbol-name symbol))))
     (if (string-match ":\\([^:]*\\)$" n)
-	(let ((symbol-part (match-string 1 n)))
+        (let ((symbol-part (match-string 1 n)))
           (if (string-match "^|\\(.*\\)|$" symbol-part)
               (match-string 1 symbol-part)
             symbol-part))
@@ -7511,7 +7513,7 @@ keys."
 (defun slime-cl-symbol-package (symbol &optional default)
   (let ((n (if (stringp symbol) symbol (symbol-name symbol))))
     (if (string-match "^\\([^:]*\\):" n)
-	(match-string 1 n)
+        (match-string 1 n)
       default)))
 
 (defun slime-qualify-cl-symbol-name (symbol-or-name)


### PR DESCRIPTION
slime.el line 1176, slime-recompile-bytecode was calling byte-compile-file with two arguments when it only takes one.
  Its doc string states that it reloads slime but it doesn't (only byte-compiles it, which doesn't do any loading as far as its documentation goes), so I've added a load there too.

contrib/slime-tramp.el was trying to call tramp-make-tramp-file-name with different number of arguments, depending on the Emacs version, which was causing compilation warnings.
To get rid of the warnings, I've moved the treatment of the arguments outside in a macro, and now call apply on tramp-make-tramp-file-name with the argument list as derived by the macro.

Test results on Emacs 30.2 below - 4 fail in other areas (as far as I can tell).
````
Selector: t
Passed:  206
Failed:  4 (4 unexpected)
Skipped: 1
Total:   211/211

Started at:   2026-03-29 16:46:15+0100
Finished.
Finished at:  2026-03-29 16:46:50+0100

..................................F....FFF.......................s.................................................................................................................................................

F display-region-12
    For input (1 (+h 1) (+h …, test ‘slime-display-region’.
    (cl-assertion-failed (= (l2p expected-point) (point)))

F display-region-6
    For input ((+h 2) (+h 7)…, test ‘slime-display-region’.
    (cl-assertion-failed (= (l2p expected-window-start) (window-start)))

F display-region-7
    For input ((+h -2) (+h (…, test ‘slime-display-region’.
    (cl-assertion-failed (= (l2p expected-window-start) (window-start)))

F display-region-8
    For input (2 (+h 1) 3 1 …, test ‘slime-display-region’.
    (cl-assertion-failed (= (l2p expected-window-start) (window-start)))
````

Emacs 29.3 (default on Ubuntu 24.04.4 LTS Noble Numbat) chokes early on during the tests, complaining that `sldb-inspect-frame-function` (slime.el line 6024) doesn't have a docstring. It doesn't have one indeed - no idea what its contents should be.