### PR TITLE
Make slime-search-buffer-package ignore comments and strings

### DIFF
--- a/slime-tests.el
+++ b/slime-tests.el
@@ -395,6 +395,37 @@ conditions (assertions)."
                        (slime-sexp-at-point)
                        #'eq)))
 
+(def-slime-test in-package.1 (string matches)
+  "Check that slime-search-buffer-package handles funny cases."
+  '(("(in-package :correct)"
+     ((1 1 ":correct")
+      (2 21 nil)
+      (22 22 ":correct")))
+    ("(in-package \"P1\")\n(defun foo ())\n(cL:in-PACKAGE #:p2)\n(defun bar())\n"
+     ((1 1 "\"P1\"")
+      ;; This is weird but harmless. We are in the first in-package form.
+      (2 17 "#:p2")
+      (18 53 "\"P1\"")
+      (54 69 "#:p2")))
+    ("(in-package :first)\n(in-package :second)\n#|\n(in-package :not-this)\n|#\n\"\n(in-package :or-this)\n\""
+     ((1 1 ":first")
+      ;; Within the (in-package :first)
+      (2 19 ":second")
+      ;; Before the end of (in-package :second)
+      (20 40 ":first")
+      (41 97 ":second"))))
+  (with-temp-buffer
+    (lisp-mode)
+    (insert string)
+    (dolist (match matches)
+      (cl-destructuring-bind (min max expected) match
+        (cl-loop for pos upfrom min upto max
+                 do (goto-char pos)
+                     (let ((package (slime-search-buffer-package)))
+                       (slime-check ("Checking %S => at pos %S got %S"
+                                     match pos package)
+                         (equal package expected))))))))
+
 (def-slime-test narrowing ()
     "Check that narrowing is properly sustained."
     '()

--- a/slime.el
+++ b/slime.el
@@ -2152,14 +2152,26 @@ or nil if nothing suitable can be found.")
 ;;  (in-package |CL|)
 ;;  (in-package #+ansi-cl :cl #-ansi-cl 'lisp)
 
+;;; Note that when the cursor is within the in-package form, this
+;;; can return nil.
 (defun slime-search-buffer-package ()
   (let ((case-fold-search t)
         (regexp (concat "^[ \t]*(\\(cl:\\|common-lisp:\\)?in-package\\>[ \t']*"
-                        "\\([^)]+\\)[ \t]*)")))
-    (save-excursion
-      (when (or (re-search-backward regexp nil t)
-                (re-search-forward regexp nil t))
-        (match-string-no-properties 2)))))
+                        "\\([^)]+\\)[ \t]*)"))
+        result)
+    (dolist (search-forward-p '(nil t))
+      (save-excursion
+        (while (and (not result)
+                    (if search-forward-p
+                        (re-search-forward regexp nil t)
+                      (re-search-backward regexp nil t)))
+          (let ((ppss (save-excursion
+                        (syntax-ppss (match-beginning 0)))))
+            ;; Skip matches in strings and comments (including the #|
+            ;; |# syntax).
+            (unless (or (nth 3 ppss) (nth 4 ppss))
+              (setq result (match-string-no-properties 2)))))))
+    result))
 
 ;;; Synchronous requests are implemented in terms of asynchronous
 ;;; ones. We make an asynchronous request with a continuation function


### PR DESCRIPTION
Previously, we relied the regexp that matches only indented in-package forms, so these didn't match:

    ;; (in-package :garbage)
    "(in-package :noise)"

However, it unfortunately matched

    #|
    (in-package :garbage)
   |#

and

   "Consider this example:

       (in-package :cl-user)
       ..."

Not anymore.

Also, I don't think it is reasonable for slime-search-buffer-package to search forwards for an in-package if it cannot find one searching backwards, but there are too many call sites for me to check, so I only added a comment about it.