### PR TITLE
swank: fix type-specifier-p for ECL

### DIFF
--- a/swank/ecl.lisp
+++ b/swank/ecl.lisp
@@ -397,8 +397,15 @@
     (if foundp arglist :not-available)))
 
 (defimplementation type-specifier-p (symbol)
-  (or (subtypep nil symbol)
-      (not (eq (type-specifier-arglist symbol) :not-available))))
+  ;; TODO: replace by ECL's own implementation once that is added to ECL
+  (or
+   ;; Hardcoded types that are not covered by a type predicate
+   (member symbol '(eql member not or and satisfies
+                    standard-char complex-array))
+   (sys:get-sysprop symbol 'SYS::TYPE-PREDICATE)
+   (sys:get-sysprop symbol 'SYS::DEFTYPE-DEFINITION)
+   (find-class symbol nil)
+   (not (eq (type-specifier-arglist symbol) :not-available))))
 
 (defimplementation function-name (f)
   (typecase f


### PR DESCRIPTION
This leads to failures for example when using `company-mode` in the slime REPL with ECL.

The new implementation is a bit ugly but I will add a corresponding utility function to ECL itself at some point, so this will get abstracted away in the future.