### PR TITLE
Support XDG directories

### DIFF
--- a/swank-loader.lisp
+++ b/swank-loader.lisp
@@ -17,6 +17,8 @@
 ;;   (setq swank-loader::*fasl-directory* "/tmp/fasl/")
 ;;   (swank-loader:init)
 
+(require 'uiop)
+
 (cl:defpackage :swank-loader
   (:use :cl)
   (:export :init
@@ -156,22 +158,9 @@ Return nil if nothing appropriate is available."
             when (string-starts-with line prefix)
               return (subseq line (length prefix))))))
 
-(defun getenv (name)
-  "Obtains the current value of the POSIX environment variable NAME."
-  (declare (type (or string symbol) name))
-  (let ((name (string name)))
-    ;; TODO allegro lispworks clozure corman cormanlisp armedbear scl mkcl
-    (or #+abcl (ext:getenv name)
-        #+ccl (ccl:getenv name)
-        #+clisp (ext:getenv name)
-        #+ecl (si:getenv name)
-        #+gcl (si:getenv name)
-        #+mkcl (mkcl:getenv name)
-        #+sbcl (sb-ext:posix-getenv name))))
-
 (defun slime-home-dir ()
-  (let ((env (getenv "SLIME_HOME"))
-        (xdg-data (getenv "XDG_DATA_HOME"))
+  (let ((env (uiop:getenv "SLIME_HOME"))
+        (xdg-data (uiop:getenv "XDG_DATA_HOME"))
         (slime-dir (make-pathname :directory '(:relative "slime")))
         (dot-slime-dir (make-pathname :directory '(:relative ".slime"))))
     (cond

--- a/swank-loader.lisp
+++ b/swank-loader.lisp
@@ -156,14 +156,40 @@ Return nil if nothing appropriate is available."
             when (string-starts-with line prefix)
               return (subseq line (length prefix))))))
 
+(defun getenv (name)
+  "Obtains the current value of the POSIX environment variable NAME."
+  (declare (type (or string symbol) name))
+  (let ((name (string name)))
+    ;; TODO allegro lispworks clozure corman cormanlisp armedbear scl mkcl
+    (or #+abcl (ext:getenv name)
+        #+ccl (ccl:getenv name)
+        #+clisp (ext:getenv name)
+        #+ecl (si:getenv name)
+        #+gcl (si:getenv name)
+        #+mkcl (mkcl:getenv name)
+        #+sbcl (sb-ext:posix-getenv name))))
+
+(defun slime-home-dir ()
+  (let ((env (getenv "SLIME_HOME"))
+        (xdg-data (getenv "XDG_DATA_HOME"))
+        (slime-dir (make-pathname :directory '(:relative "slime")))
+        (dot-slime-dir (make-pathname :directory '(:relative ".slime"))))
+    (cond
+      (env
+       (truename env))
+      (xdg-data
+       (merge-pathnames slime-dir (truename xdg-data)))
+      (t
+       (merge-pathnames dot-slime-dir (user-homedir-pathname))))))
+
 (defun default-fasl-dir ()
   (merge-pathnames
    (make-pathname
-    :directory `(:relative ".slime" "fasl"
+    :directory `(:relative "fasl"
                  ,@(if (slime-version-string) (list (slime-version-string)))
                  ,(unique-dir-name)
                  ,@(if *load-truename* (cdr (pathname-directory *load-truename*)))))
-   (user-homedir-pathname)))
+   (slime-home-dir)))
 
 (defvar *fasl-directory* (default-fasl-dir)
   "The directory where fasl files should be placed.")


### PR DESCRIPTION
closes #610

support XDG directory spec for local files

forked from @brsvh 's version, most of the credit goes to them, i just used `getenv` from `uiop` compatibility layer to avoid hand-rolled `getenv` implementation