### PR TITLE
docs: fix some typos and trim some whitespace

### DIFF
--- a/metering.lisp
+++ b/metering.lisp
@@ -559,7 +559,7 @@ Estimated total monitoring overhead: 0.88 seconds
   (multiple-value-bind (arglist foundp)
       (core:function-lambda-list name)
     (if foundp
-        (let ((position-and 
+        (let ((position-and
                (position-if #'(lambda (x)
                                 (and (symbolp x)
                                      (let ((name (symbol-name x)))
@@ -746,7 +746,7 @@ adjusted for overhead."
           (unless (or (null warn)
                       (eq (place-function name)
                           (metering-functions-new-definition finfo)))
-            (warn "Funtion ~S has been redefined, so times may be inaccurate.~@
+            (warn "Function ~S has been redefined, so times may be inaccurate.~@
                    MONITOR it again to record calls to the new definition."
                   name))
           (case nested
@@ -1231,5 +1231,3 @@ Time      Cons~
                                        :key #'m-info-cons-per-call)))))
 
 ;;; *END OF FILE*
-
-

--- a/nregex.lisp
+++ b/nregex.lisp
@@ -9,7 +9,7 @@
 ;;; (See the slime-devel mailing list archive for details.)
 ;;;
 ;;; nregex.lisp - My 4/8/92 attempt at a Lisp based regular expression
-;;;               parser. 
+;;;               parser.
 ;;;
 ;;;               This regular expression parser operates by taking a
 ;;;               regular expression and breaking it down into a list
@@ -31,7 +31,7 @@
 ;;;; CND - 6/3/2001
 (defpackage slime-nregex
   (:use #:common-lisp)
-  (:export 
+  (:export
    #:regex
    #:regex-compile
   ))
@@ -75,8 +75,8 @@
     (if (= *regex-groupings* 0)
 	(return-from regex t))
     (dotimes (i *regex-groupings*)
-      (push (funcall 'subseq 
-		     string 
+      (push (funcall 'subseq
+		     string
 		     (car (aref *regex-groups* i))
 		     (cadr (aref *regex-groups* i)))
 	    result))
@@ -97,7 +97,7 @@
 ;;; string was used.  If the result is a set of characters, return an
 ;;; array of bits indicating which characters should be set.  If the
 ;;; expression is one of the sub-group matches return a
-;;; list-expression that will provide the match.  
+;;; list-expression that will provide the match.
 ;;;
 (defun regex-quoted (char-string &optional (invert nil))
   "Usage: (regex-quoted <char-string> &optional invert)
@@ -138,7 +138,7 @@
 	       ;;
 	       ;; It is a single character specified in octal
 	       ;;
-	       (progn 
+	       (progn
 		 (setf result (do ((x 0 (1+ x))
 				   (return 0))
 				  ((= x 2) return)
@@ -159,7 +159,7 @@
 						  :end1 (+ index (length nstring))))
 				    (return-from compare nil)
 				  (incf index (length nstring)))))))))
-	  (t 
+	  (t
 	   (setf result first)))
     (if (and (vectorp result) invert)
 	(bit-xor result #*1111111110011111111111111111111101111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111 t))
@@ -178,8 +178,8 @@
   (info "Now entering regex-compile with \"~A\"~%" source)
   ;;
   ;; This routine works in two parts.
-  ;; The first pass take the regular expression and produces a list of 
-  ;; operators and lisp expressions for the entire regular expression.  
+  ;; The first pass take the regular expression and produces a list of
+  ;; operators and lisp expressions for the entire regular expression.
   ;; The second pass takes this list and produces the lambda expression.
   (let ((expression '())		; holder for expressions
 	(group 1)			; Current group index
@@ -187,7 +187,7 @@
 	(result nil)			; holder for built expression.
 	(fast-first nil))		; holder for quick unanchored scan
     ;;
-    ;; If the expression was an empty string then it alway
+    ;; If the expression was an empty string then it always
     ;; matches (so lets leave early)
     ;;
     (if (= (length source) 0)
@@ -212,13 +212,13 @@
     ;;
     ;; Also, If this is not an anchored search and the first character is
     ;; a literal, then do a quick scan to see if it is even in the string.
-    ;; If not then we can issue a quick nil, 
+    ;; If not then we can issue a quick nil,
     ;; otherwise we can start the search at the matching character to skip
     ;; the checks of the non-matching characters anyway.
     ;;
-    ;; If I really wanted to speed up this section of code it would be 
+    ;; If I really wanted to speed up this section of code it would be
     ;; easy to recognize the case of a fairly long multi-character literal
-    ;; and generate a Boyer-Moore search for the entire literal. 
+    ;; and generate a Boyer-Moore search for the entire literal.
     ;;
     ;; I generate the code to do a loop because on CMU Lisp this is about
     ;; twice as fast a calling position.
@@ -282,7 +282,7 @@
 	   ;;
 	   (incf group)
 	   (push group group-stack)
-	   (add-exp `((setf (aref *regex-groups* ,(1- group)) 
+	   (add-exp `((setf (aref *regex-groups* ,(1- group))
 			    (list index nil))))
 	   (add-exp `(,group)))
 	  ((#\))
@@ -313,7 +313,7 @@
 			   (not (eql (char source (+ x 2)) #\])))
 		      (if (>= (char-code (char source x))
 			     (char-code (char source (+ 2 x))))
-			  (error "Invalid range \"~A-~A\".  Ranges must be in acending order"
+			  (error "Invalid range \"~A-~A\".  Ranges must be in ascending order"
 				 (char source x) (char source (+ 2 x))))
 		      (do ((j (char-code (char source x)) (1+ j)))
 		       ((> j (char-code (char source (+ 2 x))))
@@ -344,7 +344,7 @@
 			    (return-from compare nil)))))))
 	  ((#\\ )
 	   ;;
-	   ;; Intreprete the next character as a special, range, octal, group or 
+	   ;; Intreprete the next character as a special, range, octal, group or
            ;; just the character itself.
 	   ;;
 	   (let ((length)
@@ -355,7 +355,7 @@
 		    (add-exp value))
 		   ((characterp value)
 		    (add-exp `((if (not (and (< index length)
-					     (eql (char string index) 
+					     (eql (char string index)
 						  ,value)))
 				   (return-from compare nil)
 				 (incf index)))))
@@ -369,7 +369,7 @@
 	     (incf eindex length)))
 	  (t
 	   ;;
-	   ;; We have a literal character.  
+	   ;; We have a literal character.
 	   ;; Scan to see how many we have and if it is more than one
 	   ;; generate a string= verses as single eql.
 	   ;;
@@ -379,9 +379,9 @@
 			    (if (position litchar *regex-special-chars*)
 				(return litchar)
 			      (progn
-				(info "Now adding ~A index ~A to lit~%" litchar 
+				(info "Now adding ~A index ~A to lit~%" litchar
 				      litindex)
-				(setf lit (concatenate 'string lit 
+				(setf lit (concatenate 'string lit
 						       (string litchar)))))))))
 	     (if (= (length lit) 1)
 		 (add-exp `((if (not (and (< index length)
@@ -393,7 +393,7 @@
 	       ;; check to see if the next character (if there is one)
 	       ;; is an astrisk or a plus or a question mark.  If so then we must not use this
 	       ;; character in the big literal.
-	       (progn 
+	       (progn
 		 (if (or (eql term #\*)
                          (eql term #\+)
                          (eql term #\?))
@@ -421,17 +421,17 @@
     ;; the END then save the new index if it didn't fail.
     ;; On an ASTRISK I need to take the previous expression and wrap
     ;; it in a do that will evaluate the expression till an error
-    ;; occurs and then another do that encompases the remainder of the
+    ;; occurs and then another do that encompasses the remainder of the
     ;; regular expression and iterates decrementing the index by one
     ;; of the matched expression sizes and then returns nil.  After
     ;; the last expression insert a form that does a return t so that
     ;; if the entire nested sub-expression succeeds then the loop
     ;; is broken manually.
-    ;; 
+    ;;
     (setf result (copy-tree nil))
     ;;
-    ;; Reversing the current expression makes building up the 
-    ;; lambda list easier due to the nexting of expressions when 
+    ;; Reversing the current expression makes building up the
+    ;; lambda list easier due to the nexting of expressions when
     ;; and astrisk has been encountered.
     (setf expression (reverse expression))
     (do ((elt 0 (1+ elt)))
@@ -454,9 +454,9 @@
 	       (setf result (append (list piece) result)))
 	      ((eql piece 'QUESTION)	; Wrap it in a block that won't fail
 	       (cond ((listp (nth (1+ elt) expression))
-		      (setf result 
+		      (setf result
 			    (append `((progn (block compare
-						    ,(nth (1+ elt) 
+						    ,(nth (1+ elt)
 							  expression))
 					     t))
 				    result))
@@ -474,7 +474,7 @@
 		      ;; This is a single character wild card so
 		      ;; do the simple form.
 		      ;;
-		      (setf result 
+		      (setf result
 			    `((let ((oindex index))
 				(block compare
 				       (do ()
@@ -495,7 +495,7 @@
 	       )
 	      (t t))))			; Just ignore everything else.
     ;;
-    ;; Now wrap the result in a lambda list that can then be 
+    ;; Now wrap the result in a lambda list that can then be
     ;; invoked or compiled, however the user wishes.
     ;;
     (if anchored

--- a/slime-tests.el
+++ b/slime-tests.el
@@ -112,7 +112,7 @@ Also don't error if `ert.el' is missing."
         `(ert-deftest ,name () ,(or docstring "No docstring for this test.")
            :tags ',tags
            ,@args))))
-  
+
   (defun split-version-string (string)
     (cl-loop for part in (split-string string "\\.")
              while (string-match-p "^[[:digit:]]+$" part)
@@ -126,7 +126,7 @@ Also don't error if `ert.el' is missing."
               (and (= head-x head-y)
                    (version>= (cdr x) (cdr y)))))
         t))
-  
+
   (defun fails-for-p (fails)
     (cl-loop for fail in fails
              for version = (string-match-p "-" fail)
@@ -797,7 +797,7 @@ Confirm that SUBFORM is correctly located."
       (slime-wait-condition "Compilation finished" (lambda () (car cell))
                             5)
       (let ((result (cdr cell)))
-        (slime-check "Compilation successfull"
+        (slime-check "Compilation successful"
           (eq (slime-compilation-result.successp result) t))))))
 
 (def-slime-test utf-8-source
@@ -1057,7 +1057,7 @@ Confirm that SUBFORM is correctly located."
 
 (defun slime-execute-as-command (name)
   "Execute `name' as if it was done by the user through the
-Command Loop. Similiar to `call-interactively' but also pushes on
+Command Loop. Similar to `call-interactively' but also pushes on
 the buffer's undo-list."
   (undo-boundary)
   (call-interactively name))
@@ -1371,7 +1371,7 @@ This test will fail more likely before dispatch caches are warmed up."
 
 (def-slime-test disconnect-and-reconnect
     ()
-    "Close the connetion.
+    "Close the connection.
 Confirm that the subprocess continues gracefully.
 Reconnect afterwards."
     '(())

--- a/slime.el
+++ b/slime.el
@@ -401,7 +401,7 @@ Works like `completion-at-point-functions'.
 
 (defmacro define-sldb-faces (&rest faces)
   "Define the set of SLDB faces.
-Each face specifiation is (NAME DESCRIPTION &optional PROPERTIES).
+Each face specification is (NAME DESCRIPTION &optional PROPERTIES).
 NAME is a symbol; the face will be called sldb-NAME-face.
 DESCRIPTION is a one-liner for the customization buffer.
 PROPERTIES specifies any default face properties."
@@ -449,7 +449,7 @@ PROPERTIES specifies any default face properties."
 
 (defvar slime-mode-indirect-map (make-sparse-keymap)
   "Empty keymap which has `slime-mode-map' as it's parent.
-This is a hack so that we can reinitilize the real slime-mode-map
+This is a hack so that we can reinitialize the real slime-mode-map
 more easily. See `slime-init-keymaps'.")
 
 (defvar slime-buffer-connection)
@@ -1255,7 +1255,7 @@ Return the created process."
   (slime-read-port-and-connect process))
 
 (defvar slime-inferior-lisp-args nil
-  "A buffer local variable in the inferior proccess.
+  "A buffer local variable in the inferior process.
 See `slime-start'.")
 
 (defun slime-start-swank-server (process args)
@@ -3486,7 +3486,7 @@ are supported:
 ;; may have been modified (but hopefully not near the beginning!)
 
 (defun slime-isearch (string)
-  "Find the longest occurence of STRING either backwards of forwards.
+  "Find the longest occurrence of STRING either backwards of forwards.
 If multiple matches exist the choose the one nearest to point."
   (goto-char
    (let* ((start (point))
@@ -3599,12 +3599,12 @@ The highlighting is automatically undone with a timer."
 
 (defun slime-find-next-note ()
   "Go to the next position with the `slime-note' text property.
-Retuns the note overlay if such a position is found, otherwise nil."
+Returns the note overlay if such a position is found, otherwise nil."
   (slime-search-property 'slime-note nil #'slime-note-at-point))
 
 (defun slime-find-previous-note ()
   "Go to the next position with the `slime-note' text property.
-Retuns the note overlay if such a position is found, otherwise nil."
+Returns the note overlay if such a position is found, otherwise nil."
   (slime-search-property 'slime-note t #'slime-note-at-point))
 
 
@@ -3839,7 +3839,7 @@ FILE-ALIST is an alist of the form ((FILENAME . (XREF ...)) ...)."
     (goto-char point)))
 
 (defun slime-postprocess-xref (original-xref)
-  "Process (for normalization purposes) an Xref comming directly
+  "Process (for normalization purposes) an Xref coming directly
 from SWANK before the rest of Slime sees it. In particular,
 convert ETAGS based xrefs to actual file+position based
 locations."
@@ -4091,9 +4091,9 @@ inserted in the current buffer."
      (slime-eval-print string))))
 
 (defvar slime-transcript-start-hook nil
-  "Hook run before start an evalution.")
+  "Hook run before start an evaluation.")
 (defvar slime-transcript-stop-hook nil
-  "Hook run after finishing a evalution.")
+  "Hook run after finishing a evaluation.")
 
 (defun slime-display-eval-result (value)
   (slime-message "%s" value))
@@ -5061,7 +5061,7 @@ function name is prompted."
       (undo-only arg))))
 
 (defvar slime-eval-macroexpand-expression nil
-  "Specifies the last macroexpansion preformed.
+  "Specifies the last macroexpansion performed.
 This variable specifies both what was expanded and how.")
 
 (defun slime-eval-macroexpand (expander &optional string)
@@ -6670,7 +6670,7 @@ position of point in the current buffer."
 
 (defun slime-inspector-operate-on-point ()
   "Invoke the command for the text at point.
-1. If point is on a value then recursivly call the inspector on
+1. If point is on a value then recursively call the inspector on
 that value.
 2. If point is on an action then call that action.
 3. If point is on a range-button fetch and insert the range."

--- a/swank-loader.lisp
+++ b/swank-loader.lisp
@@ -345,7 +345,7 @@ If DELETE is true, delete any existing SWANK packages.
 If RELOAD is true, reload SWANK, even if the SWANK package already exists.
 If LOAD-CONTRIBS is true, load all contribs
 If SETUP is true, load user init files and initialize some
-global variabes in SWANK."
+global variables in SWANK."
   (when from-emacs
     (setf *started-from-emacs* t))
   (when (and delete (find-package :swank))

--- a/swank.lisp
+++ b/swank.lisp
@@ -28,7 +28,7 @@
 (defvar *backtrace-pprint-dispatch-table*
   (let ((table (copy-pprint-dispatch nil)))
     (flet ((print-string (stream string)
-             (cond (*print-escape* 
+             (cond (*print-escape*
                     (escape-string string stream
                                    :map '((#\" . "\\\"")
                                           (#\\ . "\\\\")
@@ -57,7 +57,7 @@
   "Pretter settings for printing backtraces.")
 
 (defvar *default-worker-thread-bindings* '()
-  "An alist to initialize dynamic variables in worker threads.  
+  "An alist to initialize dynamic variables in worker threads.
 The list has the form ((VAR . VALUE) ...).  Each variable VAR will be
 bound to the corresponding VALUE.")
 
@@ -218,7 +218,7 @@ Backend code should treat the connection structure as opaque.")
 
 (defun make-connection (socket stream style)
   (let ((conn (funcall (ecase style
-                         (:spawn 
+                         (:spawn
                           #'make-multithreaded-connection)
                          ((:sigio nil :fd-handler)
                           #'make-singlethreaded-connection))
@@ -233,11 +233,11 @@ Backend code should treat the connection structure as opaque.")
   tag)
 
 (defun safe-backtrace ()
-  (ignore-errors 
-    (call-with-debugging-environment 
+  (ignore-errors
+    (call-with-debugging-environment
      (lambda () (backtrace 0 nil)))))
 
-(define-condition swank-error (error) 
+(define-condition swank-error (error)
   ((backtrace :initarg :backtrace :reader swank-error.backtrace)
    (condition :initarg :condition :reader swank-error.condition))
   (:report (lambda (c s) (princ (swank-error.condition c) s)))
@@ -255,8 +255,8 @@ to T unless you want to debug swank internals.")
   "Close the connection on internal `swank-error's."
   (let ((conn (gensym)))
   `(let ((,conn ,connection))
-     (handler-case 
-         (handler-bind ((swank-error 
+     (handler-case
+         (handler-bind ((swank-error
                          (lambda (condition)
                            (when *debug-on-swank-protocol-error*
                              (invoke-default-debugger condition)))))
@@ -302,7 +302,7 @@ to T unless you want to debug swank internals.")
 
 (defun real-input-stream (stream)
   (typecase stream
-    (synonym-stream 
+    (synonym-stream
      (real-input-stream (symbol-value (synonym-stream-symbol stream))))
     (two-way-stream
      (real-input-stream (two-way-stream-input-stream stream)))
@@ -310,7 +310,7 @@ to T unless you want to debug swank internals.")
 
 (defun real-output-stream (stream)
   (typecase stream
-    (synonym-stream 
+    (synonym-stream
      (real-output-stream (symbol-value (synonym-stream-symbol stream))))
     (two-way-stream
      (real-output-stream (two-way-stream-output-stream stream)))
@@ -329,9 +329,9 @@ Useful for low level debugging."
           (*print-pretty* nil)
           (*package* *swank-io-package*))
       (when *enable-event-history*
-        (setf (aref *event-history* *event-history-index*) 
+        (setf (aref *event-history* *event-history-index*)
               (format nil "~?" format-string args))
-        (setf *event-history-index* 
+        (setf *event-history-index*
               (mod (1+ *event-history-index*) (length *event-history*))))
       (when *log-events*
         (write-string (escape-non-ascii (format nil "~?" format-string args))
@@ -356,7 +356,7 @@ Useful for low level debugging."
   (cond ((stringp event)
          (write-string (escape-non-ascii event) stream))
         ((null event))
-        (t 
+        (t
          (write-string
           (escape-non-ascii (format nil "Unexpected event: ~A~%" event))
           stream))))
@@ -373,7 +373,7 @@ Useful for low level debugging."
   (and (stringp o)
        (every #'ascii-char-p o)))
 
-(defun ascii-char-p (c) 
+(defun ascii-char-p (c)
   (<= (char-code c) 127))
 
 
@@ -394,11 +394,11 @@ corresponding values in the CDR of VALUE."
 	    (,operator (car ,tmp))
 	    (,operands (cdr ,tmp)))
        (case ,operator
-         ,@(loop for (pattern . body) in patterns collect 
+         ,@(loop for (pattern . body) in patterns collect
                  (if (eq pattern t)
                      `(t ,@body)
                      (destructuring-bind (op &rest rands) pattern
-                       `(,op (destructuring-bind ,rands ,operands 
+                       `(,op (destructuring-bind ,rands ,operands
                                ,@body)))))
          ,@(if (eq (caar (last patterns)) t)
                '()
@@ -458,7 +458,7 @@ corresponding values in the CDR of VALUE."
            (without-slime-interrupts
              (with-swank-error-handler (connection)
                (with-io-redirection (connection)
-                 (call-with-debugger-hook #'swank-debugger-hook 
+                 (call-with-debugger-hook #'swank-debugger-hook
                                           function))))))))
 
 (defun call-with-retry-restart (msg thunk)
@@ -520,15 +520,15 @@ recently established one."
 
 (defun %stop-server (key value)
   (with-lock *connection-lock*
-    (let ((probe (find value *servers* :key (ecase key 
+    (let ((probe (find value *servers* :key (ecase key
                                               (:socket #'car)
                                               (:port #'cadr)))))
-      (cond (probe 
+      (cond (probe
              (setq *servers* (delete probe *servers*))
              (destructuring-bind (socket _port thread) probe
                (declare (ignore _port))
                (ignore-errors (close-socket socket))
-               (when (and thread 
+               (when (and thread
                           (thread-alive-p thread)
                           (not (eq thread (current-thread))))
                  (ignore-errors (kill-thread thread)))))
@@ -552,7 +552,7 @@ recently established one."
 
 ;; FIXME: this docstring is more confusing than helpful.
 (defun symbol-status (symbol &optional (package (symbol-package symbol)))
-  "Returns one of 
+  "Returns one of
 
   :INTERNAL  if the symbol is _present_ in PACKAGE as an _internal_ symbol,
 
@@ -570,51 +570,51 @@ definition with the Spec and what's commonly meant when talking
 about internal symbols most times. As the spec says:
 
   In a package P, a symbol S is
-  
+
      _accessible_  if S is either _present_ in P itself or was
                    inherited from another package Q (which implies
                    that S is _external_ in Q.)
-  
+
         You can check that with: (AND (SYMBOL-STATUS S P) T)
-  
-  
+
+
      _present_     if either P is the /home package/ of S or S has been
                    imported into P or exported from P by IMPORT, or
                    EXPORT respectively.
-  
+
                    Or more simply, if S is not _inherited_.
-  
+
         You can check that with: (LET ((STATUS (SYMBOL-STATUS S P)))
-                                   (AND STATUS 
+                                   (AND STATUS
                                         (NOT (EQ STATUS :INHERITED))))
-  
-  
+
+
      _external_    if S is going to be inherited into any package that
                    /uses/ P by means of USE-PACKAGE, MAKE-PACKAGE, or
                    DEFPACKAGE.
-  
+
                    Note that _external_ implies _present_, since to
                    make a symbol _external_, you'd have to use EXPORT
                    which will automatically make the symbol _present_.
-  
+
         You can check that with: (EQ (SYMBOL-STATUS S P) :EXTERNAL)
-  
-  
+
+
      _internal_    if S is _accessible_ but not _external_.
 
         You can check that with: (LET ((STATUS (SYMBOL-STATUS S P)))
-                                   (AND STATUS 
+                                   (AND STATUS
                                         (NOT (EQ STATUS :EXTERNAL))))
-  
+
 
         Notice that this is *different* to
                                  (EQ (SYMBOL-STATUS S P) :INTERNAL)
         because what the spec considers _internal_ is split up into two
         explicit pieces: :INTERNAL, and :INHERITED; just as, for instance,
-        CL:FIND-SYMBOL does. 
+        CL:FIND-SYMBOL does.
 
         The rationale is that most times when you speak about \"internal\"
-        symbols, you're actually not including the symbols inherited 
+        symbols, you're actually not including the symbols inherited
         from other packages, but only about the symbols directly specific
         to the package in question.
 "
@@ -718,14 +718,14 @@ e.g.: (restart-loop (http-request url) (use-value (new) (setq url new)))"
 (defun restart-server (&key (port default-server-port)
                        (style *communication-style*)
                        (dont-close *dont-close*))
-  "Stop the server listening on PORT, then start a new SWANK server 
-on PORT running in STYLE. If DONT-CLOSE is true then the listen socket 
-will accept multiple connections, otherwise it will be closed after the 
+  "Stop the server listening on PORT, then start a new SWANK server
+on PORT running in STYLE. If DONT-CLOSE is true then the listen socket
+will accept multiple connections, otherwise it will be closed after the
 first."
   (stop-server port)
   (sleep 5)
   (create-server :port port :style style :dont-close dont-close))
- 
+
 (defun accept-connections (socket style dont-close)
   (let (connection)
     (unwind-protect
@@ -813,7 +813,7 @@ if the file doesn't exist; otherwise the first line of the file."
   (without-slime-interrupts
     (handler-bind ((error #'signal-swank-error))
       (handler-case (read-message stream *swank-io-package*)
-        (swank-reader-error (c) 
+        (swank-reader-error (c)
           `(:reader-error ,(swank-reader-error.packet c)
                           ,(swank-reader-error.cause c)))))))
 
@@ -870,7 +870,7 @@ The processing is done in the extent of the toplevel restart."
             (wait-for-event `(or (:emacs-rex . _)
                                  (:emacs-channel-send . _))
                             timeout)))
-       
+
        (when timeout? (return))
        (dcase event
          ((:emacs-rex &rest args) (apply #'eval-for-emacs args))
@@ -905,8 +905,8 @@ The processing is done in the extent of the toplevel restart."
 ;;  condition: ~A~%~
 ;;  type: ~S~%~
 ;;  style: ~S]~%"
-              (loop for (i f) in backtrace collect 
-                    (ignore-errors 
+              (loop for (i f) in backtrace collect
+                    (ignore-errors
                       (format nil "~d: ~a" i (escape-non-ascii f))))
               (escape-non-ascii (safe-condition-message condition) )
               (type-of condition)
@@ -952,21 +952,21 @@ The processing is done in the extent of the toplevel restart."
           (singlethreaded-connection
            (simple-break)))
         (encode-message (list :debug-condition (current-thread-id)
-                              (format nil "Thread with id ~a not found" 
+                              (format nil "Thread with id ~a not found"
                                       id))
                         (current-socket-io)))))
 
 (defun spawn-worker-thread (connection)
-  (spawn (lambda () 
+  (spawn (lambda ()
            (with-bindings *default-worker-thread-bindings*
              (with-top-level-restart (connection nil)
-               (apply #'eval-for-emacs 
+               (apply #'eval-for-emacs
                       (cdr (wait-for-event `(:emacs-rex . _)))))))
          :name "worker"))
 
 (defun add-active-thread (connection thread)
   (etypecase connection
-    (multithreaded-connection 
+    (multithreaded-connection
      (push thread (mconn.active-threads connection)))
     (singlethreaded-connection)))
 
@@ -1027,9 +1027,9 @@ The processing is done in the extent of the toplevel restart."
   (log-event "send-event: ~s ~s~%" thread event)
   (let ((c *emacs-connection*))
     (etypecase c
-      (multithreaded-connection 
+      (multithreaded-connection
        (send thread event))
-      (singlethreaded-connection 
+      (singlethreaded-connection
        (setf (sconn.event-queue c) (nconc (sconn.event-queue c) (list event)))
        (setf (sconn.events-enqueued c) (mod (1+ (sconn.events-enqueued c))
                                             most-positive-fixnum))))))
@@ -1045,7 +1045,7 @@ The processing is done in the extent of the toplevel restart."
         (singlethreaded-connection
          (dispatch-event c event)))
       (maybe-slow-down))))
-  
+
 
 ;;;;;; Flow control
 
@@ -1084,7 +1084,7 @@ event was found."
 
 (defun wait-for-event/event-loop (connection pattern timeout)
   (assert (or (not timeout) (eq timeout t)))
-  (loop 
+  (loop
    (check-slime-interrupts)
    (let ((event (poll-for-event connection pattern)))
      (when event (return (car event))))
@@ -1094,7 +1094,7 @@ event was found."
             (return (values nil t)))
            ((or (/= events-enqueued (sconn.events-enqueued connection))
                 (eq ready :interrupt))
-            ;; rescan event queue, interrupts may enqueue new events 
+            ;; rescan event queue, interrupts may enqueue new events
             )
            (t
             (assert (equal ready (list (current-socket-io))))
@@ -1105,8 +1105,8 @@ event was found."
   (let* ((c connection)
          (tail (member-if (lambda (e) (event-match-p e pattern))
                           (sconn.event-queue c))))
-    (when tail 
-      (setf (sconn.event-queue c) 
+    (when tail
+      (setf (sconn.event-queue c)
             (nconc (ldiff (sconn.event-queue c) tail) (cdr tail)))
       tail)))
 
@@ -1135,7 +1135,7 @@ event was found."
 (defun control-thread (connection)
   (with-struct* (mconn. @ connection)
     (setf (@ control-thread) (current-thread))
-    (setf (@ reader-thread) (spawn (lambda () (read-loop connection)) 
+    (setf (@ reader-thread) (spawn (lambda () (read-loop connection))
                                    :name "reader-thread"))
     (setf (@ indentation-cache-thread)
           (spawn (lambda () (indentation-cache-loop connection))
@@ -1161,7 +1161,7 @@ event was found."
 ;;;;;; Signal driven IO
 
 (defun install-sigio-handler (connection)
-  (add-sigio-handler (connection.socket-io connection) 
+  (add-sigio-handler (connection.socket-io connection)
                      (lambda () (process-io-interrupt connection)))
   (handle-requests connection t))
 
@@ -1185,8 +1185,8 @@ event was found."
   (add-fd-handler (connection.socket-io connection)
                   (lambda () (handle-requests connection t)))
   (setf (sconn.saved-sigint-handler connection)
-        (install-sigint-handler 
-         (lambda () 
+        (install-sigint-handler
+         (lambda ()
            (invoke-or-queue-interrupt
             (lambda () (dispatch-interrupt-event connection))))))
   (handle-requests connection t))
@@ -1212,7 +1212,7 @@ event was found."
           (lambda ()
             (with-simple-restart (close-connection "Close SLIME connection.")
               (let* ((stdin (real-input-stream *standard-input*))
-                     (*standard-input* (make-repl-input-stream connection 
+                     (*standard-input* (make-repl-input-stream connection
                                                                stdin)))
                 (tagbody toplevel
                    (with-top-level-restart (connection (go toplevel))
@@ -1263,7 +1263,7 @@ event was found."
 
 (defun read-non-blocking (stream)
   (with-output-to-string (str)
-    (handler-case 
+    (handler-case
         (loop (let ((c (read-char-no-hang stream)))
                 (unless c (return))
                 (write-char c str)))
@@ -1325,7 +1325,7 @@ event was found."
 ;; FIXME: not thread save.
 (defvar *tag-counter* 0)
 
-(defun make-tag () 
+(defun make-tag ()
   (setq *tag-counter* (mod (1+ *tag-counter*) (expt 2 22))))
 
 (defun y-or-n-p-in-emacs (format-string &rest arguments)
@@ -1367,8 +1367,8 @@ entered nothing, returns NIL when user pressed C-g."
 FORM. FORM can contain lists, strings, characters, symbols and
 numbers.
 
-Characters are converted emacs' ?<char> notaion, strings are left
-as they are (except for espacing any nested \" chars, numbers are
+Characters are converted emacs' ?<char> notation, strings are left
+as they are (except for escaping any nested \" chars, numbers are
 printed in base 10 and symbols are printed as their symbol-name
 converted to lower case."
   (etypecase form
@@ -1421,7 +1421,7 @@ Emacs Lisp via `defslimefun' or otherwise marked as RPCallable."
   "The version of the swank/slime communication protocol.")
 
 (defslimefun connection-info ()
-  "Return a key-value list of the form: 
+  "Return a key-value list of the form:
 \(&key PID STYLE LISP-IMPLEMENTATION MACHINE FEATURES PACKAGE VERSION)
 PID: is the process-id of Lisp process (or nil, depending on the STYLE)
 STYLE: the communication style
@@ -1462,8 +1462,8 @@ VERSION: the protocol version"
 
 ;;;; Reading and printing
 
-(define-special *buffer-package*     
-    "Package corresponding to slime-buffer-package.  
+(define-special *buffer-package*
+    "Package corresponding to slime-buffer-package.
 
 EVAL-FOR-EMACS binds *buffer-package*.  Strings originating from a slime
 buffer are best read in this package.  See also FROM-STRING and TO-STRING.")
@@ -1474,7 +1474,7 @@ buffer are best read in this package.  See also FROM-STRING and TO-STRING.")
 (defmacro with-buffer-syntax ((&optional package) &body body)
   "Execute BODY with appropriate *package* and *readtable* bindings.
 
-This should be used for code that is conceptionally executed in an
+This should be used for code that is conceptually executed in an
 Emacs buffer."
   `(call-with-buffer-syntax ,package (lambda () ,@body)))
 
@@ -1493,12 +1493,12 @@ Emacs buffer."
                                         (msg "<<error printing object>>"))
                                   &body body)
   "Catches errors during evaluation of BODY and prints MSG instead."
-  `(handler-case (progn ,@body) 
+  `(handler-case (progn ,@body)
      (serious-condition ()
        ,(cond ((and stream object)
                (let ((gstream (gensym "STREAM+")))
                  `(let ((,gstream ,stream))
-                    (print-unreadable-object (,object ,gstream :type t 
+                    (print-unreadable-object (,object ,gstream :type t
                                                       :identity t)
                       (write-string ,msg ,gstream)))))
               (stream
@@ -1613,7 +1613,7 @@ considered to represent a symbol internal to some current package.)"
         (internal-p 		(cat package-name "::" symbol-name))
         (t 			(cat package-name ":" symbol-name))))
 
-(defun find-symbol-with-status (symbol-name status 
+(defun find-symbol-with-status (symbol-name status
                                 &optional (package *package*))
   (multiple-value-bind (symbol flag) (find-symbol symbol-name package)
     (if (and flag (eq flag status))
@@ -1670,7 +1670,7 @@ Return nil if no package matches."
 
 (defun guess-buffer-readtable (package-name)
   (let ((package (guess-package package-name)))
-    (or (and package 
+    (or (and package
              (cdr (assoc (package-name package) *readtable-alist*
                          :test #'string=)))
         *readtable*)))
@@ -1682,7 +1682,7 @@ Return nil if no package matches."
   "List of continuations for Emacs. (thread local)")
 
 (defun guess-buffer-package (string)
-  "Return a package for STRING. 
+  "Return a package for STRING.
 Fall back to the current if no such package exists."
   (or (and string (guess-package string))
       *package*))
@@ -1716,7 +1716,7 @@ Errors are trapped and invoke our debugger."
                (*eval-continuation* id))
            (check-type *buffer-package* package)
            (check-type *buffer-readtable* readtable)
-           ;; APPLY would be cleaner than EVAL. 
+           ;; APPLY would be cleaner than EVAL.
            ;; (setq result (apply (car form) (cdr form)))
            (handler-bind ((t (lambda (c) (setf condition c))))
              (setq result (with-slime-interrupts (eval form))))
@@ -1798,12 +1798,12 @@ Errors are trapped and invoke our debugger."
       (let* ((s (make-string-output-stream))
              (*standard-output* s)
              (values (multiple-value-list (eval (from-string string)))))
-        (list (get-output-stream-string s) 
+        (list (get-output-stream-string s)
               (format nil "~{~S~^~%~}" values))))))
 
 (defun eval-region (string)
   "Evaluate STRING.
-Return the results of the last form as a list and as secondary value the 
+Return the results of the last form as a list and as secondary value the
 last form."
   (with-input-from-string (stream string)
     (let (- values)
@@ -1839,7 +1839,7 @@ last form."
               (eval form))))))))
 
 (defvar *swank-pprint-bindings*
-  `((*print-pretty*   . t) 
+  `((*print-pretty*   . t)
     (*print-level*    . nil)
     (*print-length*   . nil)
     (*print-circle*   . t)
@@ -1857,11 +1857,11 @@ Used by pprint-eval.")
                  (dolist (o values)
                    (pprint o)
                    (terpri))))))))
-  
+
 (defslimefun pprint-eval (string)
   (with-buffer-syntax ()
     (let* ((s (make-string-output-stream))
-           (values 
+           (values
             (let ((*standard-output* s)
                   (*trace-output* s))
               (multiple-value-list (eval (read-from-string string))))))
@@ -1890,7 +1890,7 @@ Return the full package-name and the string to use in the prompt."
           (ellipsis (cat (subseq string 0 width) ellipsis))
           (t (subseq string 0 width)))))
 
-(defun call/truncated-output-to-string (length function 
+(defun call/truncated-output-to-string (length function
                                         &optional (ellipsis ".."))
   "Call FUNCTION with a new stream, return the output written to the stream.
 If FUNCTION tries to write more than LENGTH characters, it will be
@@ -1916,10 +1916,10 @@ aborted and return immediately with the output written so far."
   (cond ((and (not bindings) (not length))
          `(with-output-to-string (,var) . ,body))
         ((not bindings)
-         `(call/truncated-output-to-string 
+         `(call/truncated-output-to-string
            ,length (lambda (,var) . ,body)))
         (t
-         `(with-bindings ,bindings 
+         `(with-bindings ,bindings
             (with-string-stream (,var :length ,length)
               . ,body)))))
 
@@ -1932,12 +1932,12 @@ aborted and return immediately with the output written so far."
 
 (defun escape-string (string stream &key length (map '((#\" . "\\\"")
                                                        (#\\ . "\\\\"))))
-  "Write STRING to STREAM surronded by double-quotes.
+  "Write STRING to STREAM surrounded by double-quotes.
 LENGTH -- if non-nil truncate output after LENGTH chars.
 MAP -- rewrite the chars in STRING according to this alist."
   (let ((limit (or length array-dimension-limit)))
     (write-char #\" stream)
-    (loop for c across string 
+    (loop for c across string
           for i from 0 do
           (when (= i limit)
             (write-string "..." stream)
@@ -1948,7 +1948,7 @@ MAP -- rewrite the chars in STRING according to this alist."
     (write-char #\" stream)))
 
 
-;;;; Prompt 
+;;;; Prompt
 
 ;; FIXME: do we really need 45 lines of code just to figure out the
 ;; prompt?
@@ -1965,7 +1965,7 @@ MAP -- rewrite the chars in STRING according to this alist."
 
 (defun canonical-package-nickname (package)
   "Return the canonical package nickname, if any, of PACKAGE."
-  (let ((name (cdr (assoc (package-name package) *canonical-package-nicknames* 
+  (let ((name (cdr (assoc (package-name package) *canonical-package-nicknames*
                           :test #'string=))))
     (and name (string name))))
 
@@ -1989,10 +1989,10 @@ WHAT can be:
   NIL. "
   (flet ((canonicalize-filename (filename)
            (pathname-to-filename (or (probe-file filename) filename))))
-    (let ((target 
+    (let ((target
            (etypecase what
              (null nil)
-             ((or string pathname) 
+             ((or string pathname)
               `(:filename ,(canonicalize-filename what)))
              ((cons (or string pathname) *)
               `(:filename ,(canonicalize-filename (car what)) ,@(cdr what)))
@@ -2038,7 +2038,7 @@ FORM is expected, but not required, to be SETF'able."
   "Set the value of a setf'able FORM to VALUE.
 FORM and VALUE are both strings from Emacs."
   (with-buffer-syntax ()
-    (eval `(setf ,(read-from-string form) 
+    (eval `(setf ,(read-from-string form)
             ,(read-from-string (concatenate 'string "`" value))))
     t))
 
@@ -2092,7 +2092,7 @@ after Emacs causes a restart to be invoked."
 
 (defun invoke-default-debugger (condition)
   (call-with-debugger-hook nil (lambda () (invoke-debugger condition))))
-  
+
 (defvar *global-debugger* t
   "Non-nil means the Swank debugger hook will be installed globally.")
 
@@ -2113,7 +2113,7 @@ after Emacs causes a restart to be invoked."
   "The initial number of backtrace frames to send to Emacs.")
 
 (defvar *sldb-restarts* nil
-  "The list of currenlty active restarts.")
+  "The list of currently active restarts.")
 
 (defvar *sldb-stepping-p* nil
   "True during execution of a step command.")
@@ -2142,16 +2142,16 @@ after Emacs causes a restart to be invoked."
           (send-to-emacs
            (list* :debug (current-thread-id) level
                   (debugger-info-for-emacs 0 *sldb-initial-frames*)))
-          (send-to-emacs 
+          (send-to-emacs
            (list :debug-activate (current-thread-id) level nil))
-          (loop 
-           (handler-case 
-               (dcase (wait-for-event 
+          (loop
+           (handler-case
+               (dcase (wait-for-event
                                   `(or (:emacs-rex . _)
                                        (:sldb-return ,(1+ level))))
                  ((:emacs-rex &rest args) (apply #'eval-for-emacs args))
                  ((:sldb-return _) (declare (ignore _)) (return nil)))
-             (sldb-condition (c) 
+             (sldb-condition (c)
                (handle-sldb-condition c))))))
     (send-to-emacs `(:debug-return
                      ,(current-thread-id) ,level ,*sldb-stepping-p*))
@@ -2202,8 +2202,8 @@ conditions are simply reported."
   "Return a list of restarts for *swank-debugger-condition* in a
 format suitable for Emacs."
   (let ((*print-right-margin* most-positive-fixnum))
-    (loop for restart in *sldb-restarts* collect 
-          (list (format nil "~:[~;*~]~a" 
+    (loop for restart in *sldb-restarts* collect
+          (list (format nil "~:[~;*~]~a"
                         (eq restart *sldb-quit-restart*)
                         (restart-name restart))
                 (with-output-to-string (stream)
@@ -2216,7 +2216,7 @@ format suitable for Emacs."
 
 (defslimefun sldb-break-with-default-debugger (dont-unwind)
   "Invoke the default debugger."
-  (cond (dont-unwind 
+  (cond (dont-unwind
          (invoke-default-debugger *swank-debugger-condition*))
         (t
          (signal 'invoke-default-debugger))))
@@ -2228,14 +2228,14 @@ I is an integer, and can be used to reference the corresponding frame
 from Emacs; FRAME is a string representation of an implementation's
 frame."
   (loop for frame in (compute-backtrace start end)
-        for i from start collect 
+        for i from start collect
         (list* i (frame-to-string frame)
                (ecase (frame-restartable-p frame)
                  ((nil) nil)
                  ((t) `((:restartable t)))))))
 
 (defun frame-to-string (frame)
-  (with-string-stream (stream :length (* (or *print-lines* 1) 
+  (with-string-stream (stream :length (* (or *print-lines* 1)
                                          (or *print-right-margin* 100))
                               :bindings *backtrace-printer-bindings*)
     (handler-case (print-frame frame stream)
@@ -2251,7 +2251,7 @@ where
   restart     ::= (name description)
   stack-frame ::= (number description [plist])
   extra       ::= (:references and other random things)
-  cont        ::= continutation
+  cont        ::= continuation
   plist       ::= (:restartable {nil | t | :unknown})
 
 condition---a pair of strings: message, and type.  If show-source is
@@ -2300,7 +2300,7 @@ Operation was KERNEL::DIVISION, operands (1 0).\"
 
 (defun coerce-to-condition (datum args)
   (etypecase datum
-    (string (make-condition 'simple-error :format-control datum 
+    (string (make-condition 'simple-error :format-control datum
                             :format-arguments args))
     (symbol (apply #'make-condition datum args))))
 
@@ -2312,7 +2312,7 @@ Operation was KERNEL::DIVISION, operands (1 0).\"
 (defslimefun throw-to-toplevel ()
   "Invoke the ABORT-REQUEST restart abort an RPC from Emacs.
 If we are not evaluating an RPC then ABORT instead."
-  (let ((restart (or (and *sldb-quit-restart* 
+  (let ((restart (or (and *sldb-quit-restart*
                           (find-restart *sldb-quit-restart*))
                      (car (last (compute-restarts))))))
     (cond (restart (invoke-restart restart))
@@ -2445,7 +2445,7 @@ The time is measured in seconds."
         (let ((faslfile (etypecase faslfile
                           (null nil)
                           (pathname (pathname-to-filename faslfile)))))
-          (make-compilation-result :notes (reverse notes) 
+          (make-compilation-result :notes (reverse notes)
                                    :duration seconds
                                    :successp (if successp t)
                                    :loadp (if loadp t)
@@ -2514,11 +2514,11 @@ Record compiler notes signalled as `compiler-condition's."
          (column (second line-column)))
     (with-buffer-syntax ()
       (collect-notes
-       (lambda () 
+       (lambda ()
          (let ((*compile-print* t) (*compile-verbose* nil))
            (swank-compile-string string
                                  :buffer buffer
-                                 :position offset 
+                                 :position offset
                                  :filename filename
                                  :line line
                                  :column column
@@ -2534,7 +2534,7 @@ Record compiler notes signalled as `compiler-condition's."
              (let ((*compile-print* t) (*compile-verbose* nil))
                (swank-compile-string string
                                      :buffer buffer
-                                     :position position 
+                                     :position position
                                      :filename filename
                                      :policy policy)))))))
 
@@ -2705,19 +2705,19 @@ the filename of the module (or nil if the file doesn't exist).")
       (format-completion-set strings intern pname))))
 
 (defun matching-symbols (package external test)
-  (let ((test (if external 
+  (let ((test (if external
 		  (lambda (s)
-		    (and (symbol-external-p s package) 
+		    (and (symbol-external-p s package)
 			 (funcall test s)))
 		  test))
 	(result '()))
     (do-symbols (s package)
-      (when (funcall test s) 
+      (when (funcall test s)
 	(push s result)))
     (remove-duplicates result)))
 
 (defun unparse-symbol (symbol)
-  (let ((*print-case* (case (readtable-case *readtable*) 
+  (let ((*print-case* (case (readtable-case *readtable*)
                         (:downcase :upcase)
                         (t :downcase))))
     (unparse-name (symbol-name symbol))))
@@ -2788,7 +2788,7 @@ Returns a list of completions with package qualifiers if needed."
 
 ;;;; Documentation
 
-(defslimefun apropos-list-for-emacs  (name &optional external-only 
+(defslimefun apropos-list-for-emacs  (name &optional external-only
                                            case-sensitive package)
   "Make an apropos search for Emacs.
 The result is a list of property lists."
@@ -2808,9 +2808,9 @@ Like `describe-symbol-for-emacs' but with at most one line per item."
   (flet ((first-line (string)
            (let ((pos (position #\newline string)))
              (if (null pos) string (subseq string 0 pos)))))
-    (let ((desc (map-if #'stringp #'first-line 
+    (let ((desc (map-if #'stringp #'first-line
                         (describe-symbol-for-emacs symbol))))
-      (if desc 
+      (if desc
           (list* :designator (to-string symbol) desc)))))
 
 (defun map-if (test fn &rest lists)
@@ -2870,7 +2870,7 @@ that symbols accessible in the current package go first."
 (defmacro with-describe-settings ((&rest _) &body body)
   (declare (ignore _))
   `(call-with-describe-settings (lambda () ,@body)))
-    
+
 (defun describe-to-string (object)
   (with-describe-settings ()
     (with-output-to-string (*standard-output*)
@@ -2924,7 +2924,7 @@ Include the nicknames if NICKNAMES is true."
 
 ;;;; Tracing
 
-;; Use eval for the sake of portability... 
+;; Use eval for the sake of portability...
 (defun tracedp (fspec)
   (member fspec (eval '(trace))))
 
@@ -3036,7 +3036,7 @@ If non-nil, called with two arguments SPEC and TRACED-P." )
     ((:string string package)
      (with-buffer-syntax (package)
        (eval (read-from-string string))))
-    ((:inspector part) 
+    ((:inspector part)
      (inspector-nth-part part))
     ((:sldb frame var)
      (frame-var-value frame var))))
@@ -3172,7 +3172,7 @@ DSPEC is a string and LOCATION a source location. NAME is a string."
 (defvar *inspector-verbose* nil)
 
 (defvar *inspector-printer-bindings*
-  '((*print-lines*        . 1) 
+  '((*print-lines*        . 1)
     (*print-right-margin* . 75)
     (*print-pretty*       . t)
     (*print-readably*     . nil)))
@@ -3275,7 +3275,7 @@ DSPEC is a string and LOCATION a source location. NAME is a string."
 (defun prepare-range (istate start end)
   (let* ((range (content-range (istate.content istate) start end))
          (ps (loop for part in range append (prepare-part part istate))))
-    (list ps 
+    (list ps
           (if (< (length ps) (- end start))
               (+ start (length ps))
               (+ end 1000))
@@ -3287,11 +3287,11 @@ DSPEC is a string and LOCATION a source location. NAME is a string."
       (string (list part))
       (cons (dcase part
               ((:newline) (list newline))
-              ((:value obj &optional str) 
+              ((:value obj &optional str)
                (list (value-part obj str (istate.parts istate))))
               ((:label &rest strs)
                (list (list :label (apply #'cat (mapcar #'string strs)))))
-              ((:action label lambda &key (refreshp t)) 
+              ((:action label lambda &key (refreshp t))
                (list (action-part label lambda refreshp
                                   (istate.actions istate))))
               ((:line label value)
@@ -3300,7 +3300,7 @@ DSPEC is a string and LOCATION a source location. NAME is a string."
                      newline)))))))
 
 (defun value-part (object string parts)
-  (list :value 
+  (list :value
         (or string (print-part-to-string object))
         (assign-index object parts)))
 
@@ -3383,8 +3383,8 @@ Return nil if there's no previous object."
                  (read-from-string string)))
          (ignorable (remove-if #'boundp (mapcar #'car context))))
     (to-string (eval `(let ((* ',obj) (- ',form)
-                            . ,(loop for (var . val) in context 
-                                     unless (constantp var) collect 
+                            . ,(loop for (var . val) in context
+                                     unless (constantp var) collect
                                      `(,var ',val)))
                         (declare (ignorable . ,ignorable))
                         ,form)))))
@@ -3397,7 +3397,7 @@ Return nil if there's no previous object."
       (format out "--- next/prev chain ---")
       (loop for s = newest then (istate.previous s) while s do
             (let ((val (istate.object s)))
-              (format out "~%~:[  ~; *~]@~d " 
+              (format out "~%~:[  ~; *~]@~d "
                       (eq s *istate*)
                       (position val *inspector-history*))
               (print-unreadable-object (val out :type t :identity t)))))
@@ -3454,7 +3454,7 @@ Return nil if there's no previous object."
       (inspect-cons o)))
 
 (defun inspect-cons (cons)
-  (label-value-line* 
+  (label-value-line*
    ('car (car cons))
    ('cdr (cdr cons))))
 
@@ -3494,7 +3494,7 @@ Return nil if there's no previous object."
              (frob (format nil "An improper list of length ~a:" length) list))))))
 
 (defun inspect-list-aux (list)
-  (loop for i from 0  for rest on list  while (consp rest)  append 
+  (loop for i from 0  for rest on list  while (consp rest)  append
         (if (listp (cdr rest))
             (label-value-line i (car rest))
             (label-value-line* (i (car rest)) (:tail (cdr rest))))))
@@ -3517,7 +3517,7 @@ Return NIL if LIST is circular."
 
 (defun hash-table-to-alist (ht)
   (let ((result '()))
-    (maphash (lambda (key value) 
+    (maphash (lambda (key value)
                (setq result (acons key value result)))
              ht)
     result))
@@ -3534,7 +3534,7 @@ Return NIL if LIST is circular."
      (when weakness
        (label-value-line "Weakness:" weakness)))
    (unless (zerop (hash-table-count ht))
-     `((:action "[clear hashtable]" 
+     `((:action "[clear hashtable]"
                 ,(lambda () (clrhash ht))) (:newline)
        "Contents: " (:newline)))
    (let ((content (hash-table-to-alist ht)))
@@ -3608,13 +3608,13 @@ Return NIL if LIST is circular."
 ;;;;; Chars
 
 (defmethod emacs-inspect ((char character))
-  (append 
+  (append
    (label-value-line*
     ("Char code" (char-code char))
     ("Lower cased" (char-downcase char))
     ("Upper cased" (char-upcase char)))
    (if (get-macro-character char)
-       `("In the current readtable (" 
+       `("In the current readtable ("
          (:value ,*readtable*) ") it is a macro character: "
          (:value ,(get-macro-character char))))))
 
@@ -3639,8 +3639,8 @@ a time.")
 (defslimefun list-threads ()
   "Return a list (LABELS (ID NAME STATUS ATTRS ...) ...).
 LABELS is a list of attribute names and the remaining lists are the
-corresponding attribute values per thread.  
-Example: 
+corresponding attribute values per thread.
+Example:
   ((:id :name :status :priority)
    (6 \"swank-indentation-cache-thread\" \"Semaphore timed wait\" 0)
    (5 \"reader-thread\" \"Active\" 0)
@@ -3653,7 +3653,7 @@ Example:
              (equalp (thread-name (current-thread)) "worker"))
     (setf *thread-list* (delete (current-thread) *thread-list*)))
   (let* ((plist (thread-attributes (car *thread-list*)))
-         (labels (loop for (key) on plist by #'cddr 
+         (labels (loop for (key) on plist by #'cddr
                        collect key)))
     `((:id :name :status ,@labels)
       ,@(loop for thread in *thread-list*
@@ -3707,7 +3707,7 @@ The server port is written to PORT-FILE-NAME."
     (ecase type
       (:subclasses
        (mop-helper symbol #'swank-mop:class-direct-subclasses))
-      (:superclasses 
+      (:superclasses
        (mop-helper symbol #'swank-mop:class-direct-superclasses)))))
 
 
@@ -3763,7 +3763,7 @@ after each command.")
 (defun send-to-indentation-cache (request)
   (let ((c *emacs-connection*))
     (etypecase c
-      (singlethreaded-connection 
+      (singlethreaded-connection
        (handle-indentation-cache-request c request))
       (multithreaded-connection
        (without-slime-interrupts
@@ -3815,7 +3815,7 @@ belonging to PACKAGE."
                (when (or indent (gethash symbol cache))
                  (unless (equal (gethash symbol cache) indent)
                    (setf (gethash symbol cache) indent)
-                   (let ((pkgs (mapcar #'package-name 
+                   (let ((pkgs (mapcar #'package-name
                                        (symbol-packages symbol)))
                          (name (string-downcase symbol)))
                      (push (list name indent pkgs) alist)))))))
@@ -3868,7 +3868,7 @@ in Emacs."
       nil))
 
 (defun clean-arglist (arglist)
-  "Remove &whole, &enviroment, and &aux elements from ARGLIST."
+  "Remove &whole, &environment, and &aux elements from ARGLIST."
   (cond ((null arglist) '())
         ((member (car arglist) '(&whole &environment))
          (clean-arglist (cddr arglist)))
@@ -3924,7 +3924,7 @@ Collisions are caused because package information is ignored."
   (make-output-stream (make-output-function-for-target connection target)))
 
 
-;;;; Testing 
+;;;; Testing
 
 (defslimefun io-speed-test (&optional (n 1000) (m 1))
   (let* ((s *standard-output*)
@@ -3942,7 +3942,7 @@ Collisions are caused because package information is ignored."
     nil))
 
 (defslimefun flow-control-test (n delay)
-  (let ((stream (make-output-stream 
+  (let ((stream (make-output-stream
                  (let ((conn *emacs-connection*))
                    (lambda (string)
                      (declare (ignore string))

--- a/xref.lisp
+++ b/xref.lisp
@@ -1,11 +1,11 @@
-;;; -*- Mode: LISP; Package: XREF; Syntax: Common-lisp;  -*- 
+;;; -*- Mode: LISP; Package: XREF; Syntax: Common-lisp;  -*-
 ;;; Mon Jan 21 16:21:20 1991 by Mark Kantrowitz <mkant@GLINDA.OZ.CS.CMU.EDU>
 ;;; xref.lisp
 
 ;;; ****************************************************************
-;;; List Callers: A Static Analysis Cross Referencing Tool for Lisp 
+;;; List Callers: A Static Analysis Cross Referencing Tool for Lisp
 ;;; ****************************************************************
-;;; 
+;;;
 ;;; The List Callers system is a portable Common Lisp cross referencing
 ;;; utility. It grovels over a set of files and compiles a database of the
 ;;; locations of all references for each symbol used in the files.
@@ -14,15 +14,15 @@
 ;;;
 ;;; When you change a function or variable definition, it can be useful
 ;;; to know its callers, in order to update each of them to the new
-;;; definition. Similarly, having a graphic display of the structure 
+;;; definition. Similarly, having a graphic display of the structure
 ;;; (e.g., call graph) of a program can help make undocumented code more
 ;;; understandable. This static code analyzer facilitates both capabilities.
-;;; The database compiled by xref is suitable for viewing by a graphical 
+;;; The database compiled by xref is suitable for viewing by a graphical
 ;;; browser. (Note: the reference graph is not necessarily a DAG. Since many
 ;;; graphical browsers assume a DAG, this will lead to infinite loops.
 ;;; Some code which is useful in working around this problem is included,
 ;;; as well as a sample text-indenting outliner and an interface to Bates'
-;;; PSGraph Postscript Graphing facility.) 
+;;; PSGraph Postscript Graphing facility.)
 ;;;
 ;;; Written by Mark Kantrowitz, July 1990.
 ;;;
@@ -44,8 +44,8 @@
 ;;; ANY WARRANTY. The author(s) do not accept responsibility to anyone for
 ;;; the consequences of using it or for whether it serves any particular
 ;;; purpose or works at all. No warranty is made about the software or its
-;;; performance. 
-;;; 
+;;; performance.
+;;;
 ;;; Use and copying of this software and the preparation of derivative
 ;;; works based on this software are permitted, so long as the following
 ;;; conditions are met:
@@ -54,44 +54,44 @@
 ;;;	o  No fees or compensation are charged for use, copies, or
 ;;;	   access to this software. You may charge a nominal
 ;;;	   distribution fee for the physical act of transferring a
-;;;	   copy, but you may not charge for the program itself. 
+;;;	   copy, but you may not charge for the program itself.
 ;;;	o  If you modify this software, you must cause the modified
 ;;;	   file(s) to carry prominent notices (a Change Log)
 ;;;	   describing the changes, who made the changes, and the date
 ;;;	   of those changes.
 ;;;	o  Any work distributed or published that in whole or in part
-;;;	   contains or is a derivative of this software or any part 
-;;;	   thereof is subject to the terms of this agreement. The 
+;;;	   contains or is a derivative of this software or any part
+;;;	   thereof is subject to the terms of this agreement. The
 ;;;	   aggregation of another unrelated program with this software
 ;;;	   or its derivative on a volume of storage or distribution
 ;;;	   medium does not bring the other program under the scope
 ;;;	   of these terms.
 ;;;	o  Permission is granted to manufacturers and distributors of
 ;;;	   lisp compilers and interpreters to include this software
-;;;	   with their distribution. 
+;;;	   with their distribution.
 ;;;
-;;; This software is made available AS IS, and is distributed without 
+;;; This software is made available AS IS, and is distributed without
 ;;; warranty of any kind, either expressed or implied.
-;;; 
+;;;
 ;;; In no event will the author(s) or their institutions be liable to you
 ;;; for damages, including lost profits, lost monies, or other special,
 ;;; incidental or consequential damages arising out of or in connection
 ;;; with the use or inability to use (including but not limited to loss of
 ;;; data or data being rendered inaccurate or losses sustained by third
-;;; parties or a failure of the program to operate as documented) the 
+;;; parties or a failure of the program to operate as documented) the
 ;;; program, even if you have been advised of the possibility of such
 ;;; damanges, or for any claim by any other party, whether in an action of
 ;;; contract, negligence, or other tortious action.
-;;; 
+;;;
 ;;; The current version of this software and a variety of related utilities
 ;;; may be obtained by anonymous ftp from ftp.cs.cmu.edu in the directory
 ;;;    user/ai/lang/lisp/code/tools/xref/
-;;; 
+;;;
 ;;; Please send bug reports, comments, questions and suggestions to
 ;;; mkant@cs.cmu.edu. We would also appreciate receiving any changes
-;;; or improvements you may make. 
-;;; 
-;;; If you wish to be added to the Lisp-Utilities@cs.cmu.edu mailing list, 
+;;; or improvements you may make.
+;;;
+;;; If you wish to be added to the Lisp-Utilities@cs.cmu.edu mailing list,
 ;;; send email to Lisp-Utilities-Request@cs.cmu.edu with your name, email
 ;;; address, and affiliation. This mailing list is primarily for
 ;;; notification about major updates, bug fixes, and additions to the lisp
@@ -105,7 +105,7 @@
 ;;; 27-FEB-91 mk   Added insert arg to psgraph-xref to allow the postscript
 ;;;                graphs to be inserted in Scribe documents.
 ;;; 21-FEB-91 mk   Added warning if not compiled.
-;;; 07-FEB-91 mk   Fixed bug in record-callers with regard to forms at 
+;;; 07-FEB-91 mk   Fixed bug in record-callers with regard to forms at
 ;;;                toplevel.
 ;;; 21-JAN-91 mk   Added file xref-test.lisp to test xref.
 ;;; 16-JAN-91 mk   Added definition WHO-CALLS to parallel the Symbolics syntax.
@@ -114,7 +114,7 @@
 ;;; 16-JAN-91 mk   Modified print-caller-tree and related functions
 ;;;                to allow the user to specify root nodes. If the user
 ;;;                doesn't specify them, it will default to all root
-;;;                nodes, as before. 
+;;;                nodes, as before.
 ;;; 16-JAN-91 mk   Added parameter *default-graphing-mode* to specify
 ;;;                the direction of the graphing. Either :call-graph,
 ;;;                where the children of a node are those functions called
@@ -172,7 +172,7 @@
 ;;; calls within backquote and quote, which we normally ignore. If
 ;;; we redefine QUOTE's pattern so that it treats the arg like a FORM,
 ;;; we'll probably get them (though maybe the syntax will be mangled),
-;;; but most likely a lot of spurious things as well. 
+;;; but most likely a lot of spurious things as well.
 ;;;
 ;;; Define an operation for Defsystem which will run XREF-FILE on the
 ;;; files of the system. Or yet simpler, when XREF sees a LOAD form
@@ -197,7 +197,7 @@
 ;;;
 ;;; Would pay to comment record-callers and record-callers* in more
 ;;; depth.
-;;; 
+;;;
 ;;; (&OPTIONAL &REST &KEY &AUX &BODY &WHOLE &ALLOW-OTHER-KEYS &ENVIRONMENT)
 
 ;;; ********************************
@@ -209,13 +209,13 @@
 ;;;       Macintosh Allegro Common Lisp (1.3.2)
 ;;;       ExCL (Franz Allegro CL 3.1.12 [DEC 3100] 3/30/90)
 ;;;       Lucid CL (Version 2.1 6-DEC-87)
-;;;    
+;;;
 ;;;    XREF has been tested (unsuccessfully) in the following lisps:
 ;;;       Ibuki Common Lisp (01/01, October 15, 1987)
 ;;;           - if interpreted, runs into stack overflow
 ;;;           - does not compile (tried ibcl on Suns, PMAXes and RTs)
 ;;;             seems to be due to a limitation in the c compiler.
-;;;    
+;;;
 ;;;    XREF needs to be tested in the following lisps:
 ;;;       Symbolics Common Lisp (8.0)
 ;;;       Lucid Common Lisp (3.0, 4.0)
@@ -238,13 +238,13 @@
 ;;; symbol, or display the call graph of portions of the program
 ;;; (including the entire program). This allows the programmer to debug
 ;;; and document the program's structure.
-;;; 
+;;;
 ;;; XREF is primarily intended for analyzing large programs, where it is
 ;;; difficult, if not impossible, for the programmer to grasp the structure
 ;;; of the whole program. Nothing precludes using XREF for smaller programs,
 ;;; where it can be useful for inspecting the relationships between pieces
 ;;; of the program and for documenting the program.
-;;; 
+;;;
 ;;; Two aspects of the Lisp programming language greatly simplify the
 ;;; analysis of Lisp programs:
 ;;; 	o  Lisp programs are naturally represented as data.
@@ -261,14 +261,14 @@
 ;;; tree. For example, one kind of relation is that the function defined
 ;;; by the definition calls the functions in its body. The relations are
 ;;; stored in a database for later examination by the user.
-;;; 
+;;;
 ;;; While XREF currently only works for programs written in Lisp, it could
 ;;; be extended to other programming languages by writing a function to
 ;;; generate parse trees for definitions in that language, and a core
 ;;; set of patterns for the language's syntax.
-;;; 
-;;; Since XREF normally does a static syntactic analysis of the program, 
-;;; it does not detect references due to the expansion of a macro definition. 
+;;;
+;;; Since XREF normally does a static syntactic analysis of the program,
+;;; it does not detect references due to the expansion of a macro definition.
 ;;; To do this in full generality XREF would have to have knowledge about the
 ;;; semantics of the program (e.g., macros which call other functions to
 ;;; do the expansion). This entails either modifying the compiler to
@@ -285,7 +285,7 @@
 ;;; has a pattern defined for dolist, it will not call macroexpand-1 on
 ;;; a form whose car is dolist.) For this to work properly, the code must
 ;;; be loaded before being processed by XREF, and XREF's parameters should
-;;; be set so that it processes forms in their proper packages. 
+;;; be set so that it processes forms in their proper packages.
 ;;;
 ;;; If macro expansion is disabled, the default rules for handling macro
 ;;; references may not be sufficient for some user-defined macros, because
@@ -316,7 +316,7 @@
 ;;;    and the total number of forms.
 ;;;
 ;;; -----
-;;; The following functions display information about the uses of the 
+;;; The following functions display information about the uses of the
 ;;; specified symbol as a function, variable, or constant.
 ;;;
 ;;; LIST-CALLERS (symbol)                                         [FUNCTION]
@@ -484,7 +484,7 @@
 ;;;
 ;;; Patterns may be either structures to match, or a predicate
 ;;; like symbolp/numberp/stringp. The pattern specification language
-;;; is similar to the notation used in CLtL2, but in a more lisp-like 
+;;; is similar to the notation used in CLtL2, but in a more lisp-like
 ;;; form:
 ;;;    (:eq name)           The form element must be eq to the symbol NAME.
 ;;;    (:test test)         TEST must be true when applied to the form element.
@@ -520,7 +520,7 @@
 ;;;                         a variable definition or mutation. Used
 ;;;                         in the definition of let, let*, etc.
 ;;;    VARIABLE             The corresponding form element should be
-;;;                         a variable reference. 
+;;;                         a variable reference.
 ;;;
 ;;; In all other pattern symbols, it looks up the symbols pattern substitution
 ;;; and recursively matches against the pattern. Automatically destructures
@@ -536,7 +536,7 @@
 ;;;    and others...
 ;;;
 ;;; Here's some sample pattern definitions:
-;;; (define-caller-pattern defun 
+;;; (define-caller-pattern defun
 ;;;   (name lambda-list
 ;;;	(:star (:or documentation-string declaration))
 ;;;	(:star form))
@@ -556,7 +556,7 @@
 ;;;
 ;;;    This is by no means perfect. For example, let and let* are treated
 ;;;    identically, instead of differentiating between serial and parallel
-;;;    binding. But it's still a useful tool. It can be helpful in 
+;;;    binding. But it's still a useful tool. It can be helpful in
 ;;;    maintaining code, debugging problems with patch files, determining
 ;;;    whether functions are multiply defined, and help you remember where
 ;;;    a function is defined or called.
@@ -569,17 +569,17 @@
 ;;;
 ;;; Xerox Interlisp Masterscope Program:
 ;;;   Larry M Masinter, Global program analysis in an interactive environment
-;;;   PhD Thesis, Stanford University, 1980. 
+;;;   PhD Thesis, Stanford University, 1980.
 ;;;
 ;;; Symbolics Who-Calls Database:
 ;;;   User's Guide to Symbolics Computers, Volume 1, Cambridge, MA, July 1986
 ;;;   Genera 7.0, pp 183-185.
-;;;   
+;;;
 
 ;;; ********************************
 ;;; Example ************************
 ;;; ********************************
-;;; 
+;;;
 ;;; Here is an example of running XREF on a short program.
 ;;; [In Scribe documentation, give a simple short program and resulting
 ;;;  XREF output, including postscript call graphs.]
@@ -661,37 +661,37 @@ Rooted calling trees:
 
 (defpackage :pxref
   (:use :common-lisp)
-  (:export #:list-callers 
-	   #:list-users 
-	   #:list-readers 
+  (:export #:list-callers
+	   #:list-users
+	   #:list-readers
 	   #:list-setters
 	   #:what-files-call
-	   #:who-calls 
-	   #:list-callees 
-	   #:source-file 
+	   #:who-calls
+	   #:list-callees
+	   #:source-file
 	   #:clear-tables
-	   #:define-pattern-substitution 
-	   #:define-caller-pattern 
-	   #:define-variable-pattern 
+	   #:define-pattern-substitution
+	   #:define-caller-pattern
+	   #:define-variable-pattern
 	   #:define-caller-pattern-synonyms
 	   #:clear-patterns
-	   #:*last-form* 
-	   #:*xref-verbose* 
-	   #:*handle-package-forms* 
+	   #:*last-form*
+	   #:*xref-verbose*
+	   #:*handle-package-forms*
 	   #:*handle-function-forms*
 	   #:*handle-macro-forms*
 	   #:*types-to-ignore*
-	   #:*last-caller-tree* 
-	   #:*default-graphing-mode* 
+	   #:*last-caller-tree*
+	   #:*default-graphing-mode*
 	   #:*indent-amount*
-	   #:xref-file 
+	   #:xref-file
 	   #:xref-files
 	   #:write-callers-database-to-file
 	   #:display-database
-	   #:print-caller-trees 
-	   #:make-caller-tree 
-	   #:print-indented-tree 
-	   #:determine-file-dependencies 
+	   #:print-caller-trees
+	   #:make-caller-tree
+	   #:print-indented-tree
+	   #:determine-file-dependencies
 	   #:print-file-dependencies
 	   #:psgraph-xref
 	   ))
@@ -755,11 +755,11 @@ Rooted calling trees:
   "Lists all functions which call SYMBOL as a function (function invocation)."
   (callers-list symbol :callers))
 (defun list-readers (symbol)
-  "Lists all functions which refer to SYMBOL as a variable 
+  "Lists all functions which refer to SYMBOL as a variable
    (variable reference)."
   (callers-list symbol :readers))
 (defun list-setters (symbol)
-  "Lists all functions which bind/set SYMBOL as a variable 
+  "Lists all functions which bind/set SYMBOL as a variable
    (variable mutation)."
   (callers-list symbol :setters))
 (defun list-users (symbol)
@@ -776,13 +776,13 @@ Rooted calling trees:
     (:function (list-callers symbol))
     (:reader   (list-readers symbol))
     (:setter   (list-setters symbol))
-    (:variable (append (list-readers symbol) 
+    (:variable (append (list-readers symbol)
 		       (list-setters symbol)))
     (otherwise (append (list-callers symbol)
 		       (list-readers symbol)
 		       (list-setters symbol)))))
 (defun what-files-call (symbol)
-  "Lists names of files that contain uses of SYMBOL 
+  "Lists names of files that contain uses of SYMBOL
    as a function, variable, or constant."
   (callers-list symbol :file))
 (defun list-callees (symbol)
@@ -823,13 +823,13 @@ Rooted calling trees:
   (gethash name *pattern-substitution-table*))
 (defmacro define-pattern-substitution (name pattern)
   "Defines NAME to be equivalent to the specified pattern. Useful for
-   making patterns more readable. For example, the LAMBDA-LIST is 
+   making patterns more readable. For example, the LAMBDA-LIST is
    defined as a pattern substitution, making the definition of the
    DEFUN caller-pattern simpler."
   `(setf (gethash ',name *pattern-substitution-table*)
 	 ',pattern))
 
-;;; Function/Macro caller patterns: 
+;;; Function/Macro caller patterns:
 ;;; The car of the form is skipped, so we don't need to specify
 ;;; (:eq function-name) like we would for a substitution.
 ;;;
@@ -839,11 +839,11 @@ Rooted calling trees:
 ;;; package depends on the LISP package, so a symbol like 'xref::cons is
 ;;; translated automatically into 'lisp::cons. However, since
 ;;; (equal 'foo::bar 'baz::bar) returns nil unless both 'foo::bar and
-;;; 'baz::bar are inherited from the same package (e.g., LISP), 
-;;; if package handling is turned on the user must specify package 
+;;; 'baz::bar are inherited from the same package (e.g., LISP),
+;;; if package handling is turned on the user must specify package
 ;;; names in the caller pattern definitions for functions that occur
 ;;; in packages other than LISP, otherwise the symbols will not match.
-;;; 
+;;;
 ;;; Perhaps we should enforce the definition of caller patterns in the
 ;;; XREF package by wrapping the body of define-caller-pattern in
 ;;; the XREF package:
@@ -854,10 +854,10 @@ Rooted calling trees:
 ;;;    	     `(progn
 ;;;    	        (when ',caller-type
 ;;;         	     (setf (pattern-caller-type ',name) ',caller-type))
-;;;    	        (when ',value 
+;;;    	        (when ',value
 ;;;    	          (setf (gethash ',name *caller-pattern-table*)
 ;;;    		        ',value)))
-;;;          (setf *package* old-package)))) 
+;;;          (setf *package* old-package))))
 ;;; Either that, or for the purpose of pattern testing we should compare
 ;;; printreps. [The latter makes the primitive patterns like VAR
 ;;; reserved words.]
@@ -870,12 +870,12 @@ Rooted calling trees:
    described by PATTERN. CALLER-TYPE, if specified, assigns a type to
    the pattern, which may be used to exclude references to NAME while
    viewing the database. For example, all the Common Lisp definitions
-   have a caller-type of :lisp or :lisp2, so that you can exclude 
+   have a caller-type of :lisp or :lisp2, so that you can exclude
    references to common lisp functions from the calling tree."
   `(progn
      (when ',caller-type
        (setf (pattern-caller-type ',name) ',caller-type))
-     (when ',pattern 
+     (when ',pattern
        (setf (gethash ',name *caller-pattern-table*)
 	     ',pattern))))
 
@@ -931,7 +931,7 @@ Rooted calling trees:
 (defvar *handle-package-forms* nil	;'(lisp::in-package)
   "When non-NIL, and XREF-FILE sees a package-setting form like IN-PACKAGE,
    sets the current package to the specified package by evaluating the
-   form. When done with the file, xref-file resets the package to its 
+   form. When done with the file, xref-file resets the package to its
    original value. In some of the displaying functions, when this variable
    is non-NIL one may specify that all symbols from a particular set of
    packages be ignored. This is only useful if the files use different
@@ -977,7 +977,7 @@ Rooted calling trees:
 		   (consp form)
 		   (member (car form) *handle-package-forms*))
 	  (eval form))))
-    (when verbose 
+    (when verbose
       (format t "~&~D forms processed." count))
     (setq *package* old-package)
     (values)))
@@ -986,16 +986,16 @@ Rooted calling trees:
   "When T, XREF-FILE tries to be smart about forms which occur in
    a function position, such as lambdas and arbitrary Lisp forms.
    If so, it recursively calls record-callers with pattern 'FORM.
-   If the form is a lambda, makes the caller a caller of :unnamed-lambda.") 
+   If the form is a lambda, makes the caller a caller of :unnamed-lambda.")
 
 (defvar *handle-macro-forms* t
   "When T, if the file was loaded before being processed by XREF, and the
    car of a form is a macro, it notes that the parent calls the macro,
-   and then calls macroexpand-1 on the form.") 
+   and then calls macroexpand-1 on the form.")
 
 (defvar *callees-database-includes-variables* nil)
 
-(defun record-callers (filename form 
+(defun record-callers (filename form
 				&optional pattern parent (environment nil)
 				funcall)
   "RECORD-CALLERS is the main routine used to walk down the code. It matches
@@ -1013,7 +1013,7 @@ Rooted calling trees:
 	   (:IGNORE
 	    ;; Ignores the rest of the form.
 	    (values t parent environment))
-	   (NAME    
+	   (NAME
 	    ;; This is the name of a new definition.
 	    (push filename (source-file form))
 	    (values t form   environment))
@@ -1029,21 +1029,21 @@ Rooted calling trees:
 		       (pushnew :unnamed-lambda (callers-list parent
 							      :callees))))
 		   (record-callers filename form 'form parent environment))
-		  (t 
+		  (t
 		   ;; If we're just a regular function name call.
 		   (pushnew filename (callers-list form :file))
 		   (when parent
 		     (pushnew parent (callers-list form :callers))
 		     (pushnew form (callers-list parent :callees)))
-		   (values t parent environment)))) 
-	   (VAR     
+		   (values t parent environment))))
+	   (VAR
 	    ;; This is the name of a new variable definition.
 	    ;; Includes arglist parameters.
 	    (when (and (symbolp form) (not (keywordp form))
 		       (not (member form lambda-list-keywords)))
 	      (pushnew form (car environment))
 	      (pushnew filename (callers-list form :file))
-	      (when parent 
+	      (when parent
 ;		  (pushnew form (callers-list parent :callees))
 		(pushnew parent (callers-list form :setters)))
 	      (values t parent environment)))
@@ -1055,7 +1055,7 @@ Rooted calling trees:
 	      (when *callees-database-includes-variables*
 		(pushnew form (callers-list parent :callees))))
 	    (values t parent environment))
-	   (FORM    
+	   (FORM
 	    ;; A random form (var or funcall).
 	    (cond ((consp form)
 		   ;; Get new pattern from TAG.
@@ -1077,9 +1077,9 @@ Rooted calling trees:
 			    ;; The car of the form is a macro and
 			    ;; macro processing is turned on. Macroexpand-1
 			    ;; the form and try again.
-			    (record-callers filename 
+			    (record-callers filename
 					    (macroexpand-1 form)
-					    'form parent environment 
+					    'form parent environment
 					    :funcall))
 			   ((null (cdr form))
 			    ;; No more left to be processed. Note that
@@ -1091,10 +1091,10 @@ Rooted calling trees:
 			    (record-callers filename (cdr form)
 					    '((:star FORM))
 					    parent environment :funcall)))))
-		  (t 
+		  (t
 		   (when (and (not (lookup form environment))
 			      (not (numberp form))
-			      ;; the following line should probably be 
+			      ;; the following line should probably be
 			      ;; commented out?
 			      (not (keywordp form))
 			      (not (stringp form))
@@ -1107,11 +1107,11 @@ Rooted calling trees:
 		       (when *callees-database-includes-variables*
 			 (pushnew form (callers-list parent :callees)))))
 		   (values t parent environment))))
-	   (otherwise 
+	   (otherwise
 	    ;; Pattern Substitution
 	    (let ((new-pattern (lookup-pattern-substitution pattern)))
 	      (if new-pattern
-		  (record-callers filename form new-pattern 
+		  (record-callers filename form new-pattern
 				  parent environment)
 		  (when (eq pattern form)
 		    (values t parent environment)))))))
@@ -1134,31 +1134,31 @@ Rooted calling trees:
 			    parent environment))
 	   (otherwise
 	    (multiple-value-bind (d p env)
-		(record-callers* filename form pattern 
+		(record-callers* filename form pattern
 				 parent (cons nil environment))
 	      (values d p (if funcall environment env))))))))
 
 (defun record-callers* (filename form pattern parent environment
-				 &optional continuation 
+				 &optional continuation
 				 in-optionals in-keywords)
   "RECORD-CALLERS* handles complex list-structure patterns, such as
    ordered lists of subpatterns, patterns involving :star, :plus,
    &optional, &key, &rest, and so on. CONTINUATION is a stack of
    unprocessed patterns, IN-OPTIONALS and IN-KEYWORDS are corresponding
    stacks which determine whether &rest or &key has been seen yet in
-   the current pattern."   
+   the current pattern."
   ;; form must be a cons or nil.
 ;  (when form)
   (if (null pattern)
       (if (null continuation)
 	  (values t parent environment)
 	  (record-callers* filename form (car continuation) parent environment
-			   (cdr continuation) 
+			   (cdr continuation)
 			   (cdr in-optionals)
 			   (cdr in-keywords)))
       (let ((pattern-elt (car pattern)))
 	(cond ((car-eq pattern-elt :optional)
-	       (if (null form) 
+	       (if (null form)
 		   (values t parent environment)
 		   (multiple-value-bind (processed par env)
 		       (record-callers* filename form (cdr pattern-elt)
@@ -1242,7 +1242,7 @@ Rooted calling trees:
    in the database handling functions. :lisp is CLtL 1st edition,
    :lisp2 is additional patterns from CLtL 2nd edition.")
 
-(defun display-database (&optional (database :callers) 
+(defun display-database (&optional (database :callers)
 				   (types-to-ignore *types-to-ignore*))
   "Prints out the name of each symbol and all its callers. Specify database
    :callers (the default) to get function call references, :fill to the get
@@ -1274,27 +1274,27 @@ Rooted calling trees:
    through the code, so this can save some time.)"
   (with-open-file (stream filename :direction :output)
     (format stream "~&(clear-tables)")
-    (maphash #'(lambda (x y) 
+    (maphash #'(lambda (x y)
 		 (format stream "~&(setf (source-file '~S) '~S)"
 			 x y))
 	     *source-file*)
-    (maphash #'(lambda (x y) 
+    (maphash #'(lambda (x y)
 		 (format stream "~&(setf (callers-list '~S :file) '~S)"
 			 x y))
 	     *file-callers-database*)
-    (maphash #'(lambda (x y) 
+    (maphash #'(lambda (x y)
 		 (format stream "~&(setf (callers-list '~S :callers) '~S)"
 			 x y))
 	     *callers-database*)
-    (maphash #'(lambda (x y) 
+    (maphash #'(lambda (x y)
 		 (format stream "~&(setf (callers-list '~S :callees) '~S)"
 			 x y))
 	     *callees-database*)
-    (maphash #'(lambda (x y) 
+    (maphash #'(lambda (x y)
 		 (format stream "~&(setf (callers-list '~S :readers) '~S)"
 			 x y))
 	     *readers-database*)
-    (maphash #'(lambda (x y) 
+    (maphash #'(lambda (x y)
 		 (format stream "~&(setf (callers-list '~S :setters) '~S)"
 			 x y))
 	     *setters-database*)))
@@ -1304,7 +1304,7 @@ Rooted calling trees:
 ;;; Print Caller Trees *************
 ;;; ********************************
 ;;; The following function is useful for reversing a caller table into
-;;; a callee table. Possibly later we'll extend xref to create two 
+;;; a callee table. Possibly later we'll extend xref to create two
 ;;; such database hash tables. Needs to include vars as well.
 (defun invert-hash-table (table &optional (types-to-ignore *types-to-ignore*))
   "Makes a copy of the hash table in which (name value*) pairs
@@ -1312,7 +1312,7 @@ Rooted calling trees:
   (let ((target (make-hash-table :test #'equal)))
     (maphash #'(lambda (key values)
 		 (dolist (value values)
-		   (unless (member (pattern-caller-type key) 
+		   (unless (member (pattern-caller-type key)
 				   types-to-ignore)
 		     (pushnew key (gethash value target)))))
 	     table)
@@ -1345,16 +1345,16 @@ Rooted calling trees:
 
 ;;; The following functions demonstrate a possible way to interface
 ;;; xref to a graphical browser such as psgraph to mimic the capabilities
-;;; of Masterscope's graphical browser. 
+;;; of Masterscope's graphical browser.
 
 (defvar *last-caller-tree* nil)
 
 (defvar *default-graphing-mode* :call-graph
   "Specifies whether we graph up or down. If :call-graph, the children
    of a node are the functions it calls. If :caller-graph, the children
-   of a node are the functions that call it.") 
+   of a node are the functions that call it.")
 
-(defun gather-tree (parents &optional already-seen 
+(defun gather-tree (parents &optional already-seen
 			    (mode *default-graphing-mode*)
 			    (types-to-ignore *types-to-ignore*) compact)
   "Extends the tree, copying it into list structure, until it repeats
@@ -1364,7 +1364,7 @@ Rooted calling trees:
 		    (:call-graph   *callees-database*)
 		    (:caller-graph *callers-database*))))
     (declare (special *already-seen*))
-    (labels 
+    (labels
 	((amass-tree
 	  (parents &optional already-seen)
 	  (let (result this-item)
@@ -1374,7 +1374,7 @@ Rooted calling trees:
 		(pushnew parent *already-seen*)
 		(if (member parent already-seen)
 		    (setq this-item nil) ; :ignore
-		    (if compact 
+		    (if compact
 			(multiple-value-setq (this-item already-seen)
 			    (amass-tree (gethash parent database)
 					(cons parent already-seen)))
@@ -1386,7 +1386,7 @@ Rooted calling trees:
 		(unless (eq this-item :ignore)
 		  (push (if this-item
 			    (list parent this-item)
-			    parent) 
+			    parent)
 			result))))
 	    (values result		;(reverse result)
 		    already-seen))))
@@ -1407,7 +1407,7 @@ Rooted calling trees:
 			  (:caller-graph *callers-database*))))
     (maphash #'(lambda (name value)
 		 (declare (ignore value))
-		 (unless (member (pattern-caller-type name) 
+		 (unless (member (pattern-caller-type name)
 				 types-to-ignore)
 		   (if (gethash name database)
 		       (push name called-callers)
@@ -1424,7 +1424,7 @@ Rooted calling trees:
    call it.
    If compact is T, tries to eliminate the already-seen nodes, so that
    the graph for a node is printed at most once. Otherwise it will duplicate
-   the node's tree (except for cycles). This is usefull because the call tree
+   the node's tree (except for cycles). This is useful because the call tree
    is actually a directed graph, so we can either duplicate references or
    display only the first one."
   ;; Would be nice to print out line numbers and whenever we skip a duplicated
@@ -1436,7 +1436,7 @@ Rooted calling trees:
       (setq *last-caller-tree* trees)
       (let ((more-trees (gather-tree (set-difference called-callers
 						     already-seen)
-				     already-seen 
+				     already-seen
 				     mode types-to-ignore compact)))
 	(values trees more-trees)))))
 
@@ -1469,7 +1469,7 @@ Rooted calling trees:
    in printing out the database. For example, '(:lisp) would ignore all
    calls to common lisp functions. COMPACT is a flag to tell the program
    to try to compact the trees a bit by not printing trees if they have
-   already been seen. ROOT-NODES is a list of root nodes of trees to 
+   already been seen. ROOT-NODES is a list of root nodes of trees to
    display. If ROOT-NODES is nil, tries to find all root nodes in the
    database."
   (multiple-value-bind (rooted cycles)
@@ -1480,7 +1480,7 @@ Rooted calling trees:
       (format t "~&Rooted calling trees:")
       (print-indented-tree rooted 2))
     (when cycles
-      (when rooted      
+      (when rooted
 	(format t "~2%"))
       (format t "~&Cyclic calling trees:")
       (print-indented-tree cycles 2))))
@@ -1559,14 +1559,14 @@ Rooted calling trees:
 |#
 #|
 ;;; Code to print out graphical trees of CLOS class hierarchies.
-(defun print-class-hierarchy (&optional (start-class 'anything) 
+(defun print-class-hierarchy (&optional (start-class 'anything)
 					(file "classes.ps"))
   (let ((start (find-class start-class)))
     (when start
       (with-open-file (*standard-output* file :direction :output)
-	(psgraph:psgraph start 
+	(psgraph:psgraph start
 			 #'clos::class-direct-subclasses
-			 #'(lambda (x) 
+			 #'(lambda (x)
 			     (list (format nil "~A" (clos::class-name x))))
 			 t nil #'eq)))))
 
@@ -1610,10 +1610,10 @@ Rooted calling trees:
 (define-pattern-substitution declaration ((:eq declare)(:rest :ignore)))
 (define-pattern-substitution destination form)
 (define-pattern-substitution control-string string)
-(define-pattern-substitution format-arguments 
+(define-pattern-substitution format-arguments
   ((:star form)))
 (define-pattern-substitution fn
-  (:or ((:eq quote) function) 
+  (:or ((:eq quote) function)
        ((:eq function) function)
        function))
 
@@ -1632,14 +1632,14 @@ Rooted calling trees:
 (define-variable-pattern lambda-parameters-limit :lisp)
 (define-caller-pattern lambda (lambda-list (:rest body)) :lisp)
 
-(define-caller-pattern defun 
+(define-caller-pattern defun
   (name lambda-list
 	(:star (:or documentation-string declaration))
 	(:star form))
   :lisp)
 
 ;;; perhaps this should use VAR, instead of NAME
-(define-caller-pattern defvar 
+(define-caller-pattern defvar
   (var (:optional initial-value (:optional documentation-string)))
   :lisp)
 (define-caller-pattern defparameter
@@ -1701,7 +1701,7 @@ Rooted calling trees:
 
 ;;; Quote is a problem. In Defmacro & friends, we'd like to actually
 ;;; look at the argument, 'cause it hides internal function calls
-;;; of the defmacro. 
+;;; of the defmacro.
 (define-caller-pattern quote (:ignore) :lisp)
 
 (define-caller-pattern function ((:or fn form)) :lisp)
@@ -1724,13 +1724,13 @@ Rooted calling trees:
 (define-caller-pattern psetf ((:star form form)) :lisp)
 (define-caller-pattern shiftf ((:plus form) form) :lisp)
 (define-caller-pattern rotatef ((:star form)) :lisp)
-(define-caller-pattern define-modify-macro 
+(define-caller-pattern define-modify-macro
   (name
    lambda-list
    fn
    (:optional documentation-string))
   :lisp)
-(define-caller-pattern defsetf 
+(define-caller-pattern defsetf
   (:or (name name (:optional documentation-string))
        (name lambda-list (var)
 	(:star (:or declaration documentation-string))
@@ -1773,21 +1773,21 @@ Rooted calling trees:
 (define-caller-pattern progv
   (form form (:star form)) :lisp)
 (define-caller-pattern flet
-  (((:star (name lambda-list 
+  (((:star (name lambda-list
 		 (:star (:or declaration
 			     documentation-string))
 		 (:star form))))
    (:star form))
   :lisp)
 (define-caller-pattern labels
-  (((:star (name lambda-list 
+  (((:star (name lambda-list
 		 (:star (:or declaration
 			     documentation-string))
 		 (:star form))))
    (:star form))
   :lisp)
 (define-caller-pattern macrolet
-  (((:star (name lambda-list 
+  (((:star (name lambda-list
 		 (:star (:or declaration
 			     documentation-string))
 		 (:star form))))
@@ -1806,9 +1806,9 @@ Rooted calling trees:
   (form
    (:star ((:or symbol
 		((:star symbol)))
-	   (:star form)))) 
+	   (:star form))))
   :lisp)
-(define-caller-pattern typecase (form (:star (symbol (:star form)))) 
+(define-caller-pattern typecase (form (:star (symbol (:star form))))
   :lisp)
 
 ;;; Blocks and Exits
@@ -1827,7 +1827,7 @@ Rooted calling trees:
   :lisp)
 (define-caller-pattern do*
   (((:star (:or var
-		(var (:optional form (:optional form)))))) 
+		(var (:optional form (:optional form))))))
    (form (:star form))
    (:star declaration)
    (:star (:or tag form)))
@@ -1858,7 +1858,7 @@ Rooted calling trees:
    (:star declaration)
    (:star (:or tag form)))
   :lisp)
-(define-caller-pattern prog*    
+(define-caller-pattern prog*
   (((:star (:or var (var (:optional form)))))
    (:star declaration)
    (:star (:or tag form)))
@@ -1898,7 +1898,7 @@ Rooted calling trees:
 (define-variable-pattern *macroexpand-hook* :lisp)
 
 ;;; Destructuring
-(define-caller-pattern destructuring-bind 
+(define-caller-pattern destructuring-bind
   (lambda-list form
 	       (:star declaration)
 	       (:star form))
@@ -1916,15 +1916,15 @@ Rooted calling trees:
   :lisp2)
 
 ;;; Environments
-(define-caller-pattern variable-information (form &optional :ignore) 
+(define-caller-pattern variable-information (form &optional :ignore)
   :lisp2)
 (define-caller-pattern function-information (fn &optional :ignore) :lisp2)
 (define-caller-pattern declaration-information (form &optional :ignore) :lisp2)
 (define-caller-pattern augment-environment (form &key (:star :ignore)) :lisp2)
-(define-caller-pattern define-declaration 
+(define-caller-pattern define-declaration
   (name
    lambda-list
-   (:star form)) 
+   (:star form))
   :lisp2)
 (define-caller-pattern parse-macro (name lambda-list form) :lisp2)
 (define-caller-pattern enclose (form &optional :ignore) :lisp2)
@@ -1986,20 +1986,20 @@ Rooted calling trees:
 (define-caller-pattern unuse-package ((:rest :ignore)) :lisp)
 (define-caller-pattern defpackage (name (:rest :ignore)) :lisp2)
 (define-caller-pattern find-all-symbols (form) :lisp)
-(define-caller-pattern do-symbols 
+(define-caller-pattern do-symbols
   ((var (:optional form (:optional form)))
-   (:star declaration) 
-   (:star (:or tag form))) 
+   (:star declaration)
+   (:star (:or tag form)))
   :lisp)
-(define-caller-pattern do-external-symbols 
+(define-caller-pattern do-external-symbols
   ((var (:optional form (:optional form)))
-   (:star declaration) 
-   (:star (:or tag form))) 
+   (:star declaration)
+   (:star (:or tag form)))
   :lisp)
-(define-caller-pattern do-all-symbols 
+(define-caller-pattern do-all-symbols
   ((var (:optional form))
-   (:star declaration) 
-   (:star (:or tag form))) 
+   (:star declaration)
+   (:star (:or tag form)))
   :lisp)
 (define-caller-pattern with-package-iterator
   ((name form (:plus :ignore))
@@ -2189,7 +2189,7 @@ Rooted calling trees:
 (define-variable-pattern double-float-negative-epsilon :lisp)
 (define-variable-pattern long-float-negative-epsilon :lisp)
 
-;;; Characters 
+;;; Characters
 (define-variable-pattern char-code-limit :lisp)
 (define-variable-pattern char-font-limit :lisp)
 (define-variable-pattern char-bits-limit :lisp)
@@ -2479,7 +2479,7 @@ Rooted calling trees:
 (define-caller-pattern string (form) :lisp)
 
 ;;; Structures
-(define-caller-pattern defstruct 
+(define-caller-pattern defstruct
   ((:or name (name (:rest :ignore)))
    (:optional documentation-string)
    (:plus :ignore))
@@ -2573,7 +2573,7 @@ Rooted calling trees:
 (define-variable-pattern *print-level* :lisp)
 (define-variable-pattern *print-length* :lisp)
 (define-variable-pattern *print-array* :lisp)
-(define-caller-pattern with-standard-io-syntax 
+(define-caller-pattern with-standard-io-syntax
   ((:star declaration)
    (:star form))
   :lisp2)
@@ -2612,7 +2612,7 @@ Rooted calling trees:
 (define-caller-pattern finish-output ((:optional form)) :lisp)
 (define-caller-pattern force-output ((:optional form)) :lisp)
 (define-caller-pattern clear-output ((:optional form)) :lisp)
-(define-caller-pattern print-unreadable-object 
+(define-caller-pattern print-unreadable-object
   ((form form &key (:star form))
    (:star declaration)
    (:star form))
@@ -2691,10 +2691,10 @@ Rooted calling trees:
 (define-variable-pattern *break-on-warnings* :lisp)
 (define-caller-pattern break (&optional form (:star form)) :lisp)
 (define-caller-pattern check-type (form form (:optional form)) :lisp)
-(define-caller-pattern assert 
+(define-caller-pattern assert
   (form
    (:optional ((:star var))
-	      (:optional form (:star form)))) 
+	      (:optional form (:star form))))
   :lisp)
 (define-caller-pattern etypecase (form (:star (symbol (:star form)))) :lisp)
 (define-caller-pattern ctypecase (form (:star (symbol (:star form)))) :lisp)
@@ -2703,7 +2703,7 @@ Rooted calling trees:
    (:star ((:or symbol ((:star symbol)))
 	   (:star form))))
   :lisp)
-(define-caller-pattern ccase 
+(define-caller-pattern ccase
   (form
    (:star ((:or symbol ((:star symbol)))
 	   (:star form))))
@@ -2719,7 +2719,7 @@ Rooted calling trees:
 (define-caller-pattern load-time-value (form (:optional form)) :lisp2)
 (define-caller-pattern disassemble (form) :lisp)
 (define-caller-pattern function-lambda-expression (fn) :lisp2)
-(define-caller-pattern with-compilation-unit (((:star :ignore)) (:star form)) 
+(define-caller-pattern with-compilation-unit (((:star :ignore)) (:star form))
   :lisp2)
 
 ;;; Documentation
@@ -2739,7 +2739,7 @@ Rooted calling trees:
 (define-caller-pattern get-decoded-time () :lisp)
 (define-caller-pattern get-universal-time () :lisp)
 (define-caller-pattern decode-universal-time (form &optional form) :lisp)
-(define-caller-pattern encode-universal-time 
+(define-caller-pattern encode-universal-time
   (form form form form form form &optional form) :lisp)
 (define-caller-pattern get-internal-run-time () :lisp)
 (define-caller-pattern get-internal-real-time () :lisp)
@@ -2792,14 +2792,14 @@ Rooted calling trees:
 (define-caller-pattern compute-applicable-methods (fn (:star form)) :lisp2)
 (define-caller-pattern defclass (name &rest :ignore) :lisp2)
 (define-caller-pattern defgeneric (name lambda-list &rest :ignore) :lisp2)
-(define-caller-pattern define-method-combination 
+(define-caller-pattern define-method-combination
   (name lambda-list ((:star :ignore))
 	(:optional ((:eq :arguments) :ignore))
 	(:optional ((:eq :generic-function) :ignore))
 	(:star (:or declaration documentation-string))
 	(:star form))
   :lisp2)
-(define-caller-pattern defmethod 
+(define-caller-pattern defmethod
   (name (:star symbol) lambda-list
 	(:star (:or declaration documentation-string))
 	(:star form))
@@ -2810,7 +2810,7 @@ Rooted calling trees:
 (define-caller-pattern function-keywords (&rest :ignore) :lisp2)
 (define-caller-pattern generic-flet (((:star (name lambda-list))) (:star form))
   :lisp2)
-(define-caller-pattern generic-labels 
+(define-caller-pattern generic-labels
   (((:star (name lambda-list))) (:star form))
   :lisp2)
 (define-caller-pattern generic-function (lambda-list) :lisp2)
@@ -2833,9 +2833,9 @@ Rooted calling trees:
 (define-caller-pattern slot-missing (fn form form form &optional form) :lisp2)
 (define-caller-pattern slot-unbound (fn form form) :lisp2)
 (define-caller-pattern slot-value (form form) :lisp2)
-(define-caller-pattern update-instance-for-different-class 
+(define-caller-pattern update-instance-for-different-class
   (form form (:star form)) :lisp2)
-(define-caller-pattern update-instance-for-redefined-class 
+(define-caller-pattern update-instance-for-redefined-class
   (form form (:star form)) :lisp2)
 (define-caller-pattern with-accessors
   (((:star :ignore)) form
@@ -2866,7 +2866,7 @@ Rooted calling trees:
 (define-caller-pattern make-condition (form &rest :ignore) :lisp2)
 (define-caller-pattern with-simple-restart
   ((name form (:star form)) (:star form)) :lisp2)
-(define-caller-pattern restart-case 
+(define-caller-pattern restart-case
   (form
    (:star (form form (:star form))))
   :lisp2)


### PR DESCRIPTION
docs: fix some typos and trim some whitespace

Is this helpful?