### PR TITLE
A state-machine based intrepretation of ANSI terminal sequences

### DIFF
--- a/contrib/slime-xterm-color.el
+++ b/contrib/slime-xterm-color.el
@@ -1,0 +1,43 @@
+;; -*- lexical-binding: t; -*-
+;;; slime-xterm-color.el --- Colorize ANSI sequences in SLIME REPL
+
+(define-slime-contrib slime-xterm-color
+  "Colorize ANSI escape sequences in SLIME REPL output using xterm-color."
+  (:authors "Mark Evenson <evenson.not.org@gmail.com>")
+  (:license "GPL")
+  (:slime-dependencies slime-repl)
+  (:on-load (slime-xterm-color-init))
+  (:on-unload (slime-xterm-color-fini)))
+
+(require 'slime) ;; kinda obvious:  do we really need to declare in a contrib?
+(if (< emacs-major-version 29)
+    (require 'xterm-color) ;; need to explicitly install locally via
+                           ;; <https://github.com/atomontage/xterm-color/README.org>.
+  (use-package xterm-color :ensure t))
+
+(defun slime-xterm-color-init ()
+  "Initialize xterm-color processing for SLIME output."
+  
+  (advice-add 'slime-repl-emit :filter-args
+              #'slime-xterm-color--colorize-output)
+  
+  (message "slime-xterm-color initialized"))
+
+(defun slime-xterm-color-fini ()
+  "Disable xterm-color processing for SLIME output."
+  (advice-remove 'slime-repl-emit
+                 #'slime-xterm-color--colorize-output)
+  
+  (message "slime-xterm-color disabled"))
+
+(defun slime-xterm-color--colorize-output (args)
+  "Apply xterm-color to SLIME output before it's displayed."
+  (let ((output (car args)))
+    (when (stringp output)
+      ;; Apply xterm-color and remove the last character if it's a newline
+      ;; to preserve SLIME's output formatting
+      (let ((colored (xterm-color-filter output)))
+        (setcar args colored))))
+  args)
+
+(provide 'slime-xterm-color)

--- a/doc/slime.texi
+++ b/doc/slime.texi
@@ -231,6 +231,7 @@ Contributed Packages
 * Scratch Buffer::
 * SLIME Trace Dialog::
 * slime-sprof::
+* xterm-color:: 
 * slime-fancy::
 * Quicklisp::
 
@@ -2129,6 +2130,7 @@ particular packages do.
 * Scratch Buffer::
 * SLIME Trace Dialog::
 * slime-sprof::
+* xterm-color::
 * SLIME Enhanced M-.::
 * slime-fancy::
 * Quicklisp::
@@ -3130,6 +3132,40 @@ Disassemble function.
 Toggle exclusion of swank functions from the report.
 
 @end table
+
+@node xterm-color
+@section xterm-color
+With a suitably configured Emacs--compiled into @code{(>
+emacs-major-version 28)}--this contrib loads
+the @code{xterm-color} @url{https://github.com/atomontage/xterm-color}
+package for the interpretation and diplay of ANSI terminal
+controlsequences.  As opposed to the builtin @code{ansi-color}
+machinery, this implementation utilizes a proper state machine to deal
+with rather than being incompletely based upon regular expressions.
+
+A sample configuration is given below, for a SLIME that is present on
+the local filesystem under the @code{~/work/slime/} directory.
+
+@example
+    (use-package xterm-color
+      :ensure t)
+
+    (use-package slime
+      :load-path "~/work/slime" ;; change to local SLIME installation if you have one
+      :ensure t ;; if the load-path doesn't work, fallback to install via package archives
+      :defer t
+      :after (xterm-color)
+      :config
+      (slime-setup '(slime-repl
+		     slime-xterm-color
+                     ;; insert yer own faves 
+		     slime-fancy))
+      :bind ("\C-cs" . 'slime-selector)) ;; xach likes this methinks
+@end example
+
+Replacing Emacs's builtin machinery for ANSI sequences can be made
+more efficient by reading the strategies suggested
+at @url{https://github.com/atomontage/xterm-color/blob/master/README.org}.
 
 @node SLIME Enhanced M-.
 @section SLIME Enhanced M-.


### PR DESCRIPTION
A suitable <file:~/.emacs> stanza:

    (use-package xterm-color
      :ensure t)

    (use-package slime
      :load-path "~/work/slime"
      :ensure t
      :after (xterm-color)
      :config
      (slime-setup '(slime-repl
		     slime-xterm-color
		     slime-fancy)))

c.f. <https://github.com/atomontage/xterm-color/blob/master/README.org>

-- 

TODO 

  - [ ] ask for review of general contrib requirements
  - [ ] add to tests