### PR TITLE
Replace functions meant for interactive use with others.

### DIFF
--- a/contrib/slime-autodoc.el
+++ b/contrib/slime-autodoc.el
@@ -103,7 +103,7 @@
       (lisp-mode-variables t))
     (insert string)
     (let ((font-lock-verbose nil))
-      (font-lock-fontify-buffer))
+      (font-lock-ensure (point-min) (point-max)))
     (goto-char (point-min))
     (when (re-search-forward "===> \\(\\(.\\|\n\\)*\\) <===" nil t)
       (let ((highlight (match-string 1)))

--- a/contrib/slime-sprof.el
+++ b/contrib/slime-sprof.el
@@ -84,7 +84,7 @@
            (slime-sprof-browser-insert-line data 54))))
       (if (= line 1)
           (goto-char point)
-          (goto-line 2)))))
+          (slime-goto-line 2)))))
 
 (defun slime-sprof-sort (arg)
   (let* ((pos (if (markerp arg) arg (point)))

--- a/slime.el
+++ b/slime.el
@@ -4652,7 +4652,7 @@ source-location."
                       (slime-one-line-ify label))
                      (insert "\n"))))
   ;; Remove the final newline to prevent accidental window-scrolling
-  (backward-delete-char 1)
+  (delete-char -1)
   (insert " "))
 
 (defun slime-xref-next-line ()
@@ -5079,7 +5079,7 @@ This variable specifies both what was expanded and how.")
     (erase-buffer)
     (insert expansion)
     (goto-char (point-min))
-    (font-lock-fontify-buffer)))
+    (font-lock-ensure (point-min) (point-max))))
 
 (defun slime-create-macroexpansion-buffer ()
   (let ((name (slime-buffer-name :macroexpansion)))
@@ -6585,7 +6585,7 @@ KILL-BUFFER hooks for the inspector buffer."
                     'face 'slime-inspector-value-face)
             (insert title))
           (while (eq (char-before) ?\n)
-            (backward-delete-char 1))
+            (delete-char -1))
           (insert "\n" (fontify label "--------------------") "\n")
           (save-excursion
             (slime-inspector-insert-content content))


### PR DESCRIPTION
Code was using some functions meant for interactive use - replaced them with non-interactive ones.