### PR TITLE
sbcl: Remove use of named lambda.

### DIFF
--- a/swank/sbcl.lisp
+++ b/swank/sbcl.lisp
@@ -1088,11 +1088,10 @@ Return a list of the form (NAME LOCATION)."
 
 (defun make-invoke-debugger-hook (hook)
   (when hook
-    #'(sb-int:named-lambda swank-invoke-debugger-hook
-          (condition old-hook)
-        (if *debugger-hook*
-            nil         ; decline, *DEBUGGER-HOOK* will be tried next.
-            (funcall hook condition old-hook)))))
+    (lambda (condition old-hook)
+      (if *debugger-hook*
+          nil         ; decline, *DEBUGGER-HOOK* will be tried next.
+          (funcall hook condition old-hook)))))
 
 (defun set-break-hook (hook)
   (setq sb-ext:*invoke-debugger-hook* (make-invoke-debugger-hook hook)))


### PR DESCRIPTION
In the future, sbcl may make it so that #' does not accept special syntax anymore, in favor of some other more code-walker friendly mechanism (such as declarations). In addition, strings are generally better for just debug names to maintain consistency with FDEFINITION.

But there is actually no convincing reason to rely on sbcl internals here, so just remove the use of named lambda.